### PR TITLE
Update travis repo name.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ deploy:
   upload-dir: microbit/$TRAVIS_OS_NAME
   acl: public_read
   on:
-    repo: ntoll/mu
+    repo: mu-editor/mu
     branch: [master, travis]
 
 notifications:


### PR DESCRIPTION
This turned out to be a lot easier than expected. There was no need to reissue the encrypted keys, it only required the repo name in the travis file and in AppVeyor website settings.
So, the windows builds are already running, and the OS X and linux one will start working again with this PR.