### PR TITLE
Repackage

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+mu (1.0.0~beta8) stretch; urgency=medium
+
+  * Repackage
+
+ -- Serge Schneider <serge@raspberrypi.org>  Tue, 26 Sep 2017 17:39:30 +0100
+
 mu (0.9.13-1) unstable; urgency=low
 
   * Add ability to change default Python directory in the settings file. Thanks to Zander Brown for the contribution. See #179.

--- a/debian/control
+++ b/debian/control
@@ -1,13 +1,15 @@
 Source: mu
-Maintainer: Nicholas Tollervey <ntoll@ntoll.org>
 Section: python
 Priority: optional
-Build-Depends: python3-setuptools, python3, debhelper (>= 9)
-Standards-Version: 3.9.1
+Maintainer: Serge Schneider <serge@raspberrypi.org>
+Build-Depends: debhelper (>= 9), dh-python, python3-all, python3-setuptools
+Standards-Version: 3.9.8
+Homepage: https://codewith.mu/
+X-Python3-Version: >= 3.2
 
 Package: mu
 Architecture: all
-Depends: ${misc:Depends}, ${python3:Depends}, python3-setuptools, python3-pyqt5,
-         python3-pyqt5.qsci, python3-pyqt5.qtserialport, python3-serial,
-         python3-pep8, pyflakes
-Description: A simple editor for kids, teachers and new programmers.
+Depends: ${python3:Depends}, ${misc:Depends}
+Description: A simple editor for beginner programmers
+ A very simple code editor for kids, teachers and beginner programmers.
+ It's written in Python and works on Windows, OSX, Linux and Raspberry Pi.

--- a/debian/copyright
+++ b/debian/copyright
@@ -1,0 +1,24 @@
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: mu
+Source: https://github.com/mu-editor/mu
+
+Files: *
+Copyright: 2015 Nicholas H.Tollervey <ntoll@ntoll.org>
+License: GPL-3.0+
+
+License: GPL-3.0+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+ .
+ This package is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ .
+ You should have received a copy of the GNU General Public License
+ along with this program. If not, see <https://www.gnu.org/licenses/>.
+ .
+ On Debian systems, the complete text of the GNU General
+ Public License version 3 can be found in "/usr/share/common-licenses/GPL-3".

--- a/debian/py3dist-overrides
+++ b/debian/py3dist-overrides
@@ -1,0 +1,3 @@
+pyqt5 python3-pyqt5
+qscintilla python3-pyqt5.qsci
+pyqt5.qtserialport python3-pyqt5.qtserialport

--- a/debian/rules
+++ b/debian/rules
@@ -3,3 +3,5 @@
 export PYBUILD_NAME=mu
 %:
 	dh $@ --with python3 --buildsystem=pybuild
+
+override_dh_auto_test:

--- a/debian/source/format
+++ b/debian/source/format
@@ -1,1 +1,1 @@
-3.0 (quilt)
+3.0 (native)

--- a/debian/source/options
+++ b/debian/source/options
@@ -1,0 +1,1 @@
+extend-diff-ignore = "^[^/]*[.]egg-info/"

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     packages=['mu', 'mu.contrib', 'mu.resources', 'mu.modes', 'mu.debugger',
               'mu.interface', 'mu.modes.api', ],
     install_requires=['pycodestyle', 'pyflakes', 'pyserial', 'pyqt5',
-                      'qscintilla', 'qtconsole', 'matplotlib', ],
+                      'qscintilla', 'qtconsole', 'matplotlib', 'pyqt5.qtserialport', ],
     include_package_data=True,
     zip_safe=False,
     classifiers=[


### PR DESCRIPTION
Updated packaging files and added missing dependency (pyqt5.qtserialport).

I don't know how the setup.py change affects other systems, but this makes sure that the resulting deb includes the python3-pyqt.qtserialport dependency, which is otherwise missing. Let me know if that breaks anything.

I've attached the resulting .deb file for testing:
[mu_1.0.0~beta8_all.zip](https://github.com/mu-editor/mu/files/1334293/mu_1.0.0.beta8_all.zip)
