### PR TITLE
Update Travis Linux to install Python 3.5  and PyQt5 with pip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,22 +11,22 @@ matrix:
       language: generic
 
 before_install:
-  # OS and Python info
+  # OS and default Python info
   - uname -a
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then python3 -c "import sys; print(sys.executable)"; fi
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo python3 -c "import sys; print(sys.executable)"; fi
 
 install:
-  # Python 3 and pip 3 installation depends OS (and for now install PyQt & QScintilla in Linux as well)
+  # Python 3 and pip 3 installation are OS dependant
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then bash package/install_osx.sh; fi
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then bash package/install_linux.sh; fi
 
   # Install Mu dependencies (PyQt & QScintilla will be absorbed in requirements.txt once ready)
   - sudo pip3 install -r requirements.txt
-  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then sudo pip3 install PyQt5; fi
-  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then sudo pip3 install QScintilla; fi
+  - sudo pip3 install PyQt5
+  - sudo pip3 install QScintilla
 
-  # Install packaging dependencies, macOS depends on update not yet release https://github.com/pyinstaller/pyinstaller/pull/1965
+  # Install packaging dependencies, macOS depends on update not yet released https://github.com/pyinstaller/pyinstaller/pull/1965
   - sudo pip3 install git+git://github.com/pyinstaller/pyinstaller.git@483c819d6a256b58db6740696a901bd41c313f0c
 
   # Check everything was correctly installed
@@ -35,6 +35,7 @@ install:
   - python3 -c "import struct; print(struct.calcsize('P') * 8)"
   - python3 -c "import sys; print(sys.executable)"
   - pip3 --version
+  - sudo pip3 --version
   - pip3 freeze
   - python3 -c "import PyQt5"
   - python3 -c "import PyQt5.Qsci"
@@ -42,6 +43,7 @@ install:
 script:
   # Run the tests, at the moment there is a segmentation fault on Linux, this will go away with Py3.5
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then make check; fi
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then make clean; fi
 
   # Package it
   - pyinstaller package/pyinstaller.spec

--- a/package/install_linux.sh
+++ b/package/install_linux.sh
@@ -1,14 +1,13 @@
 #!/bin/bash
 set -ev
-# Ubuntu 14.04 already has Python3 installed, install pip
-curl -O https://bootstrap.pypa.io/get-pip.py
-sudo python3 get-pip.py
-rm get-pip.py
-# Cannot use the PyPI Qscintilla wheel due to linked glibc
-# https://www.riverbankcomputing.com/pipermail/qscintilla/2016-November/001173.html
+# Install Python 3.5
+sudo add-apt-repository ppa:fkrull/deadsnakes -y
 sudo apt-get update -qq
-sudo apt-get install libpython3.4-dev -y
-sudo apt-get install python3-pyqt5 -y
-sudo apt-get install python3-pyqt5.qsci -y
-sudo apt-get install python3-pyqt5.qtserialport -y
-
+sudo apt-get install python3.5 python3.5-dev -y
+# Install pip
+curl -O https://bootstrap.pypa.io/get-pip.py
+sudo python3.5 get-pip.py
+rm get-pip.py
+# Change python3 link to point to python3.5 instead of python3.4 (/usr/bin/)
+sudo mv /usr/bin/python3 /usr/bin/python3-old
+sudo ln -s /usr/bin/python3.5 /usr/bin/python3


### PR DESCRIPTION
Update the travis ci build to use Python 3.5 and pip to install PyQt5.
OS X builds already install PyQt5 with Python 3.5 and pip (ignoring the Python 3.6 issue from brew listed in https://github.com/mu-editor/mu/issues/222), so we are moving to have a universal installation procedure.

The tests for the time being are still only executed in the OS X environment. Linux still has the weird runtime error when collecting items for py.test: https://travis-ci.org/mu-editor/mu/jobs/187951166#L369
