### PR TITLE
Support for custom MicroPython runtimes

### DIFF
--- a/mu/logic.py
+++ b/mu/logic.py
@@ -157,6 +157,37 @@ def get_workspace_dir():
     return workspace_dir
 
 
+def get_runtime_hex_path():
+    """
+    Returns the path to the hex runtime file - if this has been
+    specified under element 'microbit_runtime_hex' in settings.json.
+    This can be a fully-qualified file path, or just a file name
+    in which case the file should be located in the workspace directory.
+    Returns None if no path is specified or if the file is not present.
+    """
+    runtime_hex_path = None
+    settings_path = get_settings_path()
+    settings = {}
+    try:
+        with open(settings_path) as f:
+            settings = json.load(f)
+    except FileNotFoundError:
+        logger.error('Settings file {} does not exist.'.format(settings_path))
+    except ValueError:
+        logger.error('Settings file {} could not be parsed.'.format(
+                     settings_path))
+    else:
+        if 'microbit_runtime_hex' in settings and \
+                settings['microbit_runtime_hex'] is not None:
+            runtime_hex_path = os.path.join(
+                get_workspace_dir(),
+                settings['microbit_runtime_hex'])
+            if not os.path.exists(runtime_hex_path):
+                runtime_hex_path = None
+
+    return runtime_hex_path
+
+
 def check_flake(filename, code):
     """
     Given a filename and some code to be checked, uses the PyFlakesmodule to
@@ -387,11 +418,6 @@ class Editor:
             information = ("Your script is too long!")
             self._view.show_message(message, information, 'Warning')
             return
-        # Generate a hex file.
-        python_hex = uflash.hexlify(python_script)
-        logger.debug('Python hex:')
-        logger.debug(python_hex)
-        micropython_hex = uflash.embed_hex(uflash._RUNTIME, python_hex)
         # Determine the location of the BBC micro:bit. If it can't be found
         # fall back to asking the user to locate it.
         path_to_microbit = uflash.find_microbit()
@@ -411,9 +437,15 @@ class Editor:
         logger.debug('Path to micro:bit: {}'.format(path_to_microbit))
         if path_to_microbit and os.path.exists(path_to_microbit):
             logger.debug('Flashing to device.')
-            hex_file = os.path.join(path_to_microbit, 'micropython.hex')
-            uflash.save_hex(micropython_hex, hex_file)
+            # Flash the microbit
+            rt_hex_path = get_runtime_hex_path()
+            uflash.flash(paths_to_microbits=[path_to_microbit],
+                         python_script=python_script,
+                         path_to_runtime=rt_hex_path)
             message = 'Flashing "{}" onto the micro:bit.'.format(tab.label)
+            if (rt_hex_path is not None and os.path.exists(rt_hex_path)):
+                message = message + "\nRuntime: {}". \
+                    format(rt_hex_path)
             information = ("When the yellow LED stops flashing the device"
                            " will restart and your script will run. If there"
                            " is an error, you'll see a helpful message scroll"
@@ -671,7 +703,8 @@ class Editor:
         session = {
             'theme': self.theme,
             'paths': paths,
-            'workspace': get_workspace_dir()
+            'workspace': get_workspace_dir(),
+            'microbit_runtime_hex': get_runtime_hex_path()
         }
         logger.debug(session)
         settings_path = get_settings_path()

--- a/tests/customhextest.hex
+++ b/tests/customhextest.hex
@@ -1,0 +1,1 @@
+hexcontentstest

--- a/tests/settingscorrupt.json
+++ b/tests/settingscorrupt.json
@@ -1,0 +1,1 @@
+GARBAGE

--- a/tests/settingswithcustomhex.json
+++ b/tests/settingswithcustomhex.json
@@ -1,0 +1,1 @@
+{"theme": "night", "paths": ["path/foo.py", "path/bar.py"], "workspace": "/home/foo/mycode", "microbit_runtime_hex": "customhextest.hex"}

--- a/tests/settingswithmissingcustomhex.json
+++ b/tests/settingswithmissingcustomhex.json
@@ -1,0 +1,1 @@
+{"theme": "night", "paths": ["path/foo.py", "path/bar.py"], "workspace": "/home/foo/mycode", "microbit_runtime_hex": "customhextest-missing.hex"}

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -1173,7 +1173,7 @@ def test_quit_modified_ok():
         ed.quit(mock_event)
     assert view.show_confirmation.call_count == 1
     assert mock_event.ignore.call_count == 0
-    assert mock_open.call_count == 2
+    assert mock_open.call_count == 3
     assert mock_open.return_value.write.call_count > 0
 
 
@@ -1200,7 +1200,7 @@ def test_quit_save_tabs_with_paths():
         ed.quit(mock_event)
     assert view.show_confirmation.call_count == 1
     assert mock_event.ignore.call_count == 0
-    assert mock_open.call_count == 2
+    assert mock_open.call_count == 3
     assert mock_open.return_value.write.call_count > 0
     recovered = ''.join([i[0][0] for i
                         in mock_open.return_value.write.call_args_list])
@@ -1231,7 +1231,7 @@ def test_quit_save_theme():
         ed.quit(mock_event)
     assert view.show_confirmation.call_count == 1
     assert mock_event.ignore.call_count == 0
-    assert mock_open.call_count == 2
+    assert mock_open.call_count == 3
     assert mock_open.return_value.write.call_count > 0
     recovered = ''.join([i[0][0] for i
                         in mock_open.return_value.write.call_args_list])
@@ -1261,3 +1261,14 @@ def test_quit_calls_sys_exit():
             mock.patch('builtins.open', mock_open):
         ed.quit(mock_event)
     ex.assert_called_once_with(0)
+
+
+def test_custom_hex_read():
+    """
+    Test that a custom hex file path can be read
+    """
+    with mock.patch('mu.logic.get_settings_path',
+                    return_value='tests/settingswithcustomhex.json'), \
+            mock.patch('mu.logic.get_workspace_dir',
+                       return_value=os.path.dirname(__file__)):
+        assert "customhextest.hex" in mu.logic.get_runtime_hex_path()

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -488,6 +488,18 @@ def test_flash_with_attached_device():
         s.assert_called_once_with('foo', hex_file_path)
 
 
+def test_flash_with_attached_device_and_custom_runtime():
+    """
+    Ensure the expected calls are made to uFlash and a helpful status message
+    is enacted.
+    """
+    with mock.patch('mu.logic.get_settings_path',
+                    return_value='tests/settingswithcustomhex.json'), \
+            mock.patch('mu.logic.get_workspace_dir',
+                       return_value=os.path.dirname(__file__)):
+        test_flash_with_attached_device()
+
+
 def test_flash_user_specified_device_path():
     """
     Ensure that if a micro:bit is not automatically found by uflash then it
@@ -1272,3 +1284,21 @@ def test_custom_hex_read():
             mock.patch('mu.logic.get_workspace_dir',
                        return_value=os.path.dirname(__file__)):
         assert "customhextest.hex" in mu.logic.get_runtime_hex_path()
+    """
+    Test that a corrupt settings file returns None for the
+    runtime hex path
+    """
+    with mock.patch('mu.logic.get_settings_path',
+                    return_value='tests/settingscorrupt.json'), \
+            mock.patch('mu.logic.get_workspace_dir',
+                       return_value=os.path.dirname(__file__)):
+        assert mu.logic.get_runtime_hex_path() is None
+    """
+    Test that a missing settings file returns None for the
+    runtime hex path
+    """
+    with mock.patch('mu.logic.get_settings_path',
+                    return_value='tests/settingswithmissingcustomhex.json'), \
+            mock.patch('mu.logic.get_workspace_dir',
+                       return_value=os.path.dirname(__file__)):
+        assert mu.logic.get_runtime_hex_path() is None


### PR DESCRIPTION
By default, Mu uses the MicroPython runtime that is bundled in uFlash.
This change enables custom runtimes to be used. The user can specify
the runtime in the settings.json file, e.g.:
"runtime_hex": "custom_runtime.hex"
The file can be a fully-qualified path and file name, or it can
just be a file name in which case it should be located in the
workspace directory.