### PR TITLE
Select older OS X version for Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,16 @@ matrix:
       sudo: required
       language: generic
 
+    # To maximise compatibility pick earliest image, 10.9 to be removed on 20/01/2017
     - os: osx
+      osx_image: beta-xcode6.1
       sudo: required
       language: generic
 
 before_install:
   # OS and Python info
   - uname -a
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then sw_vers; fi
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then python3 -c "import sys; print(sys.executable)"; fi
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo python3 -c "import sys; print(sys.executable)"; fi
 


### PR DESCRIPTION
With Pyinstaller on OS X we are only guaranteed compatibility on the OS version used for the build or newer. Travis was building on the default image 10.11 at the moment, so this PR reduces this to the lowest available, 10.9.5. Unfortunately this version is no longer supported and will be removed from Travis in January 20th, but we should use it for as long as we can and include this information in the release notes. 

Fixes #201 
