### PR TITLE
(WIP) Search for a settings file in the app directory.

### DIFF
--- a/mu/logic.py
+++ b/mu/logic.py
@@ -46,8 +46,6 @@ PYTHON_DIRECTORY = os.path.join(HOME_DIRECTORY, 'python')
 DATA_DIR = appdirs.user_data_dir('mu', 'python')
 #: The default directory for application logs.
 LOG_DIR = appdirs.user_log_dir('mu', 'python')
-#: The path to the JSON file containing application settings.
-SETTINGS_FILE = os.path.join(DATA_DIR, 'settings.json')
 #: The path to the log file for the application.
 LOG_FILE = os.path.join(LOG_DIR, 'mu.log')
 #: Regex to match pycodestyle (PEP8) output.
@@ -79,6 +77,27 @@ def find_microbit():
                                                  p.portName())
                  for p in available_ports])
     return None
+
+
+def get_settings_path():
+    """
+    The settings file default location is the application data directory.
+    However, a settings file in  the same directory than the application itself
+    takes preference.
+    """
+    settings_filename = 'settings.json'
+    # App location depends on being interpreted by normal Python or bundled
+    app_path = sys.executable if getattr(sys, 'frozen', False) else sys.argv[0]
+    app_dir = os.path.dirname(os.path.abspath(app_path))
+    logger.info('Application directory: {}'.format(app_dir))
+    settings_dir = os.path.join(app_dir, settings_filename)
+    if not os.path.exists(settings_dir):
+        settings_dir = os.path.join(DATA_DIR, settings_filename)
+        if not os.path.exists(settings_dir):
+            with open(settings_dir, 'w') as f:
+                logger.debug('Creating settings file: {}'.format(settings_dir))
+                json.dump({}, f)
+    return settings_dir
 
 
 def check_flake(filename, code):
@@ -246,10 +265,15 @@ class Editor:
         Attempts to recreate the tab state from the last time the editor was
         run.
         """
-        if os.path.exists(SETTINGS_FILE):
-            logger.info('Restoring session from: {}'.format(SETTINGS_FILE))
-            with open(SETTINGS_FILE) as f:
+        settings_path = get_settings_path()
+        with open(settings_path) as f:
+            try:
                 old_session = json.load(f)
+            except ValueError:
+                logger.error('Settings file {} could not be parsed.'.format(
+                             settings_path))
+            else:
+                logger.info('Restoring session from: {}'.format(settings_path))
                 logger.debug(old_session)
                 if 'theme' in old_session:
                     self.theme = old_session['theme']
@@ -572,7 +596,8 @@ class Editor:
             'paths': paths
         }
         logger.debug(session)
-        with open(SETTINGS_FILE, 'w') as out:
-            logger.debug('Saving session to: {}'.format(SETTINGS_FILE))
+        settings_path = get_settings_path()
+        with open(settings_path, 'w') as out:
+            logger.debug('Saving session to: {}'.format(settings_path))
             json.dump(session, out, indent=2)
         sys.exit(0)

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -2,6 +2,7 @@
 """
 Tests for the Editor and REPL logic.
 """
+import sys
 import os.path
 import json
 import pytest
@@ -27,7 +28,6 @@ def test_CONSTANTS():
     assert mu.logic.HOME_DIRECTORY
     assert mu.logic.PYTHON_DIRECTORY
     assert mu.logic.DATA_DIR
-    assert mu.logic.SETTINGS_FILE
     # These should NEVER change.
     assert mu.logic.MICROBIT_PID == 516
     assert mu.logic.MICROBIT_VID == 3368
@@ -68,6 +68,53 @@ def test_find_microbit_with_device():
     with mock.patch('mu.logic.QSerialPortInfo.availablePorts',
                     return_value=[mock_port, ]):
         assert mu.logic.find_microbit() == 'COM0'
+
+
+def test_get_settings_app_path():
+    """
+    Find a settings file in the application location.
+    """
+    fake_app_path = os.path.dirname(__file__)
+    fake_app_script = os.path.join(fake_app_path, 'run.py')
+    fake_local_settings = os.path.join(fake_app_path, 'settings.json')
+    with mock.patch.object(sys, 'argv', [fake_app_script]):
+        assert mu.logic.get_settings_path() == fake_local_settings
+
+
+def test_get_settings_data_path():
+    """
+    Find a settings file in the data location.
+    """
+    mock_open = mock.MagicMock()
+    mock_open.return_value.__enter__ = lambda s: s
+    mock_open.return_value.__exit__ = mock.Mock()
+    mock_exists = mock.MagicMock()
+    mock_exists.side_effect = [False, True]
+    mock_json_dump = mock.MagicMock()
+    with mock.patch('os.path.exists', mock_exists), \
+            mock.patch('builtins.open', mock_open), \
+            mock.patch('json.dump', mock_json_dump), \
+            mock.patch('mu.logic.DATA_DIR', 'fake_path'):
+        assert mu.logic.get_settings_path() == os.path.join(
+            'fake_path', 'settings.json')
+    assert not mock_json_dump.called
+
+
+def test_get_settings_no_files():
+    """
+    No settings files found, so create one.
+    """
+    mock_open = mock.MagicMock()
+    mock_open.return_value.__enter__ = lambda s: s
+    mock_open.return_value.__exit__ = mock.Mock()
+    mock_json_dump = mock.MagicMock()
+    with mock.patch('os.path.exists', return_value=False), \
+            mock.patch('builtins.open', mock_open), \
+            mock.patch('json.dump', mock_json_dump), \
+            mock.patch('mu.logic.DATA_DIR', 'fake_path'):
+        assert mu.logic.get_settings_path() == os.path.join(
+            'fake_path', 'settings.json')
+    assert mock_json_dump.call_count == 1
 
 
 def test_check_flake():
@@ -235,12 +282,14 @@ def test_editor_restore_session_missing_files():
     Missing files that were opened tabs in the previous session are safely
     ignored when attempting to restore them.
     """
+    fake_settings = os.path.join(os.path.dirname(__file__), 'settings.json')
     view = mock.MagicMock()
     ed = mu.logic.Editor(view)
     ed._view.add_tab = mock.MagicMock()
-    fake_settings = os.path.join(os.path.dirname(__file__), 'settings.json')
+    get_test_settings_path = mock.MagicMock()
+    get_test_settings_path.return_value = fake_settings
     with mock.patch('os.path.exists', return_value=True), \
-            mock.patch('mu.logic.SETTINGS_FILE', fake_settings):
+            mock.patch('mu.logic.get_settings_path', get_test_settings_path):
         ed.restore_session()
     assert ed._view.add_tab.call_count == 0
 


### PR DESCRIPTION
Taking in consideration the discussions from this week about the default location for the "mu_code" folder, and based on the fact that we'll probably add an entry in the settings to change it (
https://github.com/ntoll/mu/issues/126, https://github.com/ntoll/mu/issues/86, https://github.com/ntoll/mu/issues/87) I was thinking that having to find the settings file it's not all that straightforward to begin with.

So, this PR updates Mu to first search for the settings file in the same directory where the Mu executable or run.py file are located.