### PR TITLE
set a default help url for prereleases

### DIFF
--- a/mu/logic.py
+++ b/mu/logic.py
@@ -872,7 +872,7 @@ class Editor:
         major_version = '.'.join(__version__.split('.')[:2])
 
         logger.info('Open help URL for {} version {}'.format(language_code,
-            __version__))
+                                                             __version__))
         if (len(__version__.split('.')) > 3):
             # pre-release so show latest
             url = 'https://codewith.mu/help/latest'

--- a/mu/logic.py
+++ b/mu/logic.py
@@ -870,8 +870,15 @@ class Editor:
         current_locale, encoding = locale.getdefaultlocale()
         language_code = current_locale[:2]
         major_version = '.'.join(__version__.split('.')[:2])
-        url = 'https://codewith.mu/{}/help/{}'.format(language_code,
-                                                      major_version)
+
+        logger.info('Open help URL for {} version {}'.format(language_code,
+            __version__))
+        if (len(__version__.split('.')) > 3):
+            # pre-release so show latest
+            url = 'https://codewith.mu/help/latest'
+        else:
+            url = 'https://codewith.mu/{}/help/{}'.format(language_code,
+                                                          major_version)
         webbrowser.open_new(url)
 
     def quit(self, *args, **kwargs):

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -1228,7 +1228,10 @@ def test_show_help():
                        return_value=('en_GB', 'UTF-8')):
         ed.show_help()
         version = '.'.join(__version__.split('.')[:2])
-        url = 'https://codewith.mu/en/help/{}'.format(version)
+        if len(__version__.split('.')) > 3:
+            url = 'https://codewith.mu/help/latest'
+        else:
+            url = 'https://codewith.mu/en/help/{}'.format(version)
         wb.assert_called_once_with(url)
 
 


### PR DESCRIPTION
This PR fixes the case where Help opens a not found page when the mu version is a beta or prerelease.

Checks if there is a suffix beyond the major and minor version, if so open the default latest help page. Otherwise, open the language and release specific help.