### PR TITLE
Make sure that os.abspath failure modes happen correctly on Windows

### DIFF
--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -2019,7 +2019,7 @@ def test_load_cli():
 
     m = mock.MagicMock()
     ed.direct_load = m
-    ed.load_cli([None])
+    ed.load_cli([5])
     assert m.call_count == 0
     assert mock_view.show_message.call_count == 1
 
@@ -2043,7 +2043,7 @@ def test_abspath_fail():
     continue to process the "good" paths.
     """
     ed = mu.logic.Editor(mock.MagicMock())
-    paths = ['foo', 'bar', lambda: None, 'bar']
+    paths = ['foo', 'bar', 5, 'bar']
     with mock.patch('mu.logic.logger.error') as mock_error:
         result = ed._abspath(paths)
         assert mock_error.call_count == 1


### PR DESCRIPTION
To make Mu more robust, the new Editor._abspath functionality will log and move on if it fails to process in some way the path being passed to it. It's difficult to test this on Windows because pretty much anything (including None) will succeed when passed to os.abspath. Since we're catching all Exception, just in case, the easiest thing is to force a Type Error.

One of the test cases was fixed by 2c5b70abfc301df1c9f356a5be962e5a0b939dae but used a lambda expression to force failure. I've switched this out with a simple integer, since I had to  look twice to see if the lambda was doing something subtle (it wasn't), whereas the integer is obviously an invalid filename.