### PR TITLE
searching /sbin/mount in adafruit mode

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -17,6 +17,7 @@ These include (but are not limited to):
 * Tibs / Tony Ibbs (tibs@tonyibbs.co.uk)
 * Zander Brown
 * Alistair Broomhead (alistair.broomhead@gmail.com)
+* Frank Morton (fmorton@mac.com)
 
 We welcome contributions from anyone! Please see :doc:`contributing` for more
 information.

--- a/mu/modes/adafruit.py
+++ b/mu/modes/adafruit.py
@@ -82,11 +82,15 @@ class AdafruitMode(MicroPythonMode):
         # plugged in CIRCUITPY board.
         if os.name == 'posix':
             # We're on Linux or OSX
-            mount_output = check_output('mount').splitlines()
-            mounted_volumes = [x.split()[2] for x in mount_output]
-            for volume in mounted_volumes:
-                if volume.endswith(b'CIRCUITPY'):
-                    device_dir = volume.decode('utf-8')
+            for mount_command in [ 'mount', '/sbin/mount' ]:
+                try:
+                    mount_output = check_output(mount_command).splitlines()
+                    mounted_volumes = [x.split()[2] for x in mount_output]
+                    for volume in mounted_volumes:
+                        if volume.endswith(b'CIRCUITPY'):
+                            device_dir = volume.decode('utf-8')
+                except FileNotFoundError:
+                    next
         elif os.name == 'nt':
             # We're on Windows.
 

--- a/mu/modes/adafruit.py
+++ b/mu/modes/adafruit.py
@@ -82,7 +82,7 @@ class AdafruitMode(MicroPythonMode):
         # plugged in CIRCUITPY board.
         if os.name == 'posix':
             # We're on Linux or OSX
-            for mount_command in [ 'mount', '/sbin/mount' ]:
+            for mount_command in ['mount', '/sbin/mount']:
                 try:
                     mount_output = check_output(mount_command).splitlines()
                     mounted_volumes = [x.split()[2] for x in mount_output]


### PR DESCRIPTION
By default, non-root users do not have "mount" in their path, but can access it using "/sbin/mount". This pull requests first uses "mount", and then if not found, attempts to use "/sbin/mount". Other locations may be easily added to the array of possible locationsl