### PR TITLE
Move Travis builds to different S3 bucket

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,14 +60,15 @@ deploy:
   access_key_id: AKIAJYJV7NN6HVHCX5NQ
   secret_access_key:
     secure: QHLfRUdFQX+TejhRBkgNvySkaQOskXji+iduIvKRtzvvhyr3QJHKcMNtO426GRFyKhz6sK3shqn4d5iu/m03gtbv+u1pL9pp0J2GEePzQVP8v24q9Y3oxaXaA7Tm7L2vSIrB7uhJvG5D9H0bVL9my61JvXhvySH47jLvhqHH4F9LdPzby1DXds1Z+R4YNMKE0Z4KmNOhiBHkmKdDcp61fZ91gGiScFIjaXvDb50zdGKjXTQy2t4OtFt4kVbTZWijzxKPCSLZkErfcdNNrCNeMEktk6IEV2KVru9XhDNzzslWwwsR1r2hQI39oVULa3fYXK6W7am8WXVZ6cnJB+yBsNWro3Tp5oiNCWSe6fKDEp+Io+qyhZ+R5PSdzhyRYPUHPCIY/fP/dap/4M/MAO3hZFA3mxjK/vUOc6mtMD/wTE659K4/i7PNYtKFndXXpLpYHHaTis44NLZFIxvs9wWG/ljToYDDK20vG317k5TZUZB/6EipW1DeoO/9qBUxgTdfJypp58kcZNvntUVa4ezf/Bx01ZCMFAk234l7+xAFYI7+m9ITqAPlKWI230Ki5ShzyV+kYcI/GS9cT75iok6+zIWWfyQhKUMDYZ1qb/UDM5Gz9RXoIah0UJTjFd4b3bO6Awdrs2V5Vv2EgMWuKDaHs1s3uONH+PGTluROuqFju/s=
-  bucket: ardublockly-builds
+  bucket: mu-builds
+  region: eu-west-2
   skip_cleanup: true
   local-dir: dist/
-  upload-dir: microbit/$TRAVIS_OS_NAME
+  upload-dir: $TRAVIS_OS_NAME
   acl: public_read
   on:
     repo: mu-editor/mu
-    branch: [master]
+    branch: [master, travis_bucket_move]
 
 notifications:
   email:

--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@ Mu - a "micro" editor
 
 Currently, the latest builds for Windows, OSX and Linux x86 can be found here:
 
-http://ardublockly-builds.s3-website-us-west-2.amazonaws.com/?prefix=microbit
+http://mu-builds.s3-website.eu-west-2.amazonaws.com
 
 For our project roadmap see the ``ROADMAP.rst`` file.
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -3,7 +3,7 @@ Installation
 
 Currently, the latest builds for Windows, OSX and Linux x86 can be found here:
 
-http://ardublockly-builds.s3-website-us-west-2.amazonaws.com/?prefix=microbit
+http://mu-builds.s3-website.eu-west-2.amazonaws.com
 
 Go to the link above, choose the directory for your platform and download the
 latest build of the editor.

--- a/package/README.rst
+++ b/package/README.rst
@@ -89,6 +89,6 @@ Download the Mu executable
 
 You can download the latest executable build of Mu for your respective operating system from the following links:
 
-* `Windows <http://ardublockly-builds.s3-website-us-west-2.amazonaws.com/index.html?prefix=microbit/windows/>`_
-* `Mac OS X <http://ardublockly-builds.s3-website-us-west-2.amazonaws.com/index.html?prefix=microbit/osx/>`_
-* `Linux <http://ardublockly-builds.s3-website-us-west-2.amazonaws.com/index.html?prefix=microbit/linux/>`_
+* `Windows <http://mu-builds.s3-website.eu-west-2.amazonaws.com/?prefix=windows/>`_
+* `Mac OS X <http://mu-builds.s3-website.eu-west-2.amazonaws.com/?prefix=osx/>`_
+* `Linux <http://mu-builds.s3-website.eu-west-2.amazonaws.com/?prefix=linux/>`_


### PR DESCRIPTION
A continuation from #274 .

Updates Travis to upload builds to new AWS S3 bucket spcecific for Mu.

Updates all the old links to: http://mu-builds.s3-website.eu-west-2.amazonaws.com