### PR TITLE
Add python3-pyqt5.qtwebkit dependancy

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -157,7 +157,7 @@ You may need to grab the GIT submodules used for the blockly based UI::
 For this to work you'll need to have Qt5 and Python 3 installed.
 
 * On Debian based systems this is covered by installing: python3-pyqt5,
-  python3-pyqt5.qsci and python3-pyqt5.qtserialport.
+  python3-pyqt5.qsci, python3-pyqt5.qtserialport and python3-pyqt5.qtwebkit.
 
 * On Mac OS, first install PyQT5::
 

--- a/debian/control
+++ b/debian/control
@@ -8,6 +8,6 @@ Standards-Version: 3.9.1
 Package: mu
 Architecture: all
 Depends: ${misc:Depends}, ${python3:Depends}, python3-setuptools, python3-pyqt5,
-         python3-pyqt5.qsci, python3-pyqt5.qtserialport, python3-serial,
-         python3-pep8, pyflakes
+         python3-pyqt5.qsci, python3-pyqt5.qtserialport, python3-pyqt5.qtwebkit,
+         python3-serial, python3-pep8, pyflakes
 Description: A simple editor for kids, teachers and new programmers.

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -15,7 +15,7 @@ Assuming you have Git installed, you do it like this from the command line::
 For Mu to work you'll need to have Qt5 and Python 3 installed.
 
 * On Debian based systems this is covered by installing: ``python3-pyqt5``,
-  ``python3-pyqt5.qsci`` and ``python3-pyqt5.qtserialport``.
+  ``python3-pyqt5.qsci``, ``python3-pyqt5.qtserialport`` and ``python3-pyqt5.qtwebkit``.
 
 * On Mac OS, first install PyQT5::
 

--- a/package/README.rst
+++ b/package/README.rst
@@ -47,7 +47,7 @@ Assuming you are running a Linux distribution with apt.
 
 * Install PyQt5::
 
-    $ sudo apt-get install python3-pyqt5 python3-pyqt5.qsci python3-pyqt5.qtserialport
+    $ sudo apt-get install python3-pyqt5 python3-pyqt5.qsci python3-pyqt5.qtserialport python3-pyqt5.qtwebkit
 
 * Install PyInstaller::
 


### PR DESCRIPTION
Add python3-pyqt5.qtwebkit as a needed dependency for Debian/Ubuntu (tested on Raspberry Pi running Raspbian Jessie) for blocks support.