### PR TITLE
Update Pi installation instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -78,8 +78,8 @@ platforms, run::
 
 If you are building for the Pi there are two steps::
 
-    $ apt-get install python3-pyqt5 python3-pyqt5.qsci and python3-pyqt5.qtserialport python3-dev
-    $ pip install -r requirements-pi.txt
+    $ apt-get install python3-pyqt5 python3-pyqt5.qsci and python3-pyqt5.qtserialport python3-pyqt5.qtsvg python3-dev
+    $ pip install -r requirements_pi.txt
 
 To run the local development version of "mu", in the root of this repository
 type::


### PR DESCRIPTION
Small typo in the requirements_pi.txt file, and adding a missing requirement for iPython qtconsole.
 
Qtconsole tries to import a series of different PyQt5 modules (https://github.com/jupyter/qtconsole/blob/19ce2ede040e744f10012c41b295f80fefdca0fa/qtconsole/qt_loaders.py#L272) and QtSvg has to be installed via apt-get on the pi. It is possible the same might be required on other debian based distros.