### PR TITLE
Fix macOS Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,9 @@ matrix:
       sudo: required
       language: generic
 
-    # To maximise compatibility pick earliest image, 10.9 to be removed on 20/01/2017
+    # To maximise compatibility pick earliest image, 10.10 oldest available
     - os: osx
-      osx_image: beta-xcode6.1
+      osx_image: xcode6.4
       sudo: required
       language: generic
 
@@ -68,7 +68,7 @@ deploy:
   acl: public_read
   on:
     repo: mu-editor/mu
-    branch: [master, travis_bucket_move]
+    branch: [master]
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,27 +24,24 @@ install:
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then bash package/install_osx.sh; fi
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then bash package/install_linux.sh; fi
 
-  # Install Mu dependencies (PyQt & QScintilla will be absorbed in requirements.txt once ready)
+  # Install Mu dependencies
   - sudo pip3 install -r requirements.txt
-  - sudo pip3 install PyQt5
-  - sudo pip3 install QScintilla
 
-  # Install packaging dependencies, macOS depends on update not yet released https://github.com/pyinstaller/pyinstaller/pull/1965
-  - sudo pip3 install git+git://github.com/pyinstaller/pyinstaller.git@483c819d6a256b58db6740696a901bd41c313f0c
+  # Install packaging dependencies
+  - sudo pip3 install pyinstaller==3.3.1
 
   # Check everything was correctly installed
   - echo $PATH
   - python3 --version
   - python3 -c "import struct; print(struct.calcsize('P') * 8)"
   - python3 -c "import sys; print(sys.executable)"
+  - python3 -m pip --version
   - pip3 --version
   - sudo pip3 --version
   - pip3 freeze
-  - python3 -c "import PyQt5"
-  - python3 -c "import PyQt5.Qsci"
 
 script:
-  # Run the tests, at the moment there is a segmentation fault on Linux, this will go away with Py3.5
+  # Run the tests, at the moment there is a segmentation fault on Linux
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then make check; fi
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then make clean; fi
 

--- a/package/install_osx.sh
+++ b/package/install_osx.sh
@@ -2,11 +2,9 @@
 set -ev
 brew update >/dev/null 2>&1  # This produces a lot of output that's not very interesting
 
-# Install Python 3.5 creates python3, python3.5, and pip3.5 commands but no pip3
+# Install Python 3.6 creates python3, python3.6, and pip3.6 commands but no pip3
 brew tap zoidbergwill/python
-brew install python35
-# Contrary zoidbergwill tap documentation turns out this symbolic link is not required
-# sudo ln -s /usr/local/Cellar/python35/3.5.2/bin/python3.5 /usr/bin/python3
+brew install python36
 
-# Copy pip3.5 symlink rather than creating one, better in case installation path changes
-cp -R /usr/local/bin/pip3.5 /usr/local/bin/pip3
+# Copy pip3.6 symlink rather than creating one, better in case installation path changes
+cp -R /usr/local/bin/pip3.6 /usr/local/bin/pip3


### PR DESCRIPTION
The travis builds were failing, this was mostly because pygame is only available as a mac wheel for Python 3.6, and the macOS installation script was still using Python 3.5.

This PR updates that, and a few other small things around that needed updating to keep up with Mu dependencies.