### PR TITLE
Constancy between the themes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ __pycache__
 # Distribution / packaging
 .Python
 env/
+.env/
 build/
 develop-eggs/
 dist/
@@ -67,6 +68,9 @@ target/
 
 # Pycharm
 .idea/
+
+# Visual Studio Code
+.vscode
 
 # OSX
 .DS_Store

--- a/mu/resources/css/contrast.css
+++ b/mu/resources/css/contrast.css
@@ -1,41 +1,64 @@
-QStackedWidget, QWidget, QApplication {
+QToolBar, QToolButton {
+    background: transparent;
+    margin: 0;
+    border: none;
+    padding: 0;
+}
+
+QToolButton {
+    padding: 4px 2px;
+}
+
+QToolButton:hover {
+    background: #666;
+    color: yellow;
+}
+
+QStackedWidget, QWidget, QApplication, QLabel, QStatusBar, QTabBar {
     background-color: black;
     color: white;
 }
 
-QDialog, QLabel, QStatusBar {
-    background-color: #333;
-    color: white;
-}
-
-QToolButton:hover {
-    color: #FF0000;
-}
-
-QTextEdit {
+QDialog, QTextEdit {
     background-color: black;
     color: white;
     border: 1px solid white;
 }
 
 QTabBar {
-    background: #333;
+    border: none;
+    background: black;
+}
+
+QTabBar::tab, QListWidget::item:hover, QListWidget::item:focus {
+    background: #3b3b3b;
+    border: none;
+    padding: 4px 8px;
+    margin: 0;
+}
+
+QTabBar::tab::hover, QListWidget::item::selected  {
+    background: #666;
+    border: none;
+    padding: 4px 8px;
+    margin: 0;
 }
 
 QTabBar::tab::selected {
     background: #555;
+    border: none;
+    padding: 4px 8px;
+    margin: 0;
 }
 
-QToolBar, QToolButton {
-    background: transparent;
+QTabWidget::pane {
+    border: none;
+    border-top: 2px solid #555;
+    border-bottom: 2px solid #555;
 }
 
-QSplitter::handle {
-    background: #333;
-}
-
-QMessageBox {
-    border: 1px solid white;
+QsciScintilla {
+    border: none;
 }
 
 QListWidget {
@@ -44,6 +67,11 @@ QListWidget {
     border: 1px solid white;
 }
 
-QListWidget::item:selected {
-    background: #444;
+QListWidget::item:selected, QListWidget::item:hover, QListWidget::item:focus {
+    padding: 0;
+    color: white;
+}
+
+QMessageBox {
+    border: 1px solid white;
 }

--- a/mu/resources/css/contrast.css
+++ b/mu/resources/css/contrast.css
@@ -75,3 +75,12 @@ QListWidget::item:selected, QListWidget::item:hover, QListWidget::item:focus {
 QMessageBox {
     border: 1px solid white;
 }
+
+QStatusBar QLabel {
+    padding: 2px;
+    margin: 0;
+}
+
+QStatusBar QLabel:hover, QStatusBar QLabel:focus {
+    background: #666;
+}

--- a/mu/resources/css/day.css
+++ b/mu/resources/css/day.css
@@ -1,23 +1,70 @@
-QStackedWidget, QWidget {
-    background-color: #EEE;
-    color: black;
+QToolBar, QToolButton {
+    background: transparent;
+    margin: 0;
+    border: none;
+    padding: 0;
+}
+
+QToolButton {
+    padding: 4px 2px;
 }
 
 QToolButton:hover {
     background-color: #cccccc;
-    border: #999999;
+}
+
+QStackedWidget, QWidget, QApplication, QDialog, QLabel, QStatusBar, QTabBar {
+    background-color: #EEE;
+    color: black;
 }
 
 QTextEdit {
     background-color: white;
     color: black;
+    border: none;
 }
 
-QToolBar, QToolButton {
-    background: transparent;
+QTabBar {
+    border: none;
+}
+
+QTabBar::tab, QListWidget::item:hover, QListWidget::item:focus {
+    background: #d4d4d4;
+    border: none;
+    padding: 4px 8px;
+    margin: 0;
+}
+
+QTabBar::tab::hover, QListWidget::item::selected  {
+    background: #c4c4c4;
+    border: none;
+    padding: 4px 8px;
+    margin: 0;
+}
+
+QTabBar::tab::selected {
+    background: #9e9e9e;
+    border: none;
+    padding: 4px 8px;
+    margin: 0;
+}
+
+QTabWidget::pane {
+    border: none;
+    border-top: 2px solid #9e9e9e;
+    border-bottom: 2px solid #9e9e9e;
+}
+
+QsciScintilla {
+    border: none;
 }
 
 QListWidget {
     background-color: white;
+    color: black;
+}
+
+QListWidget::item:selected, QListWidget::item:hover, QListWidget::item:focus {
+    padding: 0;
     color: black;
 }

--- a/mu/resources/css/day.css
+++ b/mu/resources/css/day.css
@@ -68,3 +68,12 @@ QListWidget::item:selected, QListWidget::item:hover, QListWidget::item:focus {
     padding: 0;
     color: black;
 }
+
+QStatusBar QLabel {
+    padding: 2px;
+    margin: 0;
+}
+
+QStatusBar QLabel:hover, QStatusBar QLabel:focus {
+    background: #cccccc;
+}

--- a/mu/resources/css/night.css
+++ b/mu/resources/css/night.css
@@ -68,3 +68,12 @@ QListWidget::item:selected, QListWidget::item:hover, QListWidget::item:focus {
     padding: 0;
     color: white;
 }
+
+QStatusBar QLabel {
+    padding: 2px;
+    margin: 0;
+}
+
+QStatusBar QLabel:hover, QStatusBar QLabel:focus {
+    background: #333;
+}

--- a/mu/resources/css/night.css
+++ b/mu/resources/css/night.css
@@ -1,23 +1,70 @@
-QStackedWidget, QWidget, QApplication {
-    background-color: #222;
-    color: #CCC;
+QToolBar, QToolButton {
+    background: transparent;
+    margin: 0;
+    border: none;
+    padding: 0;
+}
+
+QToolButton {
+    padding: 4px 2px;
 }
 
 QToolButton:hover {
     background-color: #333;
-    border: #CCC;
+}
+
+QStackedWidget, QWidget, QApplication, QDialog, QLabel, QStatusBar, QTabBar {
+    background-color: #222;
+    color: white;
 }
 
 QTextEdit {
     background-color: #222;
-    color: #CCC;
+    color: white;
+    border: none;
 }
 
-QToolBar, QToolButton {
-    background: transparent;
+QTabBar {
+    border: none;
+}
+
+QTabBar::tab, QListWidget::item:hover, QListWidget::item:focus {
+    background: #474747;
+    border: none;
+    padding: 4px 8px;
+    margin: 0;
+}
+
+QTabBar::tab::hover, QListWidget::item::selected  {
+    background: #5c5c5c;
+    border: none;
+    padding: 4px 8px;
+    margin: 0;
+}
+
+QTabBar::tab::selected {
+    background: #6b6b6b;
+    border: none;
+    padding: 4px 8px;
+    margin: 0;
+}
+
+QTabWidget::pane {
+    border: none;
+    border-top: 2px solid #6b6b6b;
+    border-bottom: 2px solid #6b6b6b;
+}
+
+QsciScintilla {
+    border: none;
 }
 
 QListWidget {
     background-color: #222;
-    color: #CCC;
+    color: white;
+}
+
+QListWidget::item:selected, QListWidget::item:hover, QListWidget::item:focus {
+    padding: 0;
+    color: white;
 }


### PR DESCRIPTION
Currently the UI jumps around and behaves differently in different themes, this brings consistency between the themes

Unfortunately there doesn't seem to be a way to style the margin without overly complex code (isn't visible to CSS :disappointed: )
![peek 2018-03-11 11-47](https://user-images.githubusercontent.com/17074021/37253713-1e4d635e-252d-11e8-87ba-ed5d90199752.gif)
