### PR TITLE
Change unicode arrow included in the check markers text

### DIFF
--- a/mu/interface/editor.py
+++ b/mu/interface/editor.py
@@ -238,7 +238,7 @@ class EditorPane(QsciScintilla):
             markers = self.check_indicators[indicator]['markers']
             for k, marker_list in markers.items():
                 for m in marker_list:
-                    lines[m['line_no']].append('\u2BB4' +
+                    lines[m['line_no']].append('\u2191' +
                                                m['message'].capitalize())
         for line, messages in lines.items():
             text = '\n'.join(messages).strip()

--- a/tests/interface/test_editor.py
+++ b/tests/interface/test_editor.py
@@ -262,7 +262,7 @@ def test_EditorPane_show_annotations():
     ep.annotate = mock.MagicMock()
     ep.show_annotations()
     ep.annotate.assert_called_once_with(1,
-                                        '\u2BB4Message 1\n\u2BB4Message 2',
+                                        '\u2191Message 1\n\u2191Message 2',
                                         ep.annotationDisplay())
 
 


### PR DESCRIPTION
Changes `⮴` to `↑` in the messages shown when the "check" button is pressed.

Fixes https://github.com/mu-editor/mu/issues/387.