### PR TITLE
Run tests natively on AppVeyor (Windows with no MinGW)

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -62,7 +62,10 @@ install:
 # Not a project with an msbuild file, build done at install.
 build: None
 
+# Makefiles support provided by MinGW, which does POSIX translations, so run tests natively as well
 test_script:
+  - cmd: make clean
+  - cmd: py.test
   - cmd: make check
 
 # Push artifacts to s3 bucket and list all


### PR DESCRIPTION
At the moment the tests are run on AppVeyor using the makefile, for which we need to run it under MinGW. While working on previous PRs I've noticed that the POSIX implementation does some translation (like path slashes) hiding some `py.test` failures due to platform differences.
This PR updates AppVeyor to run both `make test` and `py.test`.