### PR TITLE
Open logging for output as utf-8

### DIFF
--- a/mu/app.py
+++ b/mu/app.py
@@ -28,7 +28,7 @@ from logging.handlers import TimedRotatingFileHandler
 from PyQt5.QtCore import QTimer
 from PyQt5.QtWidgets import QApplication, QSplashScreen
 from mu import __version__
-from mu.logic import Editor, LOG_FILE, LOG_DIR, DEBUGGER_PORT
+from mu.logic import Editor, LOG_FILE, LOG_DIR, DEBUGGER_PORT, ENCODING
 from mu.interface import Window
 from mu.resources import load_pixmap
 from mu.modes import (PythonMode, AdafruitMode, MicrobitMode, DebugMode,
@@ -46,7 +46,8 @@ def setup_logging():
                '%(levelname)s: %(message)s')
     formatter = logging.Formatter(log_fmt)
     handler = TimedRotatingFileHandler(LOG_FILE, when='midnight',
-                                       backupCount=5, delay=0)
+                                       backupCount=5, delay=0,
+                                       encoding=ENCODING)
     handler.setFormatter(formatter)
     handler.setLevel(logging.DEBUG)
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -6,7 +6,7 @@ import sys
 import os.path
 from unittest import mock
 from mu.app import excepthook, run, setup_logging, debug, setup_modes
-from mu.logic import LOG_FILE, LOG_DIR, DEBUGGER_PORT
+from mu.logic import LOG_FILE, LOG_DIR, DEBUGGER_PORT, ENCODING
 
 
 def test_setup_logging():
@@ -20,7 +20,8 @@ def test_setup_logging():
         setup_logging()
         mkdir.assert_called_once_with(LOG_DIR)
         log_conf.assert_called_once_with(LOG_FILE, when='midnight',
-                                         backupCount=5, delay=0)
+                                         backupCount=5, delay=0,
+                                         encoding=ENCODING)
         logging.getLogger.assert_called_once_with()
         assert sys.excepthook == excepthook
 


### PR DESCRIPTION
The entire contents of the editor is written out via logging.debug() at various points. Previously, no encoding was specified when opening the logger; this will use the locale default which (on my Western Windows machine) won't encode, eg, Chinese characters.

This PR specifies the Mu default encoding (currently utf-8) when logging