### PR TITLE
Win test errors

### DIFF
--- a/tests/interface/test_main.py
+++ b/tests/interface/test_main.py
@@ -705,7 +705,7 @@ def test_Window_update_debug_inspector_with_exception():
     mock_standard_item = mock.MagicMock()
     mock_eval = mock.MagicMock(side_effect=Exception('BOOM!'))
     with mock.patch('mu.interface.main.QStandardItem', mock_standard_item), \
-            mock.patch('mu.interface.main.eval', mock_eval):
+            mock.patch('builtins.eval', mock_eval):
         w.update_debug_inspector(locals_dict)
     # You just have to believe this is correct. I checked! :-)
     assert mock_standard_item.call_count == 2

--- a/tests/modes/test_debug.py
+++ b/tests/modes/test_debug.py
@@ -52,7 +52,7 @@ def test_debug_start():
     mock_debugger_class = mock.MagicMock(return_value=mock_debugger)
     dm = DebugMode(editor, view)
     dm.workspace_dir = mock.MagicMock(return_value='/bar')
-    with mock.patch('mu.modes.debugger.open') as oa, \
+    with mock.patch('builtins.open') as oa, \
             mock.patch('mu.modes.debugger.Debugger', mock_debugger_class), \
             mock.patch('mu.modes.debugger.write_and_flush'):
         dm.start()

--- a/tests/modes/test_microbit.py
+++ b/tests/modes/test_microbit.py
@@ -120,7 +120,7 @@ def test_flash_with_attached_device_and_custom_runtime():
         mm = MicrobitMode(editor, view)
         mm.flash()
         assert editor.show_status_message.call_count == 1
-        assert 'tests/customhextest.hex' in \
+        assert os.path.join('tests', 'customhextest.hex') in \
             editor.show_status_message.call_args[0][0]
         assert fl.call_count == 1
 

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -676,7 +676,7 @@ def test_save_no_path():
     ed.modes = {
         'python': mock_mode,
     }
-    with mock.patch('mu.logic.open', mock_open):
+    with mock.patch('builtins.open', mock_open):
         ed.save()
     assert mock_open.call_count == 1
     mock_open.assert_called_with('foo.py', 'w', newline='')
@@ -716,7 +716,7 @@ def test_save_file_with_exception():
     view.show_message = mock.MagicMock()
     mock_open = mock.MagicMock(side_effect=OSError())
     ed = mu.logic.Editor(view)
-    with mock.patch('mu.logic.open', mock_open):
+    with mock.patch('builtins.open', mock_open):
         ed.save()
     assert view.current_tab.setModified.call_count == 0
     assert view.show_message.call_count == 1
@@ -738,7 +738,7 @@ def test_save_python_file():
     mock_open.return_value.__exit__ = mock.Mock()
     mock_open.return_value.write = mock.MagicMock()
     ed = mu.logic.Editor(view)
-    with mock.patch('mu.logic.open', mock_open):
+    with mock.patch('builtins.open', mock_open):
         ed.save()
     mock_open.assert_called_once_with('foo.py', 'w', newline='')
     mock_open.return_value.write.assert_called_once_with('foo')
@@ -760,7 +760,7 @@ def test_save_with_no_file_extension():
     mock_open.return_value.__exit__ = mock.Mock()
     mock_open.return_value.write = mock.MagicMock()
     ed = mu.logic.Editor(view)
-    with mock.patch('mu.logic.open', mock_open):
+    with mock.patch('builtins.open', mock_open):
         ed.save()
     mock_open.assert_called_once_with('foo.py', 'w', newline='')
     mock_open.return_value.write.assert_called_once_with('foo')
@@ -1211,7 +1211,7 @@ def test_autosave():
     view.widgets = [mock_tab, ]
     ed = mu.logic.Editor(view)
     mock_open = mock.MagicMock()
-    with mock.patch('mu.logic.open', mock_open), \
+    with mock.patch('builtins.open', mock_open), \
             mock.patch('mu.logic.os'):
         ed.autosave()
     assert mock_open.call_count == 1


### PR DESCRIPTION
Looking at appveyor, once the script got far enough to try `py.test` we had some errors:
From https://ci.appveyor.com/project/carlosperate/mu/build/1.0.548 :

```
py.test
============================= test session starts =============================
platform win32 -- Python 3.4.4, pytest-3.2.2, py-1.4.34, pluggy-0.4.0
rootdir: C:\projects\mu, inifile:
collected 424 items
tests\test_app.py ....
tests\test_logic.py ....................................F.FFF....................F.....
tests\test_resources.py .....
tests\debugger\test_client.py ............................................
tests\debugger\test_runner.py ....................................................
tests\interface\test_dialogs.py ........
tests\interface\test_editor.py ...................
tests\interface\test_main.py ....................................F........................
tests\interface\test_panes.py ...........................................................................
tests\interface\test_themes.py ....
tests\modes\test_adafruit.py .......
tests\modes\test_base.py ...................
tests\modes\test_debug.py .F..............................
tests\modes\test_microbit.py ....F................
tests\modes\test_python3.py ......

...

==================== 8 failed, 416 passed in 4.80 seconds =====================
Command exited with code 1
```

One was a simple os-specific slash, the others I couldn't replicate on my dev machine but could get around by mocking `builtins.open` instead of `mu.<package>.open`. Not sure if that's the best way to resolve it, but does the job, so have a look and feel free to reject it if there is a better way.

Since this PR does not include the changes required for the appveyor script to get passed the pyinstaller failues, the PR autochecks will fail the AppVeyor check.
These are the results with this changes + appveyor script (from previous test):
https://ci.appveyor.com/project/carlosperate/mu/build/1.0.551
```
py.test
============================= test session starts =============================
platform win32 -- Python 3.4.4, pytest-3.2.2, py-1.4.34, pluggy-0.4.0
rootdir: C:\projects\mu, inifile:
collected 424 items
tests\test_app.py ....
tests\test_logic.py ...................................................................
tests\test_resources.py .....
tests\debugger\test_client.py ............................................
tests\debugger\test_runner.py ....................................................
tests\interface\test_dialogs.py ........
tests\interface\test_editor.py ...................
tests\interface\test_main.py .............................................................
tests\interface\test_panes.py ...........................................................................
tests\interface\test_themes.py ....
tests\modes\test_adafruit.py .......
tests\modes\test_base.py ...................
tests\modes\test_debug.py ................................
tests\modes\test_microbit.py .....................
tests\modes\test_python3.py ......
========================= 424 passed in 3.63 seconds ==========================
```