### PR TITLE
Use a settings file local to the Mu executable.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ deploy:
   acl: public_read
   on:
     repo: ntoll/mu
-    branch: [master, travis]
+    branch: [master, travis, local_settings]
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ deploy:
   acl: public_read
   on:
     repo: mu-editor/mu
-    branch: [master, travis, local_settings]
+    branch: [master]
 
 notifications:
   email:

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -7,13 +7,17 @@ Contributions are welcome without prejudice from *anyone* irrespective of
 age, gender, religion, race or sexuality. Good quality code and engagement
 with respect, humour and intelligence wins every time.
 
-* If you're from a background which isn't well-represented in most geeky groups, get involved - *we want to help you make a difference*.
-* If you're from a background which *is* well-represented in most geeky groups, get involved - *we want your help making a difference*.
-* If you're worried about not being technical enough, get involved - *your fresh perspective will be invaluable*.
+* If you're from a background which isn't well-represented in most geeky
+  groups, get involved - *we want to help you make a difference*.
+* If you're from a background which *is* well-represented in most geeky
+  groups, get involved - *we want your help making a difference*.
+* If you're worried about not being technical enough, get involved - *your
+  fresh perspective will be invaluable*.
 * If you think you're an imposter, get involved.
 * If your day job isn't code, get involved.
 * This isn't a group of experts, just people. Get involved!
-* We are interested in educational, social and technical problems. If you are too, get involved.
+* We are interested in educational, social and technical problems. If you are
+  too, get involved.
 * This is a new community. *No-one knows what they are doing*, so, get involved.
 
 We expect contributors to follow the Python Software Foundation's Code of

--- a/mu/logic.py
+++ b/mu/logic.py
@@ -25,6 +25,7 @@ import re
 import json
 import logging
 import tempfile
+import platform
 import webbrowser
 from PyQt5.QtWidgets import QMessageBox
 from PyQt5.QtSerialPort import QSerialPortInfo
@@ -102,6 +103,9 @@ def get_settings_path():
     # App location depends on being interpreted by normal Python or bundled
     app_path = sys.executable if getattr(sys, 'frozen', False) else sys.argv[0]
     app_dir = os.path.dirname(os.path.abspath(app_path))
+    # The os x bundled application is placed 3 levels deep in the .app folder
+    if platform.system() == 'Darwin' and getattr(sys, 'frozen', False):
+        app_dir = os.path.dirname(os.path.dirname(os.path.dirname(app_dir)))
     logger.info('Application directory: {}'.format(app_dir))
     settings_dir = os.path.join(app_dir, settings_filename)
     if not os.path.exists(settings_dir):


### PR DESCRIPTION
This is a continuation from #140, which was merged into a non-master branch to trigger the CI builds to create the executable files for all Operating Systems.

As a quick recap from #140:

> So what this PR is proposing is to allow Mu to first check if there is a setting.json present in the same directory where Mu is located, and use that instead of the default OS specific DATA_DIR location. If there is no file right next to the Mu executable or run.py file, then it would just fall back to the original behaviour.