### PR TITLE
Update Appveyor script to run tests in CI server.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,9 +17,9 @@ clean:
 	rm -rf mu.egg-info
 	rm -rf .coverage
 	rm -rf docs/_build
-	find . \( -name '*.py[co]' -o -name dropin.cache \) -print0 | $(XARGS) rm
-	find . \( -name '*.bak' -o -name dropin.cache \) -print0 | $(XARGS) rm
-	find . \( -name '*.tgz' -o -name dropin.cache \) -print0 | $(XARGS) rm
+	find . \( -name '*.py[co]' -o -name dropin.cache \) -delete
+	find . \( -name '*.bak' -o -name dropin.cache \) -delete
+	find . \( -name '*.tgz' -o -name dropin.cache \) -delete
 
 pyflakes:
 	find . \( -name _build -o -name var -o -path ./docs -o -path ./mu/contrib \) -type d -prune -o -name '*.py' -print0 | $(XARGS) pyflakes

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,6 @@ init:
 
   # Utilise pre-installed MinGw for make
   - ps: $env:PATH = 'C:\MinGW\msys\1.0\bin;C:\MinGW\mingw32\bin;C:\MinGW\bin;' + $env:PATH
-  #- cmd: copy c:\MinGW\bin\mingw32-make.exe c:\MinGW\bin\make.exe
 
   # As AppVeyor has multiple python install, check which one uses by default
   - cmd: ECHO %PYTHON% %PYTHON_VERSION% %PYTHON_ARCH%
@@ -54,21 +53,21 @@ install:
   - cmd: python -c "import PyQt5"
   - cmd: python -c "import PyQt5.Qsci"
 
-  # Build mu using PyInstaller and rename executable with timestamp
+  # Build mu using PyInstaller, rename dist folder and executable with timestamp
   - cmd: pyinstaller package\pyinstaller.spec
-  - cmd: dir dist
-  - ps: Rename-Item .\dist\mu.exe mu-$(get-date -f yyyy-MM-dd_HH_mm_ss).exe
+  - ps: Rename-Item -path .\dist upload
+  - cmd: dir upload
+  - ps: Rename-Item .\upload\mu.exe mu-$(get-date -f yyyy-MM-dd_HH_mm_ss).exe
 
 # Not a project with an msbuild file, build done at install.
 build: None
 
 test_script:
-  #- cmd: sh -c "make check"
   - cmd: make check
 
 # Push artifacts to s3 bucket and list all
 before_deploy:
-  - ps: Get-ChildItem .\dist\*.exe | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name -DeploymentName ardublockly-s3-deployment }
+  - ps: Get-ChildItem .\upload\*.exe | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name -DeploymentName ardublockly-s3-deployment }
   - ps: foreach($artifactName in $artifacts.keys) { $artifacts[$artifactName] }
 
 # Deploy build to Amazon S3 bucket

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 environment:
   matrix:
     - PYTHON: "C:\\Python34"
-      PYTHON_VERSION: "3.4.3"
+      PYTHON_VERSION: "3.4.4"
       PYTHON_ARCH: "32"
 
 platform: x86
@@ -9,41 +9,50 @@ platform: x86
 configuration: Release
 
 init:
+  - cmd: ver
   - cmd: ECHO Processor architecture - %PROCESSOR_ARCHITECTURE%
   - cmd: wmic OS get OSArchitecture
 
-  # As AppVeyor has multiple python install, verify which one uses by default
+  # Utilise pre-installed MinGw for make
+  - ps: $env:PATH = 'C:\MinGW\msys\1.0\bin;C:\MinGW\mingw32\bin;C:\MinGW\bin;' + $env:PATH
+  #- cmd: copy c:\MinGW\bin\mingw32-make.exe c:\MinGW\bin\make.exe
+
+  # As AppVeyor has multiple python install, check which one uses by default
   - cmd: ECHO %PYTHON% %PYTHON_VERSION% %PYTHON_ARCH%
   - cmd: python --version
   - cmd: python -c "import struct; print(struct.calcsize('P') * 8)"
+  - cmd: python -c "import sys; print(sys.executable)"
 
-  # Set the relevant python and pip location to the path
+  # Set the relevant Python and pip location to the path
   - cmd: set PATH=%PYTHON%;%PYTHON%\scripts;%PATH%
   - cmd: ECHO Path - %PATH%
 
   # Verify the new default python
   - cmd: python --version
   - cmd: python -c "import struct; print(struct.calcsize('P') * 8)"
+  - cmd: python -c "import sys; print(sys.executable)"
   - cmd: pip --version
 
   # Check out installed python packages
   - cmd: pip freeze
 
 install:
-  # Temporary fix for PyQt not being installed in correct directory: https://github.com/appveyor/ci/issues/363
-  - REG ADD HKCU\Software\Python\PythonCore\3.4\InstallPath /f /ve /t REG_SZ /d C:\Python34
+  # Fix for PyQt not being installed in correct directory: https://github.com/appveyor/ci/issues/363
+  - cmd: REG ADD HKCU\Software\Python\PythonCore\3.4\InstallPath /f /ve /t REG_SZ /d C:\Python34
 
   # Download PyQt5 with 10min timeout, rename to pyqt5_installer.exe, and install
-  - ps: Start-FileDownload 'http://downloads.sourceforge.net/project/pyqt/PyQt5/PyQt-5.4.2/PyQt5-5.4.2-gpl-Py3.4-Qt5.4.2-x32.exe' -FileName pyqt5_installer.exe -Timeout 600000
+  - ps: Start-FileDownload 'http://downloads.sourceforge.net/project/pyqt/PyQt5/PyQt-5.5.1/PyQt5-5.5.1-gpl-Py3.4-Qt5.5.1-x32.exe' -FileName pyqt5_installer.exe -Timeout 600000
+
   - cmd: pyqt5_installer.exe /S
-  - cmd: python -c "import PyQt5"
 
   # Install python dependencies (v3.2 has VC++ redistributable dependencies)
   - cmd: pip install pyinstaller==3.1.1
   - cmd: pip install -r requirements.txt
 
-  # Check installed packages again
+  # Check installed packages
   - cmd: pip freeze
+  - cmd: python -c "import PyQt5"
+  - cmd: python -c "import PyQt5.Qsci"
 
   # Build mu using PyInstaller and rename executable with timestamp
   - cmd: pyinstaller package\pyinstaller.spec
@@ -53,8 +62,9 @@ install:
 # Not a project with an msbuild file, build done at install.
 build: None
 
-# No tests for now
-#test_script: None
+test_script:
+  #- cmd: sh -c "make check"
+  - cmd: make check
 
 # Push artifacts to s3 bucket and list all
 before_deploy:

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -167,7 +167,8 @@ def test_get_settings_no_files_cannot_create():
             mock.patch('mu.logic.DATA_DIR', 'fake_path'), \
             mock.patch('mu.logic.logger', return_value=None) as logger:
         mu.logic.get_settings_path()
-        msg = 'Unable to create settings file: fake_path/settings.json'
+        msg = 'Unable to create settings file: ' \
+              'fake_path{}settings.json'.format(os.path.sep)
         logger.error.assert_called_once_with(msg)
 
 


### PR DESCRIPTION
This PR updates the Appveyor script and Makefile to be able to run the tests on the Windows CI server. With that I had to do a minor update to a test that was failing on Windows.

I've also updated the PyQt version to the latest available for Python 3.4.