### PR TITLE
Fix Ctrl keys to work on Windows and Linux; add VT100 cursor control in REPL

### DIFF
--- a/mu/interface.py
+++ b/mu/interface.py
@@ -741,6 +741,7 @@ class REPLPane(QTextEdit):
         self.setAcceptRichText(False)
         self.setReadOnly(False)
         self.setUndoRedoEnabled(False)
+        self.setContextMenuPolicy(Qt.PreventContextMenu)
         self.setObjectName('replpane')
         # open the serial port
         self.serial = QSerialPort(self)

--- a/mu/interface.py
+++ b/mu/interface.py
@@ -773,8 +773,15 @@ class REPLPane(QTextEdit):
         Creates custom context menu with just copy and paste
         """
         menu = QMenu(self)
-        menu.addAction("Copy", self.copy)
-        menu.addAction("Paste", self.repl_paste)
+        if platform.system() == 'Darwin':
+            copy_keys = QKeySequence(Qt.CTRL + Qt.Key_C)
+            paste_keys = QKeySequence(Qt.CTRL + Qt.Key_V)
+        else:
+            copy_keys = QKeySequence(Qt.CTRL + Qt.SHIFT + Qt.Key_C)
+            paste_keys = QKeySequence(Qt.CTRL + Qt.SHIFT + Qt.Key_V)
+
+        menu.addAction("Copy", self.copy, copy_keys)
+        menu.addAction("Paste", self.repl_paste, paste_keys)
         menu.exec_(QCursor.pos())
 
     def cursor_to_end(self):

--- a/mu/interface.py
+++ b/mu/interface.py
@@ -762,12 +762,8 @@ class REPLPane(QTextEdit):
 
     def repl_paste(self):
         """
-        Moves cursor to the very end then pastes
+        Grabs clipboard contents then sends down the serial port
         """
-        tc = self.textCursor()
-        tc.movePosition(QTextCursor.End)
-        self.setTextCursor(tc)
-
         clipboard = QApplication.clipboard()
         self.serial.write(bytes(clipboard.text(), 'utf8'))
 

--- a/mu/interface.py
+++ b/mu/interface.py
@@ -826,6 +826,10 @@ class REPLPane(QTextEdit):
             msg = b'\x1B[C'
         elif key == Qt.Key_Left:
             msg = b'\x1B[D'
+        elif key == Qt.Key_Home:
+            msg = b'\x1B[H'
+        elif key == Qt.Key_End:
+            msg = b'\x1B[F'
         elif (platform.system() == 'Darwin' and
                 data.modifiers() == Qt.MetaModifier) or \
              (platform.system() != 'Darwin' and

--- a/mu/interface.py
+++ b/mu/interface.py
@@ -836,8 +836,10 @@ class REPLPane(QTextEdit):
             # Command-key on Mac, Ctrl-Shift on Win/Lin
             if key == Qt.Key_C:
                 self.copy()
+                msg = b''
             elif key == Qt.Key_V:
                 self.repl_paste()
+                msg = b''
 
         self.serial.write(msg)
 

--- a/mu/interface.py
+++ b/mu/interface.py
@@ -765,7 +765,8 @@ class REPLPane(QTextEdit):
         Grabs clipboard contents then sends down the serial port
         """
         clipboard = QApplication.clipboard()
-        self.serial.write(bytes(clipboard.text(), 'utf8'))
+        if clipboard is not None:
+            self.serial.write(bytes(clipboard.text(), 'utf8'))
 
     def repl_context_menu(self):
         """"

--- a/mu/interface.py
+++ b/mu/interface.py
@@ -26,7 +26,8 @@ from PyQt5.QtCore import QSize, Qt, pyqtSignal, QIODevice
 from PyQt5.QtWidgets import (QToolBar, QAction, QStackedWidget, QDesktopWidget,
                              QWidget, QVBoxLayout, QShortcut, QSplitter,
                              QTabWidget, QFileDialog, QMessageBox, QTextEdit,
-                             QFrame, QListWidget, QGridLayout, QLabel, QMenu)
+                             QFrame, QListWidget, QGridLayout, QLabel, QMenu,
+                             QApplication)
 from PyQt5.QtGui import (QKeySequence, QColor, QTextCursor, QFontDatabase,
                          QCursor)
 from PyQt5.Qsci import QsciScintilla, QsciLexerPython, QsciAPIs
@@ -766,7 +767,9 @@ class REPLPane(QTextEdit):
         tc = self.textCursor()
         tc.movePosition(QTextCursor.End)
         self.setTextCursor(tc)
-        self.paste()
+
+        clipboard = QApplication.clipboard()
+        self.serial.write(bytes(clipboard.text(), 'utf8'))
 
     def repl_context_menu(self):
         """"
@@ -776,6 +779,14 @@ class REPLPane(QTextEdit):
         menu.addAction("Copy", self.copy)
         menu.addAction("Paste", self.repl_paste)
         menu.exec_(QCursor.pos())
+
+    def cursor_to_end(self):
+        """
+        moves cursor to the very end
+        """
+        tc = self.textCursor()
+        tc.movePosition(QTextCursor.End)
+        self.setTextCursor(tc)
 
     def set_theme(self, theme):
         """


### PR DESCRIPTION
Not tested on microbit, but equivalent code from my esp8266 fork works fine. 
