### PR TITLE
Style context menus

### DIFF
--- a/mu/app.py
+++ b/mu/app.py
@@ -25,7 +25,7 @@ import platform
 import pkgutil
 import logging
 from logging.handlers import TimedRotatingFileHandler
-from PyQt5.QtCore import QTimer
+from PyQt5.QtCore import QTimer, Qt
 from PyQt5.QtWidgets import QApplication, QSplashScreen
 from mu import __version__
 from mu.logic import Editor, LOG_FILE, LOG_DIR, DEBUGGER_PORT, ENCODING
@@ -97,6 +97,7 @@ def run():
     logging.info('Python path: {}'.format(sys.path))
     # The app object is the application running on your computer.
     app = QApplication(sys.argv)
+    app.setAttribute(Qt.AA_DontShowIconsInMenus)
     # Create the "window" we'll be looking at.
     editor_window = Window()
     # Create the "editor" that'll control the "window".

--- a/mu/resources/css/contrast.css
+++ b/mu/resources/css/contrast.css
@@ -9,12 +9,12 @@ QToolButton {
     padding: 4px 2px;
 }
 
-QToolButton:hover {
+QToolButton:hover, QMenu::item:selected  {
     background: #666;
     color: yellow;
 }
 
-QStackedWidget, QWidget, QApplication, QLabel, QStatusBar, QTabBar {
+QStackedWidget, QWidget, QApplication, QLabel, QStatusBar, QTabBar, QMenu {
     background-color: black;
     color: white;
 }
@@ -94,4 +94,30 @@ QStatusBar QLabel {
 
 #AdministrationLabel:hover, #AdministrationLabel:focus {
     background: #666;
+}
+
+QMenu {
+    border: 3px solid yellow;
+    min-width: 100px;
+}
+
+QMenu::item {
+    border: none;
+    padding: 5px 15px;
+    width: 100%;
+}
+
+QMenu::item:selected {
+    border: none;
+}
+
+QMenu::item:disabled {
+    color: gray;
+}
+
+QMenu::separator {
+    border: none;
+    border-bottom: 2px solid yellow;
+    padding: 0px;
+    margin: 0px;
 }

--- a/mu/resources/css/day.css
+++ b/mu/resources/css/day.css
@@ -9,11 +9,12 @@ QToolButton {
     padding: 4px 2px;
 }
 
-QToolButton:hover {
+QToolButton:hover, QMenu::item:selected  {
     background-color: #cccccc;
 }
 
-QStackedWidget, QWidget, QApplication, QDialog, QLabel, QStatusBar, QTabBar {
+QStackedWidget, QWidget, QApplication, QDialog,
+QLabel, QStatusBar, QTabBar, QMenu {
     background-color: #EEE;
     color: black;
 }
@@ -82,4 +83,30 @@ QStatusBar QLabel {
 
 #AdministrationLabel:hover, #AdministrationLabel:focus {
     background: #cccccc;
+}
+
+QMenu {
+    border: none;
+    min-width: 100px;
+}
+
+QMenu::item {
+    border: none;
+    padding: 5px 15px;
+    width: 100%;
+}
+
+QMenu::item:selected {
+    border: none;
+}
+
+QMenu::item:disabled {
+    color: #cccccc;
+}
+
+QMenu::separator {
+    border: none;
+    border-bottom: 1px solid #cccccc;
+    padding: 0px;
+    margin: 0px;
 }

--- a/mu/resources/css/night.css
+++ b/mu/resources/css/night.css
@@ -9,11 +9,12 @@ QToolButton {
     padding: 4px 2px;
 }
 
-QToolButton:hover {
+QToolButton:hover, QMenu::item:selected {
     background-color: #333;
 }
 
-QStackedWidget, QWidget, QApplication, QDialog, QLabel, QStatusBar, QTabBar {
+QStackedWidget, QWidget, QApplication, QDialog,
+QLabel, QStatusBar, QTabBar, QMenu {
     background-color: #222;
     color: white;
 }
@@ -80,4 +81,30 @@ QStatusBar QLabel {
 
 #AdministrationLabel:hover, #AdministrationLabel:focus {
     background: #444;
+}
+
+QMenu {
+    border: none;
+    min-width: 100px;
+}
+
+QMenu::item {
+    border: none;
+    padding: 5px 15px;
+    width: 100%;
+}
+
+QMenu::item:selected {
+    border: none;
+}
+
+QMenu::item:disabled {
+    color: #333;
+}
+
+QMenu::separator {
+    border: none;
+    border-bottom: 1px solid #333;
+    padding: 0px;
+    margin: 0px;
 }


### PR DESCRIPTION
This is particularly important for the high contrast theme

At the moment there is no distinction between items and those that are disabled and the user has no indication of the hovered item (i.e. the clickyness)

Current master:
![peek 2018-03-28 11-12](https://user-images.githubusercontent.com/17074021/38023018-0f3299d0-3279-11e8-904f-9f5517e92db4.gif)

Proposal:
![peek 2018-03-28 11-13](https://user-images.githubusercontent.com/17074021/38023025-10fc0472-3279-11e8-83ac-6c368a0c1be0.gif)

I seem to be generating a lot of PRs lately, sorry if I'm filling your inbox :smile: 