### PR TITLE
Recommend that the stdlib venv be used on Windows

### DIFF
--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -26,9 +26,14 @@ environment install all the dependencies into your virtualenv via the
 
     Using a virtualenv will ensure your development environment is safely
     isolated from such problematic version conflicts.
-    
+
     If in doubt, throw away your virtualenv and start again with a fresh
     install from ``requirements.txt`` as per the instructions above.
+
+    On Windows, use the venv module from the standard library to avoid an
+    issue with the Qt modules missing a DLL::
+
+        py -3 -mvenv .venv
 
 Raspberry Pi
 ++++++++++++


### PR DESCRIPTION
(cf https://github.com/mu-editor/mu/issues/354)

The current version of virtualenv (15.1) does not copy python3.dll into the venv created. But the latest Qt modules link to python3.dll. The stdlib venv module does copy python3.dll and we're only supporting 3.5+ so venv will always be present