### PR TITLE
Add script to create Windows MSI installer

### DIFF
--- a/package/README.rst
+++ b/package/README.rst
@@ -99,3 +99,12 @@ You can download the latest executable build of Mu for your respective operating
 * `Windows <http://mu-builds.s3-website.eu-west-2.amazonaws.com/?prefix=windows/>`_
 * `Mac OS X <http://mu-builds.s3-website.eu-west-2.amazonaws.com/?prefix=osx/>`_
 * `Linux <http://mu-builds.s3-website.eu-west-2.amazonaws.com/?prefix=linux/>`_
+
+Create Windows MSI Installer
+------------------
+
+To create an MSI install the Wix Toolset http://wixtoolset.org/.
+Note: only the unreleased version 3.14 will install on Windows 10, you can download it here http://wixtoolset.org/releases/weekly/.
+
+* Set the version in the mu.wxs file.
+* Run `python create_msi.py`

--- a/package/create_msi.bat
+++ b/package/create_msi.bat
@@ -1,0 +1,32 @@
+@echo off
+
+:: Takes the MSI Name, the folder to bundle as parameters and the Wix config path and the Wix config name without the extension
+:: The last parameter is only needed because I don't know how to extract the file name from the path
+:: Ex.
+:: cmd> call create_msi.bat Application /full/path/to/app/dir/with/exe/ /path/to/app.wxs app
+
+setlocal
+set PATH=C:\Program Files (x86)\WiX Toolset v3.14\bin;%PATH%
+set msiName=%1
+set BuildDir=%2
+set WxsFile=%3
+set WxsName=%4
+
+:: -nologo - supress heat logo output
+:: -suid   - supress uuid for files, directories and components
+:: -ag     - Add guids
+:: -cd     - Component group name (used in EDMS.wxs)
+:: -dr     - We are creating INSTALLDIR
+:: -var    - Required to use proper path
+:: -out    - Output file (used by candle.exe below)
+echo %~dp0fromHeat.wxs
+echo %BuildDir%
+heat dir "%BuildDir%" -nologo -suid -ag -sfrag -srd -cg FromHeat -dr INSTALLDIR -var var.MyDir -out "%~dp0fromHeat.wxs"
+if errorlevel 1 exit 1
+
+:: -out output file (used by light.exe below)
+candle -dMyDir="%BuildDir%" "%WxsFile%" "%~dp0fromHeat.wxs" -out %~dp0
+::if errorlevel 1 exit 1
+
+light %~dp0%WxsName%.wixobj %~dp0fromHeat.wixobj -o "%~dp0%msiName%"
+::if errorlevel 1 exit 1

--- a/package/create_msi.py
+++ b/package/create_msi.py
@@ -1,0 +1,20 @@
+import os
+import subprocess
+
+THIS_DIR = os.path.abspath(os.path.dirname(__file__))
+
+
+def BuildMsi(Name, BuildDir, WxsPath, WxsName):
+    args = [os.path.join(THIS_DIR, "create_msi.bat"),
+            Name,
+            BuildDir,
+            WxsPath,
+            WxsName,
+    ]
+    p = subprocess.run(args)
+
+if __name__ == "__main__":
+    buildDir = os.path.join(THIS_DIR, "dist", "mu")
+    wxsPath = os.path.join(THIS_DIR, "mu.wxs")
+    wxsName = "mu"
+    BuildMsi("Mu Editor", buildDir, wxsPath, wxsName)

--- a/package/mu.wxs
+++ b/package/mu.wxs
@@ -1,0 +1,48 @@
+<?xml version="1.0"?>
+
+<?define ProductName = "Mu Editor"?>
+<?define ProductVersion = "0.0.1"?>
+<!-- NEVER CHANGE THE upgrade_code BELOW!!!! -->
+<?define ProductUpgradeCode = "4981284B-DCB8-4257-91CA-D79EDC94A9E8"?>
+<?define CompanyName = "Trylan Erruh"?>
+<?define InstallDir = "Mu Editor"?>
+
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+  <Product Id="*" UpgradeCode="$(var.ProductUpgradeCode)"
+           Name="$(var.ProductName)" Version="$(var.ProductVersion)" Manufacturer="$(var.CompanyName)" Language="1033">
+    <Package InstallerVersion="200" Compressed="yes" Comments="Windows Installer Package"/><!-- InstallScope="perUser" InstallPrivileges="limited"/> -->
+    <Media Id="1" Cabinet="product.cab" EmbedCab="yes"/>
+    <!-- <Icon Id="ProductIcon" SourceFile="example.ico"/> -->
+    <Property Id="ARPPRODUCTICON" Value="ProductIcon"/>
+    <Property Id="ARPHELPLINK" Value="https://codewith.mu/"/>
+    <Property Id="ARPURLINFOABOUT" Value="https://codewith.mu/"/>
+    <Property Id="ARPNOREPAIR" Value="1"/>
+    <Property Id="ARPNOMODIFY" Value="1"/>
+    <Upgrade Id="$(var.ProductUpgradeCode)">
+      <UpgradeVersion Minimum="$(var.ProductVersion)" OnlyDetect="yes" Property="NEWERVERSIONDETECTED"/>
+      <UpgradeVersion Minimum="0.0.0" Maximum="$(var.ProductVersion)" IncludeMinimum="yes" IncludeMaximum="no"
+                      Property="OLDERVERSIONBEINGUPGRADED"/>
+    </Upgrade>
+    <Condition Message="A newer version of this software is already installed.">NOT NEWERVERSIONDETECTED</Condition>
+
+    <Feature Id="ProgramFiles">
+      <ComponentGroupRef Id="FromHeat" />
+    </Feature>
+
+    <Directory Id="TARGETDIR" Name="SourceDir">
+      <!-- <Directory Id="LocalAppDataFolder"> -->
+      <Directory Id="ProgramFilesFolder">
+        <Directory Id="INSTALLDIR" Name="$(var.InstallDir)"></Directory>
+      </Directory>
+    </Directory>
+
+    <InstallExecuteSequence>
+      <RemoveExistingProducts After="InstallValidate"/>
+    </InstallExecuteSequence>
+    <!--
+    <Feature Id="DefaultFeature" Level="1">
+      <ComponentRef Id="ApplicationShortcuts"/>
+    </Feature>
+    -->
+   </Product>
+</Wix>


### PR DESCRIPTION
It packages the directory that is created by PyInstaller. I was not able to create the executable on Windows. (twisted failed to install for me on Windows 10 and Python 3.6).

Hopefully this is a good starting point and someone who has the PyInstaller executable can run this and create an MSI.

The MSI requires admin permission and installs into the Program Files directory.
There are lines commented out that will not require admin and will install into the users local AppData directory.