### PR TITLE
Catch `OSError`s when saving

### DIFF
--- a/mu/logic.py
+++ b/mu/logic.py
@@ -602,11 +602,19 @@ class Editor:
             if not os.path.basename(tab.path).endswith('.py'):
                 # No extension given, default to .py
                 tab.path += '.py'
-            with open_atomic(tab.path, 'w', newline='') as f:
-                logger.info('Saving script to: {}'.format(tab.path))
-                logger.debug(tab.text())
-                f.write(tab.text())
-            tab.setModified(False)
+            try:
+                with open_atomic(tab.path, 'w', newline='') as f:
+                    logger.info('Saving script to: {}'.format(tab.path))
+                    logger.debug(tab.text())
+                    f.write(tab.text())
+                tab.setModified(False)
+            except OSError as e:
+                logger.error(e)
+                message = 'Could not save file.'
+                information = ("Error saving file to disk. Ensure you have "
+                               "permission to write the file and "
+                               "sufficient disk space.")
+                self._view.show_message(message, information)
         else:
             # The user cancelled the filename selection.
             tab.path = None

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -997,6 +997,24 @@ def test_save_no_path_no_path_given():
     assert view.current_tab.path is None
 
 
+def test_save_file_with_exception():
+    """
+    If the file cannot be written, return an error message.
+    """
+    view = mock.MagicMock()
+    view.current_tab = mock.MagicMock()
+    view.current_tab.path = 'foo.py'
+    view.current_tab.text = mock.MagicMock(return_value='foo')
+    view.current_tab.setModified = mock.MagicMock(return_value=None)
+    view.show_message = mock.MagicMock()
+    mock_open_atomic = mock.MagicMock(side_effect=OSError())
+    ed = mu.logic.Editor(view)
+    with mock.patch('mu.logic.open_atomic', mock_open_atomic):
+        ed.save()
+    assert view.current_tab.setModified.call_count == 0
+    assert view.show_message.call_count == 1
+
+
 def test_save_python_file():
     """
     If the path is a Python file (ending in *.py) then save it and reset the


### PR DESCRIPTION
If an `OSError` occurs during file save, it should be caught and passed
along to the user.