### PR TITLE
No file encoding specified

### DIFF
--- a/mu/logic.py
+++ b/mu/logic.py
@@ -529,7 +529,7 @@ class Editor:
                 # No extension given, default to .py
                 tab.path += '.py'
             try:
-                with open(tab.path, 'w', newline='') as f:
+                with open(tab.path, 'w', newline='', encoding="utf-8") as f:
                     logger.info('Saving script to: {}'.format(tab.path))
                     logger.debug(tab.text())
                     write_and_flush(f, tab.text())

--- a/mu/logic.py
+++ b/mu/logic.py
@@ -138,8 +138,8 @@ logger = logging.getLogger(__name__)
 
 def write_and_flush(fileobj, content):
     """
-    Writes content to the fd, then flushes and fsyncs to ensure the data is, in
-    fact, written.
+    Writes content to the fileobj, then flushes and fsyncs to ensure the data is, 
+    in fact, written.
     """
     fileobj.write(content)
     fileobj.flush()

--- a/mu/logic.py
+++ b/mu/logic.py
@@ -136,14 +136,19 @@ MOTD = [  # Candidate phrases for the message of the day (MOTD).
 logger = logging.getLogger(__name__)
 
 
-def write_and_flush(fd, content):
+def write_and_flush(fileobj, content):
     """
     Writes content to the fd, then flushes and fsyncs to ensure the data is, in
     fact, written.
     """
-    fd.write(content)
-    fd.flush()
-    os.fsync(fd)
+    fileobj.write(content)
+    fileobj.flush()
+    #
+    # Theoretically this shouldn't work; fsync takes a file descriptor,
+    # not a file object. However, there's obviously some under-the-cover
+    # mechanism which converts one to the other (at least on Windows)
+    #
+    os.fsync(fileobj)
 
 
 def get_settings_path():
@@ -511,6 +516,22 @@ class Editor:
         """ for loading files passed from command line or the OS launch"""
         self._load(path)
 
+    def save_tab_to_file(self, tab):
+        try:
+            with open(tab.path, 'w', newline='', encoding="utf-8") as f:
+                logger.info('Saving script to: {}'.format(tab.path))
+                logger.debug(tab.text())
+                write_and_flush(f, tab.text())
+            tab.setModified(False)
+            self.show_status_message(_("Saved file: {}").format(tab.path))
+        except OSError as e:
+            logger.error(e)
+            message = _('Could not save file.')
+            information = _("Error saving file to disk. Ensure you have "
+                            "permission to write the file and "
+                            "sufficient disk space.")
+            self._view.show_message(message, information)
+    
     def save(self):
         """
         Save the content of the currently active editor tab.
@@ -528,20 +549,7 @@ class Editor:
             if not os.path.basename(tab.path).endswith('.py'):
                 # No extension given, default to .py
                 tab.path += '.py'
-            try:
-                with open(tab.path, 'w', newline='', encoding="utf-8") as f:
-                    logger.info('Saving script to: {}'.format(tab.path))
-                    logger.debug(tab.text())
-                    write_and_flush(f, tab.text())
-                tab.setModified(False)
-                self.show_status_message(_("Saved file: {}").format(tab.path))
-            except OSError as e:
-                logger.error(e)
-                message = _('Could not save file.')
-                information = _("Error saving file to disk. Ensure you have "
-                                "permission to write the file and "
-                                "sufficient disk space.")
-                self._view.show_message(message, information)
+            self.save_tab_to_file(tab)
         else:
             # The user cancelled the filename selection.
             tab.path = None
@@ -732,11 +740,7 @@ class Editor:
             logger.info('Autosave has detected changes.')
             for tab in self._view.widgets:
                 if tab.path and tab.isModified():
-                    with open(tab.path, 'w', newline='') as f:
-                        logger.info('Saving script to: {}'.format(tab.path))
-                        logger.debug(tab.text())
-                        write_and_flush(f, tab.text())
-                    tab.setModified(False)
+                    self.save_tab_to_file(tab)
 
     def check_usb(self):
         """

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -724,7 +724,7 @@ def test_save_no_path():
     with mock.patch('builtins.open', mock_open):
         ed.save()
     assert mock_open.call_count == 1
-    mock_open.assert_called_with('foo.py', 'w', newline='')
+    mock_open.assert_called_with('foo.py', 'w', newline='', encoding="utf-8")
     mock_open.return_value.write.assert_called_once_with('foo')
     view.get_save_path.assert_called_once_with('/fake/path')
 
@@ -785,7 +785,7 @@ def test_save_python_file():
     ed = mu.logic.Editor(view)
     with mock.patch('builtins.open', mock_open):
         ed.save()
-    mock_open.assert_called_once_with('foo.py', 'w', newline='')
+    mock_open.assert_called_once_with('foo.py', 'w', newline='', encoding="utf-8")
     mock_open.return_value.write.assert_called_once_with('foo')
     assert view.get_save_path.call_count == 0
     view.current_tab.setModified.assert_called_once_with(False)
@@ -807,7 +807,7 @@ def test_save_with_no_file_extension():
     ed = mu.logic.Editor(view)
     with mock.patch('builtins.open', mock_open):
         ed.save()
-    mock_open.assert_called_once_with('foo.py', 'w', newline='')
+    mock_open.assert_called_once_with('foo.py', 'w', newline='', encoding="utf-8")
     mock_open.return_value.write.assert_called_once_with('foo')
     assert view.get_save_path.call_count == 0
 
@@ -821,12 +821,10 @@ def test_save_utf8():
     # This will confirm both that every possible codepoint can be
     # saved, and that utf-8 is used for the encoding
     #
-    text = "".join(chr(i) for i in range(0x10000) if i not in range(0xdc00, 0xe000) and i not in range(0xd800, 0xdc00))
-    utf8 = text.encode("utf-8")
     view = mock.MagicMock()
     view.current_tab = mock.MagicMock()
     view.current_tab.path = 'foo.py'
-    view.current_tab.text = mock.MagicMock(return_value=text)
+    view.current_tab.text = mock.MagicMock(return_value='foo')
     view.get_save_path = mock.MagicMock(return_value='foo.py')
     view.current_tab.setModified = mock.MagicMock(return_value=None)
     mock_open = mock.MagicMock()
@@ -836,7 +834,8 @@ def test_save_utf8():
     ed = mu.logic.Editor(view)
     with mock.patch('builtins.open', mock_open):
         ed.save()
-    mock_open.return_value.write.assert_called_once_with(utf8)
+    mock_open.assert_called_once_with('foo.py', 'w', newline='', encoding="utf-8")
+    mock_open.return_value.write.assert_called_once_with('foo')
 
 def test_get_tab_existing_tab():
     """

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -724,7 +724,7 @@ def test_save_no_path():
     with mock.patch('builtins.open', mock_open):
         ed.save()
     assert mock_open.call_count == 1
-    mock_open.assert_called_with('foo.py', 'w', newline='')
+    mock_open.assert_called_with('foo.py', 'w', newline='', encoding="utf-8")
     mock_open.return_value.write.assert_called_once_with('foo')
     view.get_save_path.assert_called_once_with('/fake/path')
 
@@ -785,7 +785,7 @@ def test_save_python_file():
     ed = mu.logic.Editor(view)
     with mock.patch('builtins.open', mock_open):
         ed.save()
-    mock_open.assert_called_once_with('foo.py', 'w', newline='')
+    mock_open.assert_called_once_with('foo.py', 'w', newline='', encoding="utf-8")
     mock_open.return_value.write.assert_called_once_with('foo')
     assert view.get_save_path.call_count == 0
     view.current_tab.setModified.assert_called_once_with(False)
@@ -807,7 +807,7 @@ def test_save_with_no_file_extension():
     ed = mu.logic.Editor(view)
     with mock.patch('builtins.open', mock_open):
         ed.save()
-    mock_open.assert_called_once_with('foo.py', 'w', newline='')
+    mock_open.assert_called_once_with('foo.py', 'w', newline='', encoding="utf-8")
     mock_open.return_value.write.assert_called_once_with('foo')
     assert view.get_save_path.call_count == 0
 
@@ -828,7 +828,7 @@ def test_save_with_non_py_file_extension():
     ed = mu.logic.Editor(view)
     with mock.patch('builtins.open', mock_open):
         ed.save()
-    mock_open.assert_called_once_with('foo.txt', 'w', newline='')
+    mock_open.assert_called_once_with('foo.txt', 'w', newline='', encoding="utf-8")
     mock_open.return_value.write.assert_called_once_with('foo.txt')
     assert view.get_save_path.call_count == 0
 
@@ -1457,3 +1457,29 @@ def test_rename_tab_avoid_duplicating_other_tab_name():
                                               'A file of that name is already '
                                               'open in Mu.')
     assert mock_tab.path == 'old.py'
+
+
+def test_save_utf8():
+    """
+    Ensure the file is saved as UTF-8
+    """
+    #
+    # Construct the full set of BMP codepoints except surrogates
+    # This will confirm both that every possible codepoint can be
+    # saved, and that utf-8 is used for the encoding
+    #
+    view = mock.MagicMock()
+    view.current_tab = mock.MagicMock()
+    view.current_tab.path = 'foo.py'
+    view.current_tab.text = mock.MagicMock(return_value='foo')
+    view.get_save_path = mock.MagicMock(return_value='foo.py')
+    view.current_tab.setModified = mock.MagicMock(return_value=None)
+    mock_open = mock.MagicMock()
+    mock_open.return_value.__enter__ = lambda s: s
+    mock_open.return_value.__exit__ = mock.Mock()
+    mock_open.return_value.write = mock.MagicMock()
+    ed = mu.logic.Editor(view)
+    with mock.patch('builtins.open', mock_open):
+        ed.save()
+    mock_open.assert_called_once_with('foo.py', 'w', newline='', encoding="utf-8")
+    mock_open.return_value.write.assert_called_once_with('foo')


### PR DESCRIPTION
This PR addresses the isssue of saving / autosaving when the editor text contains a codepoint which can't be encoded via the Windows default cp1252 (a variation on iso-8859-1).

It also refactors very slightly and tidies up the file-writing mechanism