### PR TITLE
Add obvious versioning information for all to see.

### DIFF
--- a/mu/interface.py
+++ b/mu/interface.py
@@ -592,6 +592,7 @@ class FileTabs(QTabWidget):
         super(FileTabs, self).__init__()
         self.setTabsClosable(True)
         self.tabCloseRequested.connect(self.removeTab)
+        self.currentChanged.connect(self.change_tab)
 
     def removeTab(self, tab_id):
         """
@@ -605,6 +606,18 @@ class FileTabs(QTabWidget):
             if window.show_confirmation(msg) == QMessageBox.Cancel:
                 return
         super(FileTabs, self).removeTab(tab_id)
+
+    def change_tab(self, tab_id):
+        """
+        Update the application title to reflect the name of the file in the
+        currently selected tab.
+        """
+        current_tab = self.widget(tab_id)
+        window = self.nativeParentWidget()
+        if current_tab:
+            window.update_title(current_tab.label)
+        else:
+            window.update_title(None)
 
 
 class Window(QStackedWidget):
@@ -684,7 +697,9 @@ class Window(QStackedWidget):
 
         @new_tab.modificationChanged.connect
         def on_modified():
-            self.tabs.setTabText(new_tab_index, new_tab.label)
+            modified_tab_index = self.tabs.currentIndex()
+            self.tabs.setTabText(modified_tab_index, new_tab.label)
+            self.update_title(new_tab.label)
 
         self.tabs.setCurrentIndex(new_tab_index)
         self.connect_zoom(new_tab)
@@ -886,6 +901,7 @@ class Window(QStackedWidget):
         widget_layout.addWidget(self.button_bar)
         widget_layout.addWidget(self.splitter)
         self.tabs = FileTabs()
+        self.tabs.setMovable(True)
         self.splitter.addWidget(self.tabs)
 
         self.addWidget(self.widget)

--- a/mu/interface.py
+++ b/mu/interface.py
@@ -32,6 +32,7 @@ from PyQt5.QtGui import (QKeySequence, QColor, QTextCursor, QFontDatabase,
                          QCursor)
 from PyQt5.Qsci import QsciScintilla, QsciLexerPython, QsciAPIs
 from PyQt5.QtSerialPort import QSerialPort
+from mu import __version__
 from mu.contrib import microfs
 from mu.resources import load_icon, load_stylesheet, load_font_data
 
@@ -611,7 +612,7 @@ class Window(QStackedWidget):
     Defines the look and characteristics of the application's main window.
     """
 
-    title = "Mu"
+    title = "Mu {}".format(__version__)
     icon = "icon"
 
     _zoom_in = pyqtSignal(int)

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -7,6 +7,7 @@ from PyQt5.QtWidgets import (QApplication, QAction, QWidget, QFileDialog,
 from PyQt5.QtCore import QIODevice, Qt, QSize
 from PyQt5.QtGui import QTextCursor, QIcon
 from unittest import mock
+from mu import __version__
 import os
 import platform
 import mu.interface
@@ -672,7 +673,7 @@ def test_Window_attributes():
     Expect the title and icon to be set correctly.
     """
     w = mu.interface.Window()
-    assert w.title == "Mu"
+    assert w.title == "Mu {}".format(__version__)
     assert w.icon == "icon"
 
 


### PR DESCRIPTION
This branch introduces two changes:

* The version of Mu is displayed in the title bar of the application. If you are ever in any doubt, it'll say "Mu 0.1.13" in the title bar. Since this value is also used by window managers when they list currently running applications, it should be pretty ubiquitous.

* Fix a unit test to ensure said version number is used as expected.

Hopefully, this will help @whaleygeek with support tickets. It also has the advantage of being obvious and simple, it follows the Mu philosophy! :-)