### PR TITLE
support small screens

### DIFF
--- a/mu/interface.py
+++ b/mu/interface.py
@@ -874,8 +874,6 @@ class Window(QStackedWidget):
         size = self.geometry()
         self.move((screen.width() - size.width()) / 2,
                   (screen.height() - size.height()) / 2)
-        if super().geometry().height()<600:
-            self.button_bar.setCompactMode(True)
 
 
     def reset_annotations(self):

--- a/mu/interface.py
+++ b/mu/interface.py
@@ -531,7 +531,6 @@ class ButtonBar(QToolBar):
         self.slots = {}
 
         self.setMovable(False)
-        
         self.setIconSize(QSize(64, 64))
         self.setToolButtonStyle(3)
         self.setContextMenuPolicy(Qt.PreventContextMenu)
@@ -565,15 +564,12 @@ class ButtonBar(QToolBar):
 
     def setCompactMode(self, toggle):
         """
-        Option for a compact button bar to be used when the window is very small.
-
+        Compact button bar for when window is very small.
         """
-        if toggle == True:
+        if toggle is True:
             self.setIconSize(QSize(25, 25))
-            self.setToolButtonStyle(0)
         else:
             self.setIconSize(QSize(64, 64))
-            self.setToolButtonStyle(3)  
 
     def addAction(self, name, tool_text):
         """
@@ -875,7 +871,6 @@ class Window(QStackedWidget):
         self.move((screen.width() - size.width()) / 2,
                   (screen.height() - size.height()) / 2)
 
-
     def reset_annotations(self):
         """
         Resets the state of annotations on the current tab.
@@ -925,15 +920,15 @@ class Window(QStackedWidget):
         self.show()
         self.autosize_window()
 
-    def resizeEvent(self,resizeEvent):
+    def resizeEvent(self, resizeEvent):
         """
         Respond to window getting too small for the button bar to fit well.
-
         """
-        if super().geometry().height()<600:
+        if super().geometry().height() < 600:
             self.button_bar.setCompactMode(True)
         else:
             self.button_bar.setCompactMode(False)
+
 
 class REPLPane(QTextEdit):
     """

--- a/mu/interface.py
+++ b/mu/interface.py
@@ -531,6 +531,7 @@ class ButtonBar(QToolBar):
         self.slots = {}
 
         self.setMovable(False)
+        
         self.setIconSize(QSize(64, 64))
         self.setToolButtonStyle(3)
         self.setContextMenuPolicy(Qt.PreventContextMenu)
@@ -561,6 +562,18 @@ class ButtonBar(QToolBar):
         self.addAction(name="help",
                        tool_text="Show help about Mu in a browser.")
         self.addAction(name="quit", tool_text="Quit Mu.")
+
+    def setCompactMode(self, toggle):
+        """
+        Option for a compact button bar to be used when the window is very small.
+
+        """
+        if toggle == True:
+            self.setIconSize(QSize(25, 25))
+            self.setToolButtonStyle(0)
+        else:
+            self.setIconSize(QSize(64, 64))
+            self.setToolButtonStyle(3)  
 
     def addAction(self, name, tool_text):
         """
@@ -861,6 +874,9 @@ class Window(QStackedWidget):
         size = self.geometry()
         self.move((screen.width() - size.width()) / 2,
                   (screen.height() - size.height()) / 2)
+        if super().geometry().height()<600:
+            self.button_bar.setCompactMode(True)
+
 
     def reset_annotations(self):
         """
@@ -888,7 +904,7 @@ class Window(QStackedWidget):
         # Give the window a default icon, title and minimum size.
         self.setWindowIcon(load_icon(self.icon))
         self.update_title()
-        self.setMinimumSize(926, 600)
+        self.setMinimumSize(800, 400)
 
         self.widget = QWidget()
         self.splitter = QSplitter(Qt.Vertical)
@@ -911,6 +927,15 @@ class Window(QStackedWidget):
         self.show()
         self.autosize_window()
 
+    def resizeEvent(self,resizeEvent):
+        """
+        Respond to window getting too small for the button bar to fit well.
+
+        """
+        if super().geometry().height()<600:
+            self.button_bar.setCompactMode(True)
+        else:
+            self.button_bar.setCompactMode(False)
 
 class REPLPane(QTextEdit):
     """

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -586,18 +586,19 @@ def test_ButtonBar_init():
         assert mock_add_action.call_count == 12
         assert mock_add_separator.call_count == 3
 
+
 def test_ButtonBar_setCompactMode():
     """
     Does the button bar shrink in compact mode and grow out of it?
     """
-    bb = mu.interface.ButtonBar(None)
-    bb.setCompactMode(True)
-    mock_icon_size.assert_called_once_with(QSize(25, 25))
-    mock_tool_button_size.assert_called_once_with(0)
-    bb.setCompactMode(False)
-    mock_icon_size.assert_called_once_with(QSize(64, 64))
-    mock_tool_button_size.assert_called_once_with(3)
-    
+    mock_icon_size = mock.MagicMock(return_value=None)
+    with mock.patch('mu.interface.ButtonBar.setIconSize', mock_icon_size):
+        bb = mu.interface.ButtonBar(None)
+        bb.setCompactMode(True)
+        mock_icon_size.assert_called_once_with(QSize(25, 25))
+        bb.setCompactMode(False)
+        mock_icon_size.assert_called_once_with(QSize(64, 64))
+
 
 def test_ButtonBar_add_action():
     """
@@ -627,7 +628,7 @@ def test_ButtonBar_connect():
     assert mock_shortcut.call_count == 1
     slot = bb.slots['save']
     slot.pyqtConfigure.assert_called_once_with(triggered=mock_handler)
-    
+
 
 def test_FileTabs_init():
     """
@@ -722,10 +723,11 @@ def test_Window_attributes():
 
 def test_Window_resizeEvent():
     w = mu.interface.Window()
-    w.resize(1024,768)
-    assert mock_setCompactMode.assert_called_once_with(False)
-    w.resize(800,400)
-    assert mock_setCompactMode.assert_called_once_with(False)
+    w.button_bar.setCompactMode = mock.MagicMock()
+    w.resize(1024, 768)
+    assert w.button_bar.setCompactMode.assert_called_once_with(False)
+    w.resize(800, 400)
+    assert w.button_bar.setCompactMode.assert_called_once_with(False)
 
 
 def test_Window_zoom_in():
@@ -1242,7 +1244,7 @@ def test_Window_setup():
     assert w.setWindowIcon.call_count == 1
     assert isinstance(w.setWindowIcon.call_args[0][0], QIcon)
     w.update_title.assert_called_once_with()
-    w.setMinimumSize.assert_called_once_with(926, 600)
+    w.setMinimumSize.assert_called_once_with(800, 400)
     assert w.widget == mock_widget
     assert w.splitter == mock_splitter
     w.widget.setLayout.assert_called_once_with(mock_layout)

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -595,9 +595,9 @@ def test_ButtonBar_setCompactMode():
     with mock.patch('mu.interface.ButtonBar.setIconSize', mock_icon_size):
         bb = mu.interface.ButtonBar(None)
         bb.setCompactMode(True)
-        mock_icon_size.assert_called_once_with(QSize(25, 25))
+        mock_icon_size.assert_called_with(QSize(25, 25))
         bb.setCompactMode(False)
-        mock_icon_size.assert_called_once_with(QSize(64, 64))
+        mock_icon_size.assert_called_with(QSize(64, 64))
 
 
 def test_ButtonBar_add_action():
@@ -723,11 +723,11 @@ def test_Window_attributes():
 
 def test_Window_resizeEvent():
     w = mu.interface.Window()
-    w.button_bar.setCompactMode = mock.MagicMock()
+    w.button_bar = mock.MagicMock()
     w.resize(1024, 768)
-    assert w.button_bar.setCompactMode.assert_called_once_with(False)
+    w.button_bar.setCompactMode.assert_called_with(False)
     w.resize(800, 400)
-    assert w.button_bar.setCompactMode.assert_called_once_with(False)
+    w.button_bar.setCompactMode.assert_called_with(True)
 
 
 def test_Window_zoom_in():

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -586,6 +586,18 @@ def test_ButtonBar_init():
         assert mock_add_action.call_count == 12
         assert mock_add_separator.call_count == 3
 
+def test_ButtonBar_setCompactMode():
+    """
+    Does the button bar shrink in compact mode and grow out of it?
+    """
+    bb = mu.interface.ButtonBar(None)
+    bb.setCompactMode(True)
+    mock_icon_size.assert_called_once_with(QSize(25, 25))
+    mock_tool_button_size.assert_called_once_with(0)
+    bb.setCompactMode(False)
+    mock_icon_size.assert_called_once_with(QSize(64, 64))
+    mock_tool_button_size.assert_called_once_with(3)
+    
 
 def test_ButtonBar_add_action():
     """
@@ -615,7 +627,7 @@ def test_ButtonBar_connect():
     assert mock_shortcut.call_count == 1
     slot = bb.slots['save']
     slot.pyqtConfigure.assert_called_once_with(triggered=mock_handler)
-
+    
 
 def test_FileTabs_init():
     """
@@ -706,6 +718,14 @@ def test_Window_attributes():
     w = mu.interface.Window()
     assert w.title == "Mu {}".format(__version__)
     assert w.icon == "icon"
+
+
+def test_Window_resizeEvent():
+    w = mu.interface.Window()
+    w.resize(1024,768)
+    assert mock_setCompactMode.assert_called_once_with(False)
+    w.resize(800,400)
+    assert mock_setCompactMode.assert_called_once_with(False)
 
 
 def test_Window_zoom_in():


### PR DESCRIPTION
Was using a raspberry pi official display earlier today with school kids. Mu was very difficult on their little screens. This patch allows a smaller minimum screen size but when the window is resized small the button bar shrinks. When it is made bigger it grows again. I include tests.
Please note this is my first  pyqt, testing and github experience. Total newbie. Hope its ok? Sorry if its bad. Fixes issue "Mu interface on small screens #122"