### PR TITLE
FIX: Highlight Code Errors Under Windows

### DIFF
--- a/mu/logic.py
+++ b/mu/logic.py
@@ -152,7 +152,7 @@ def check_pycodestyle(code):
     os.remove(code_filename)
     # Parse the output from the tool into a dictionary of structured data.
     style_feedback = {}
-    for result in results.split(os.linesep):
+    for result in results.split('\n'):
         matcher = STYLE_REGEX.match(result)
         if matcher:
             line_no, col, msg = matcher.groups()


### PR DESCRIPTION
The kids are getting indentation errors and it's quite difficult to debug. I wanted to add whitespace characters similar to Sublime:
![sublime](https://cloud.githubusercontent.com/assets/1617013/18031365/3623318c-6cd5-11e6-8a09-d46895c5780e.png)

The best I could do in mu is:
![in mu](https://cloud.githubusercontent.com/assets/1617013/18031362/230a3230-6cd5-11e6-892a-269ef311868c.png)

I can't seem to make the characters larger or visible only when highlighted. [I couldn't get tabs to show as arrows either.](http://pyqt.sourceforge.net/Docs/QScintilla2/classQsciScintilla.html#ab83469cc9550eadcd5d4e8ca3d20d07b)

If anyone has ideas :+1: 