### PR TITLE
CI Linux: Enable tests on the Linux Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ before_install:
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then sw_vers; fi
   # Python 3 and pip 3 installation required in macOS
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then bash package/install_osx.sh; fi
-  # Linux needs to install pip again to have  pip3 for the right Python version
+  # Linux needs to install pip again to have pip3 for the right Python version
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then bash package/install_pip3.sh; fi
   # Check everything was correctly installed
   - echo $PATH
@@ -73,6 +73,7 @@ deploy:
   on:
     repo: mu-editor/mu
     branch: [master]
+    python: 3.6
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,19 @@
-# Travis can building for Linux (Ubuntu 14.04 x64) and OS X (El Capitan)
+# Travis can building for Linux and macOS
 matrix:
   include:
+    # To maximise compatibility pick earliest image, Ubuntu 14.04.5 x64
     - os: linux
       dist: trusty
       sudo: required
-      language: generic
+      language: python
+      python: 3.5
+    - os: linux
+      dist: trusty
+      sudo: required
+      language: python
+      python: 3.6
 
-    # To maximise compatibility pick earliest image, 10.10 oldest available
+    # To maximise compatibility pick earliest image, OS X 10.10 Yosemite
     - os: osx
       osx_image: xcode6.4
       sudo: required
@@ -16,20 +23,10 @@ before_install:
   # OS and default Python info
   - uname -a
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then sw_vers; fi
-  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then python3 -c "import sys; print(sys.executable)"; fi
-  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo python3 -c "import sys; print(sys.executable)"; fi
-
-install:
-  # Python 3 and pip 3 installation are OS dependent
+  # Python 3 and pip 3 installation required in macOS
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then bash package/install_osx.sh; fi
-  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then bash package/install_linux.sh; fi
-
-  # Install Mu dependencies
-  - sudo pip3 install -r requirements.txt
-
-  # Install packaging dependencies
-  - sudo pip3 install pyinstaller==3.3.1
-
+  # Linux needs to install pip again to have  pip3 for the right Python version
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then bash package/install_pip3.sh; fi
   # Check everything was correctly installed
   - echo $PATH
   - python3 --version
@@ -37,13 +34,23 @@ install:
   - python3 -c "import sys; print(sys.executable)"
   - python3 -m pip --version
   - pip3 --version
-  - sudo pip3 --version
+
+install:
+  # Install Mu dependencies
+  - pip3 install -r requirements.txt
+  # Install packaging dependencies
+  - pip3 install pyinstaller==3.3.1
+  # Install helpful pytest plug-in
+  - pip3 install pytest-faulthandler
+  # Check everything was correctly installed
   - pip3 freeze
 
 script:
-  # Run the tests, at the moment there is a segmentation fault on Linux
+  # Run the tests
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then make check; fi
-  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then make clean; fi
+  # PyQt crashes without a frame buffer, so Linux needs "X Virtual Framebuffer"
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then xvfb-run make check; fi
+  - make clean
 
   # Package it
   - pyinstaller package/pyinstaller.spec

--- a/package/install_linux.sh
+++ b/package/install_linux.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 set -ev
-# Install Python 3.5
+# Install Python 3.6
 sudo add-apt-repository ppa:deadsnakes/ppa -y
 sudo apt-get update -qq
-sudo apt-get install python3.5 python3.5-dev -y
+sudo apt-get install python3.6 python3.6-dev -y
 # Install pip
 curl -O https://bootstrap.pypa.io/get-pip.py
-sudo python3.5 get-pip.py
+sudo python3.6 get-pip.py
 rm get-pip.py
-# Change python3 link to point to python3.5 instead of python3.4 (/usr/bin/)
+# Change python3 link to point to python3.6 instead of python3.4 (/usr/bin/)
 sudo mv /usr/bin/python3 /usr/bin/python3-old
-sudo ln -s /usr/bin/python3.5 /usr/bin/python3
+sudo ln -s /usr/bin/python3.6 /usr/bin/python3

--- a/package/install_pip3.sh
+++ b/package/install_pip3.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -ev
+# Check python3 installation
+python3 --version
+python3 -c "import sys; print(sys.executable)"
+# Install pip
+curl -O https://bootstrap.pypa.io/get-pip.py
+python3 get-pip.py
+rm get-pip.py


### PR DESCRIPTION
This has been an itch I've been dying to scratch for quite a long time. Fixes https://github.com/mu-editor/mu/issues/244 and the reason why we coudn't run the tests on Linux Travis.

Turns out Qt was failing during launch/object initialisation in odd ways when running headless in Travis (in retrospect that's one of the first things I should have checked, I've tripped over the same stone before...) and pytest swallowing the stack trace didn't help either. But anyways, using xvfb on Linux is all that's needed.

There is a bit of a clean up and I've also moved from setting up our own Python environment to use the ones provided by Travis itself, so with Linux we are testing on Python 3.5 and 3.6.