### PR TITLE
Add safe file write

### DIFF
--- a/mu/contrib/atomicfile.py
+++ b/mu/contrib/atomicfile.py
@@ -1,0 +1,139 @@
+# -*- coding: utf-8 -*-
+import errno
+import os
+import sys
+import tempfile
+import codecs
+
+
+def _get_permissions(file_path):
+    """
+    Get the file permissions, if it can't access them returns system default.
+    """
+    try:
+        st_mode = os.lstat(file_path).st_mode & 0o777
+    except OSError as err:
+        if err.errno != errno.ENOENT:
+            raise
+        current_umask = os.umask(0)
+        os.umask(current_umask)
+        st_mode = (~current_umask) & 0o777
+    return st_mode
+
+
+def _make_temp(name, permissions=None):
+    """
+    Create a temporary file with the filename similar the given ``name``.
+    The permission bits are copied from the original file or ``permissions``.
+
+    Returns: the name of the temporary file.
+    """
+    d, fn = os.path.split(name)
+    fd, temp_name = tempfile.mkstemp(prefix=".%s-" % fn, dir=d)
+    os.close(fd)
+
+    # Temporary files are created with mode 0600, which is usually not what we
+    # want. Apply the function argument value, or copy original file mode.
+    st_mode = permissions if permissions else _get_permissions(name)
+    st_mode |= 0o600
+    # On Windows, only the Owner Read and Write bits (0600) are affected.
+    os.chmod(temp_name, st_mode)
+
+    return temp_name
+
+
+class AtomicFile(object):
+    """
+    Writable file object that atomically writes a file.
+
+    All writes will go to a temporary file.
+    Call ``close()`` when you are done writing, and AtomicFile will rename
+    the temporary copy to the original name, making the changes visible.
+    If the object is destroyed without being closed, all your writes are
+    discarded.
+    If an ``encoding`` argument is specified, codecs.open will be called to open
+    the file in the wanted encoding.
+    """
+    def __init__(self, name, mode="w+b", permissions=None, encoding=None,
+                 newline=None):
+        self._name = name  # permanent name
+        self._permissions = permissions if permissions \
+            else _get_permissions(self._name)
+        self._temp_name = _make_temp(name, permissions=self._permissions)
+        if encoding:
+            self._fp = codecs.open(self._temp_name, mode, encoding)
+        else:
+            if sys.version_info > (3, 0):
+                self._fp = open(self._temp_name, mode, newline=newline)
+            else:
+                self._fp = open(self._temp_name, mode)
+
+        # delegated methods
+        self.write = self._fp.write
+        self.fileno = self._fp.fileno
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, exc_tb):
+        if exc_type:
+            return
+        self.close()
+
+    def close(self):
+        if not self._fp.closed:
+            self._fp.close()
+            try:
+                os.rename(self._temp_name, self._name)
+            except OSError as e:
+                if e.errno != errno.EEXIST:
+                    raise
+                # Fall back to move original file and rename again
+                original_to_remove = "%s.prev.bak" % self._name
+                if os.path.isfile(original_to_remove):
+                    # First make sure you have write access, then delete it
+                    os.chmod(original_to_remove, 0o777)
+                    try:
+                        os.unlink(original_to_remove)
+                    except OSError:
+                        raise
+                os.rename(self._name, original_to_remove)
+                os.rename(self._temp_name, self._name)
+                os.chmod(original_to_remove, 0o666)
+                try:
+                    os.unlink(original_to_remove)
+                except OSError:
+                    pass
+            os.chmod(self._name, self._permissions)
+
+    def discard(self):
+        if not self._fp.closed:
+            try:
+                os.unlink(self._temp_name)
+            except OSError:
+                pass
+            self._fp.close()
+
+    def __del__(self):
+        if getattr(self, "_fp", None):  # constructor actually did something
+            self.discard()
+
+
+def open_atomic(name, mode="w+b", permissions=None, encoding=None,
+                newline=None):
+    """
+    Aims to be the "equivalent" of the open() function returning an
+    AtomicFile object.
+    """
+    if 'r' in mode or 'a' in mode or 'x' in mode:
+        raise TypeError('Read or append modes are not implemented.')
+
+    if newline:
+        if sys.version_info < (3, 0):
+            raise TypeError("'newline' is an invalid keyword argument for this"
+                            "function in Python 2.")
+        if encoding:
+            raise TypeError("'newline' cannot be combined with encoding")
+
+    return AtomicFile(name, mode=mode, permissions=permissions,
+                      encoding=encoding, newline=newline)

--- a/mu/logic.py
+++ b/mu/logic.py
@@ -36,6 +36,7 @@ try:  # pragma: no cover
 except ImportError:  # pragma: no cover
     from pep8 import StyleGuide, Checker
 from mu.contrib import uflash, appdirs, microfs
+from mu.contrib.atomicfile import open_atomic
 from mu import __version__
 
 
@@ -191,7 +192,7 @@ def check_pycodestyle(code):
     # the code.
     code_fd, code_filename = tempfile.mkstemp()
     os.close(code_fd)
-    with open(code_filename, 'w', newline='') as code_file:
+    with open_atomic(code_filename, 'w', newline='') as code_file:
         code_file.write(code)
     # Configure which PEP8 rules to ignore.
     style = StyleGuide(parse_argv=False, config_file=False)
@@ -598,7 +599,7 @@ class Editor:
             if not os.path.basename(tab.path).endswith('.py'):
                 # No extension given, default to .py
                 tab.path += '.py'
-            with open(tab.path, 'w', newline='') as f:
+            with open_atomic(tab.path, 'w', newline='') as f:
                 logger.info('Saving script to: {}'.format(tab.path))
                 logger.debug(tab.text())
                 f.write(tab.text())

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -933,17 +933,18 @@ def test_save_no_path():
     view.current_tab.path = None
     view.current_tab.text = mock.MagicMock(return_value='foo')
     view.get_save_path = mock.MagicMock(return_value='foo.py')
-    mock_open = mock.MagicMock()
-    mock_open.return_value.__enter__ = lambda s: s
-    mock_open.return_value.__exit__ = mock.Mock()
-    mock_open.return_value.write = mock.MagicMock()
+    mock_open_atomic = mock.MagicMock()
+    mock_open_atomic.return_value.__enter__ = lambda s: s
+    mock_open_atomic.return_value.__exit__ = mock.Mock()
+    mock_open_atomic.return_value.write = mock.MagicMock()
     ed = mu.logic.Editor(view)
-    with mock.patch('builtins.open', mock_open):
+    with mock.patch('mu.logic.get_workspace_dir', return_value='/fake/path'), \
+            mock.patch('mu.logic.open_atomic', mock_open_atomic):
         ed.save()
-    assert mock_open.call_count == 2
-    mock_open.assert_called_with('foo.py', 'w', newline='')
-    mock_open.return_value.write.assert_called_once_with('foo')
-    view.get_save_path.assert_called_once_with(mu.logic.get_workspace_dir())
+    assert mock_open_atomic.call_count == 1
+    mock_open_atomic.assert_called_with('foo.py', 'w', newline='')
+    mock_open_atomic.return_value.write.assert_called_once_with('foo')
+    view.get_save_path.assert_called_once_with('/fake/path')
 
 
 def test_save_no_path_no_path_given():
@@ -972,15 +973,15 @@ def test_save_python_file():
     view.current_tab.text = mock.MagicMock(return_value='foo')
     view.get_save_path = mock.MagicMock()
     view.current_tab.setModified = mock.MagicMock(return_value=None)
-    mock_open = mock.MagicMock()
-    mock_open.return_value.__enter__ = lambda s: s
-    mock_open.return_value.__exit__ = mock.Mock()
-    mock_open.return_value.write = mock.MagicMock()
+    mock_open_atomic = mock.MagicMock()
+    mock_open_atomic.return_value.__enter__ = lambda s: s
+    mock_open_atomic.return_value.__exit__ = mock.Mock()
+    mock_open_atomic.return_value.write = mock.MagicMock()
     ed = mu.logic.Editor(view)
-    with mock.patch('builtins.open', mock_open):
+    with mock.patch('mu.logic.open_atomic', mock_open_atomic):
         ed.save()
-    mock_open.assert_called_once_with('foo.py', 'w', newline='')
-    mock_open.return_value.write.assert_called_once_with('foo')
+    mock_open_atomic.assert_called_once_with('foo.py', 'w', newline='')
+    mock_open_atomic.return_value.write.assert_called_once_with('foo')
     assert view.get_save_path.call_count == 0
     view.current_tab.setModified.assert_called_once_with(False)
 
@@ -994,15 +995,15 @@ def test_save_with_no_file_extension():
     view.current_tab.path = 'foo'
     view.current_tab.text = mock.MagicMock(return_value='foo')
     view.get_save_path = mock.MagicMock()
-    mock_open = mock.MagicMock()
-    mock_open.return_value.__enter__ = lambda s: s
-    mock_open.return_value.__exit__ = mock.Mock()
-    mock_open.return_value.write = mock.MagicMock()
+    mock_open_atomic = mock.MagicMock()
+    mock_open_atomic.return_value.__enter__ = lambda s: s
+    mock_open_atomic.return_value.__exit__ = mock.Mock()
+    mock_open_atomic.return_value.write = mock.MagicMock()
     ed = mu.logic.Editor(view)
-    with mock.patch('builtins.open', mock_open):
+    with mock.patch('mu.logic.open_atomic', mock_open_atomic):
         ed.save()
-    mock_open.assert_called_once_with('foo.py', 'w', newline='')
-    mock_open.return_value.write.assert_called_once_with('foo')
+    mock_open_atomic.assert_called_once_with('foo.py', 'w', newline='')
+    mock_open_atomic.return_value.write.assert_called_once_with('foo')
     assert view.get_save_path.call_count == 0
 
 


### PR DESCRIPTION
Although not really fixing issue 200, this PR would introduce a safer way to write files that could would prevent data loss when issues arise during file writing.

Using the "w" mode on python erases the file before it starts writing, so if anything goes wrong during this operation the previous content of the file is lost. If on top of that the application crashes during this process then the user basically loses all their work. This is far from ideal from a text/code editor, so this PR introduces a the AtomicFile class to write to a temporary file and replace the original on file close.

I had a look at different python implementations of this type of functionality, and the most comprehensive modules/packages did very OS specific tricks in different platforms to ensure the operations are as atomic as possible using ctypes to access lower level OS functionality. I preferred to use a more "python only" approach, so forked https://github.com/sashka/atomicfile into https://github.com/carlosperate/atomicfile, enabled testing on more platforms with travis and appveyor and fixed some issues.