### PR TITLE
Fix #126 Change name of default Python directory

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -4,3 +4,4 @@ Peter Inglesby
 Carlos Pereira Atencio (carlosperate@embeddedlog.com)
 Nick Sarbicki (nick.a.sarbicki@gmail.com)
 Kushal Das (mail@kushaldas.in)
+Tibs / Tony Ibbs (tibs@tonyibbs.co.uk)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,0 +1,8 @@
+Release History
+===============
+
+0.9.12
+------
+
+* Change the default Python directory from ``~/python`` to ``~/mu_code``.
+* Start changelog

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,4 +5,6 @@ Release History
 ------
 
 * Change the default Python directory from ``~/python`` to ``~/mu_code``.
+  This fixes issue #126.
+* Add instructions for installing PyQt5 and QScintilla on Mac OS.
 * Start changelog

--- a/README.rst
+++ b/README.rst
@@ -163,6 +163,18 @@ For this to work you'll need to have Qt5 and Python 3 installed.
 
     brew install https://raw.githubusercontent.com/mu-editor/mu/master/package/extras/qscintilla2.rb
 
+  .. note:: If you have an existing virtual environment it will not have
+     changed to add the new packages. The simplest thing to do is to create a
+     new virtual environment, remembering to use the
+     ``--system-site-packages`` switch so that installed libraries are
+     included. For instance::
+
+        $ virtualenv -p /usr/local/bin/python3 --system-site-packages ~/env/py3
+
+     or::
+
+        $ mkvirtualenv -p /usr/local/bin/python3 --system-site-packages py3
+
 Ensure you have the correct dependencies for development installed by creating
 a virtualenv and running::
 

--- a/README.rst
+++ b/README.rst
@@ -150,8 +150,18 @@ repository with the following command::
 
     $ git clone https://github.com/ntoll/mu.git
 
-For this to work you'll need to have Qt5 and Python 3 installed. On Debian
-based systems this is covered by installing: python3-pyqt5, python3-pyqt5.qsci and python3-pyqt5.qtserialport.
+For this to work you'll need to have Qt5 and Python 3 installed.
+
+* On Debian based systems this is covered by installing: python3-pyqt5,
+  python3-pyqt5.qsci and python3-pyqt5.qtserialport.
+
+* On Mac OS, first install PyQT5::
+
+    brew install pyqt5 --with-python3
+
+  Then install QScintilla using the recipe from the mu repository::
+
+    brew install https://raw.githubusercontent.com/mu-editor/mu/master/package/extras/qscintilla2.rb
 
 Ensure you have the correct dependencies for development installed by creating
 a virtualenv and running::

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -1,6 +1,9 @@
 Development
 ===========
 
+.. Much of this information is also in the README.rst file at the top level.
+   If you are updating one, remember to update the other.
+
 If you only want to use Mu as a code editor then ignore this section. If you'd
 like to contribute to the development of Mu, please read on...
 
@@ -9,9 +12,30 @@ Assuming you have Git installed, you do it like this from the command line::
 
     git clone https://github.com/ntoll/mu.git
 
-For Mu to work you'll need to have Qt5 and Python 3 installed. On Debian based
-systems this is covered by installing: ``python3-pyqt5``,
-``python3-pyqt5.qsci`` and ``python3-pyqt5.qtserialport``.
+For Mu to work you'll need to have Qt5 and Python 3 installed.
+
+* On Debian based systems this is covered by installing: ``python3-pyqt5``,
+  ``python3-pyqt5.qsci`` and ``python3-pyqt5.qtserialport``.
+
+* On Mac OS, first install PyQT5::
+
+    brew install pyqt5 --with-python3
+
+  Then install QScintilla using the recipe from the mu repository::
+
+    brew install https://raw.githubusercontent.com/mu-editor/mu/master/package/extras/qscintilla2.rb
+
+  .. note:: If you have an existing virtual environment it will not have
+     changed to add the new packages. The simplest thing to do is to create a
+     new virtual environment, remembering to use the
+     ``--system-site-packages`` switch so that installed libraries are
+     included. For instance::
+
+        $ virtualenv -p /usr/local/bin/python3 --system-site-packages ~/env/py3
+
+     or::
+
+        $ mkvirtualenv -p /usr/local/bin/python3 --system-site-packages py3
 
 Ensure you have the correct dependencies for development installed by creating
 a virtualenv and running::

--- a/mu/logic.py
+++ b/mu/logic.py
@@ -44,12 +44,13 @@ MICROBIT_PID = 516
 MICROBIT_VID = 3368
 #: The user's home directory.
 HOME_DIRECTORY = os.path.expanduser('~')
-#: The default directory for Python scripts.
-PYTHON_DIRECTORY = os.path.join(HOME_DIRECTORY, 'python')
-#: The default directory for application data.
-DATA_DIR = appdirs.user_data_dir('mu', 'python')
+#: The default directory for Python scripts. This needs to be in the user's
+#  home directory, and visible (so not a . directory)
+PYTHON_DIRECTORY = os.path.join(HOME_DIRECTORY, 'mu_code')
+#: The default directory for application data (i.e., configuration).
+DATA_DIR = appdirs.user_data_dir(appname='mu', appauthor='python')
 #: The default directory for application logs.
-LOG_DIR = appdirs.user_log_dir('mu', 'python')
+LOG_DIR = appdirs.user_log_dir(appname='mu', appauthor='python')
 #: The path to the JSON file containing application settings.
 SETTINGS_FILE = os.path.join(DATA_DIR, 'settings.json')
 #: The path to the log file for the application.


### PR DESCRIPTION
Change the name of the default Python (save/load) directory from ~/python to ~/mu_code, which fixes #126

Also:

- Add a changelog, CHANGES.rst
- Update the development documentation (in README.rst and docs/development.rst) to explain how to install PyQt5 and QScintilla on Mac OS
- Add me to the AUTHORS file