### PR TITLE
CI Windows: Clean up AppVeyor file, reduce make checks 

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -13,9 +13,6 @@ init:
   - cmd: ECHO Processor architecture - %PROCESSOR_ARCHITECTURE%
   - cmd: wmic OS get OSArchitecture
 
-  # Utilise pre-installed MinGw for make
-  - ps: $env:PATH = 'C:\MinGW\msys\1.0\bin;C:\MinGW\mingw32\bin;C:\MinGW\bin;' + $env:PATH
-
   # As AppVeyor has multiple python install, check which one uses by default
   - cmd: ECHO %PYTHON% %PYTHON_VERSION% %PYTHON_ARCH%
   - cmd: python --version
@@ -36,12 +33,13 @@ init:
   - cmd: pip freeze
 
 install:
-  # Install / check python dependencies (v3.2 has VC++ redistributable dependencies)
+  # Install Mu Python dependencies
   - cmd: pip install simplegeneric 
-  - cmd: pip install pgzero 
-  - cmd: pip install pynsist
   - cmd: pip install -r requirements.txt
-
+  
+  # Install helpful pytest plug-in
+  - cmd: pip install pytest-faulthandler
+  
   # Check installed packages
   - cmd: pip freeze
   - cmd: python -c "import PyQt5"
@@ -63,9 +61,8 @@ install:
 # Not a project with an msbuild file, build done at install.
 build: None
 
-# Makefiles support provided by MinGW, which does POSIX translations, so run tests natively as well
 test_script:
-  - cmd: make check 
+  - cmd: make check
 
 # Push artifacts to s3 bucket and list all
 before_deploy:


### PR DESCRIPTION
_**Edit:** The text below from the original PR does no longer apply to the final squashed commit._

***
MinGW, along many other things, adds a POSIX layer on top of Windows, so we need to run the tests more "natively" as well without it.

This PR adds a pytest call after the `make check` and cleans up very minimally the AppVeyor script.

Apart from that I've removed the `make check` that runs as part of every `make win32` and `make win64`, as otherwise we have the same checks running 4 times on every CI build. If you think that should still be there anyway let me know and I'll revert it.