### PR TITLE
Mock get_workspace_dir() to avoid file operations

### DIFF
--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -928,7 +928,7 @@ def test_load_hex_file():
     with mock.patch('mu.logic.get_workspace_dir', mock_workspace_dir), \
             mock.patch('builtins.open', mock_open), \
             mock.patch('mu.logic.uflash.extract_script',
-                            return_value=hex_file) as s:
+                       return_value=hex_file) as s:
         ed.load()
     assert view.get_load_path.call_count == 1
     assert s.call_count == 1

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -905,7 +905,9 @@ def test_load_python_file():
     view.add_tab = mock.MagicMock()
     ed = mu.logic.Editor(view)
     mock_open = mock.mock_open(read_data='PYTHON')
-    with mock.patch('builtins.open', mock_open):
+    mock_workspace_dir = mock.MagicMock(return_value='/foo')
+    with mock.patch('mu.logic.get_workspace_dir', mock_workspace_dir), \
+            mock.patch('builtins.open', mock_open):
         ed.load()
     assert view.get_load_path.call_count == 1
     view.add_tab.assert_called_once_with('foo.py', 'PYTHON')
@@ -921,10 +923,12 @@ def test_load_hex_file():
     view.add_tab = mock.MagicMock()
     ed = mu.logic.Editor(view)
     mock_open = mock.mock_open(read_data='PYTHON')
+    mock_workspace_dir = mock.MagicMock(return_value='/foo')
     hex_file = 'RECOVERED'
-    with mock.patch('builtins.open', mock_open), \
+    with mock.patch('mu.logic.get_workspace_dir', mock_workspace_dir), \
+            mock.patch('builtins.open', mock_open), \
             mock.patch('mu.logic.uflash.extract_script',
-                       return_value=hex_file) as s:
+                            return_value=hex_file) as s:
         ed.load()
     assert view.get_load_path.call_count == 1
     assert s.call_count == 1
@@ -940,7 +944,9 @@ def test_load_error():
     view.add_tab = mock.MagicMock()
     ed = mu.logic.Editor(view)
     mock_open = mock.MagicMock(side_effect=FileNotFoundError())
-    with mock.patch('builtins.open', mock_open):
+    mock_workspace_dir = mock.MagicMock(return_value='/foo')
+    with mock.patch('mu.logic.get_workspace_dir', mock_workspace_dir), \
+            mock.patch('builtins.open', mock_open):
         ed.load()
     assert view.get_load_path.call_count == 1
     assert view.add_tab.call_count == 0


### PR DESCRIPTION
`get_workspace_dir()` opens `settings.json`, which shouldn't be
happening during a unit test.

This also causes tests to fail on Python 3.4.3 (Ubuntu 14.04). The mocked `read_data` was being consumed when `json.load()` was being called, so when `f.read()` was being called, there wasn't any data left.

This was a really weird bug to track down, it's briefly alluded to here:
https://docs.python.org/3.4/library/unittest.mock.html#mock-open

> Changed in version 3.4: Added readline() and readlines() support. The mock of read() changed to consume read_data rather than returning it on each call.
> Changed in version 3.4.4: read_data is now reset on each call to the mock.
