### PR TITLE
Update CI servers to include branch and commit in filename

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -83,3 +83,5 @@ deploy:
   bucket: ardublockly-builds
   set_public: true
   folder: microbit\windows
+  on:
+    branch: [master]

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -57,7 +57,7 @@ install:
   - cmd: pyinstaller package\pyinstaller.spec
   - ps: Rename-Item -path .\dist upload
   - cmd: dir upload
-  - ps: Rename-Item .\upload\mu.exe mu-$(get-date -f yyyy-MM-dd_HH_mm_ss).exe
+  - ps: Rename-Item .\upload\mu.exe mu_$(get-date -f yyyy-MM-dd_HH_mm)_$($env:APPVEYOR_REPO_BRANCH)_$($env:APPVEYOR_REPO_COMMIT.subString(0,7)).exe
 
 # Not a project with an msbuild file, build done at install.
 build: None

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,8 +51,8 @@ script:
   # Package it
   - pyinstaller package/pyinstaller.spec
   - du -sk dist/
-  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then mv dist/mu dist/mu-$(date '+%Y-%m-%d_%H_%M_%S'); fi
-  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then cd dist && zip --symlinks -r mu-$(date '+%Y-%m-%d_%H_%M_%S').zip mu.app && rm -r mu.app && rm mu && cd ..; fi
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then mv dist/mu dist/mu_$(date '+%Y-%m-%d_%H_%M')_${TRAVIS_BRANCH}_${TRAVIS_COMMIT:0:7}.bin; fi
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then cd dist && zip --symlinks -r mu_$(date '+%Y-%m-%d_%H_%M')_${TRAVIS_BRANCH}_${TRAVIS_COMMIT:0:7}.zip mu.app && rm -r mu.app && rm mu && cd ..; fi
 
 # Deploy the build version in an S3 bucket
 deploy:


### PR DESCRIPTION
Small change on the CI/build servers, changes the current name from:
 `mu_<date>_<time>`
to
`mu_<date>_<shorter time>_<branch name>_<7 digits commit hash>.<extension>`

So it is a bit longer, but it in essence it goes from something like:
 `mu-2017-01-17_18_16_36`
to
`mu_2017-01-17-18_16_ci_branch_hash_3c651fbf25.bin`
This way it maintains chronological order (up to a minute resolution) in http://ardublockly-builds.s3-website-us-west-2.amazonaws.com/index.html?prefix=microbit/ and it now also contains a lot more valuable information.

This is specially useful to be able to tell the difference between master builds, which should be more stable, and builds from WIP branches. It will also be really useful to identify specific test builds to keep around when cleaning up the old builds, as there is a few that we might want to keep around (for instance there is a windows executable with console output that will definitely keep coming in handy).

Apart from I have also updated AppVeyor to only deploy builds from master (this was the current behaviour for Travis already). So, when working in other branches we can easily and temporarily update the travis and appveyor scripts to include our WIP branch, this way we don't unnecessary pollute the AWS S3 bucket. Appveyor stores the artifacts on each build anyway, so that windows builds can always be downloaded without sending the .exe files to AWS.