### PR TITLE
Force Travis OS X to install Python 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_install:
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo python3 -c "import sys; print(sys.executable)"; fi
 
 install:
-  # Python 3 and pip 3 installation are OS dependant
+  # Python 3 and pip 3 installation are OS dependent
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then bash package/install_osx.sh; fi
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then bash package/install_linux.sh; fi
 

--- a/package/install_osx.sh
+++ b/package/install_osx.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 set -ev
 brew update >/dev/null 2>&1  # This produces a lot of output that's not very interesting
-brew install python3
 
+# Install Python 3.5 creates python3, python3.5, and pip3.5 commands but no pip3
+brew tap zoidbergwill/python
+brew install python35
+# Contrary zoidbergwill tap documentation turns out this symbolic link is not required
+# sudo ln -s /usr/local/Cellar/python35/3.5.2/bin/python3.5 /usr/bin/python3
+
+# Copy pip3.5 symlink rather than creating one, better in case installation path changes
+cp -R /usr/local/bin/pip3.5 /usr/local/bin/pip3


### PR DESCRIPTION
Been testing this on my fork, so it should be working. However since travis seems to be taking almost 2h for each OS X build to commence (their worker backlog after 3pm goes from 0 to almost a 1000 jobs queued) I'm leaving this PR submitted tonight and hopefully should be all green in the morning.

We have until Friday before the current OS X 10.9 Mavericks image is retired and the oldest version we can be compatible becomes 10.10 Yosemite.