### PR TITLE
Add option for the Mu modes to attempt to open a file

### DIFF
--- a/mu/interface/main.py
+++ b/mu/interface/main.py
@@ -224,7 +224,7 @@ class Window(QMainWindow):
         for tab in self.widgets:
             tab.setReadOnly(is_readonly)
 
-    def get_load_path(self, folder, extensions):
+    def get_load_path(self, folder, extensions='*'):
         """
         Displays a dialog for selecting a file to load. Returns the selected
         path. Defaults to start in the referenced folder.

--- a/mu/interface/main.py
+++ b/mu/interface/main.py
@@ -224,13 +224,13 @@ class Window(QMainWindow):
         for tab in self.widgets:
             tab.setReadOnly(is_readonly)
 
-    def get_load_path(self, folder):
+    def get_load_path(self, folder, extensions):
         """
         Displays a dialog for selecting a file to load. Returns the selected
         path. Defaults to start in the referenced folder.
         """
         path, _ = QFileDialog.getOpenFileName(self.widget, 'Open file', folder,
-                                              '*.py *.PY *.hex')
+                                              extensions)
         logger.debug('Getting load path: {}'.format(path))
         return path
 

--- a/mu/logic.py
+++ b/mu/logic.py
@@ -38,7 +38,6 @@ try:  # pragma: no cover
     from pycodestyle import StyleGuide, Checker
 except ImportError:  # pragma: no cover
     from pep8 import StyleGuide, Checker
-from mu.contrib import uflash
 from mu.resources import path
 from mu import __version__
 
@@ -726,43 +725,43 @@ class Editor:
                 self._view.show_message(msg.format(os.path.basename(path)))
                 self._view.focus_tab(widget)
                 return
+        name, text, newline, file_mode = None, None, None, None
         try:
             if path.lower().endswith('.py'):
                 # Open the file, read the textual content and set the name as
                 # the path to the file.
                 try:
                     text, newline = read_and_decode(path)
-                except UnicodeDecodeError as exc:
-                    message = _("Mu cannot read the characters in {}")
+                except UnicodeDecodeError:
+                    message = _('Mu cannot read the characters in {}')
                     filename = os.path.basename(path)
                     self._view.show_message(message.format(filename), error)
                     return
                 name = path
-            elif path.lower().endswith('.hex'):
-                # Open the hex, extract the Python script therein and set the
-                # name to None, thus forcing the user to work out what to name
-                # the recovered script.
-                try:
-                    with open(path, newline='') as f:
-                        text = uflash.extract_script(f.read())
-                        newline = sniff_newline_convention(text)
-                except Exception:
-                    filename = os.path.basename(path)
-                    message = _("Unable to load file {}").format(filename)
-                    info = _("Mu doesn't understand the hex file and cannot "
-                             "extract any Python code. Are you sure this is "
-                             "a hex file created with MicroPython?")
+            else:
+                # Delegate the open operation to the Mu modes. Leave the name
+                # as None, thus forcing the user to work out what to name the
+                # recovered script.
+                for mode_name, mode in self.modes.items():
+                    try:
+                        text = mode.open_file(path)
+                    except Exception as exc:
+                        # No worries, log it and try the next mode
+                        logger.warning('Error when mode {} try to open the '
+                                       '{} file.'.format(mode_name, path),
+                                       exc_info=exc)
+                    else:
+                        if text:
+                            newline = sniff_newline_convention(text)
+                            file_mode = mode_name
+                            break
+                else:
+                    message = _('Mu was not able to open this file')
+                    info = _('Currently Mu only works with Python source '
+                             'files or hex files created with embedded '
+                             'MicroPython code.')
                     self._view.show_message(message, info)
                     return
-                name = None
-            else:
-                # Mu won't open other file types, although this may change in
-                # the future.
-                message = _("Mu only opens .py and .hex files")
-                info = _("Currently Mu only works with Python source files or "
-                         "hex files created with embedded MicroPython code.")
-                self._view.show_message(message, info)
-                return
         except OSError:
             message = _("Could not load {}").format(path)
             logger.exception('Could not load {}'.format(path))
@@ -770,6 +769,15 @@ class Editor:
                      "permission to read it?\n\nPlease check and try again.")
             self._view.show_message(message, info)
         else:
+            if file_mode and self.mode != file_mode:
+                device_name = self.modes[file_mode].name
+                message = _('Is this a {} file?').format(device_name)
+                info = _('It looks like this could be a {} file.\n\n'
+                         'Would you like to change Mu to the {}'
+                         'mode?').format(device_name, device_name)
+                if self._view.show_confirmation(
+                        message, info, icon='Question') == QMessageBox.Ok:
+                    self.change_mode(file_mode)
             logger.debug(text)
             self._view.add_tab(
                 name, text, self.modes[self.mode].api(), newline)

--- a/mu/logic.py
+++ b/mu/logic.py
@@ -787,7 +787,16 @@ class Editor:
         Loads a Python file from the file system or extracts a Python script
         from a hex file.
         """
-        path = self._view.get_load_path(self.modes[self.mode].workspace_dir())
+        # Get all supported extensions from the different modes
+        extensions = ['py']
+        for mode_name, mode in self.modes.items():
+            if mode.file_extensions:
+                extensions += mode.file_extensions
+        extensions = set([e.lower() for e in extensions])
+        extensions = '*.{} *.{}'.format(' *.'.join(extensions),
+                                        ' *.'.join(extensions).upper())
+        path = self._view.get_load_path(self.modes[self.mode].workspace_dir(),
+                                        extensions)
         if path:
             self._load(path)
 

--- a/mu/modes/base.py
+++ b/mu/modes/base.py
@@ -86,6 +86,7 @@ class BaseMode(QObject):
     has_debugger = False
     save_timeout = 5  #: Number of seconds to wait before saving work.
     builtins = None  #: Symbols to assume as builtins when checking code style.
+    file_extensions = []
 
     def __init__(self, editor, view):
         self.editor = editor

--- a/mu/modes/base.py
+++ b/mu/modes/base.py
@@ -176,6 +176,12 @@ class BaseMode(QObject):
                  "time.")
         self.view.show_message(msg, info)
 
+    def open_file(self, path):
+        """
+        Some files are not plain text and each mode can attempt to decode them.
+        """
+        return None
+
 
 class MicroPythonMode(BaseMode):
     """

--- a/mu/modes/microbit.py
+++ b/mu/modes/microbit.py
@@ -169,6 +169,7 @@ class MicrobitMode(MicroPythonMode):
     fs = None  #: Reference to filesystem navigator.
     flash_thread = None
     flash_timer = None
+    file_extensions = ['hex']
 
     valid_boards = [
         (0x0D28, 0x0204),  # micro:bit USB VID, PID

--- a/mu/modes/microbit.py
+++ b/mu/modes/microbit.py
@@ -465,3 +465,17 @@ class MicrobitMode(MicroPythonMode):
         """
         self.set_buttons(files=True)
         super().on_data_flood()
+
+    def open_file(self, path):
+        """
+        Tries to open a MicroPython hex file with an embedded Python script.
+        """
+        text = None
+        if path.lower().endswith('.hex'):
+            # Try to open the hex and extract the Python script
+            try:
+                with open(path, newline='') as f:
+                    text = uflash.extract_script(f.read())
+            except Exception:
+                return None
+        return text

--- a/tests/interface/test_main.py
+++ b/tests/interface/test_main.py
@@ -385,10 +385,10 @@ def test_Window_get_load_path():
     w = mu.interface.main.Window()
     w.widget = mock.MagicMock()
     with mock.patch('mu.interface.main.QFileDialog', mock_fd):
-        assert w.get_load_path('micropython') == path
-    mock_fd.getOpenFileName.assert_called_once_with(w.widget, 'Open file',
-                                                    'micropython',
-                                                    '*.py *.PY *.hex')
+        returned_path = w.get_load_path('micropython', '*.py *.hex *.PY *.HEX')
+    assert returned_path == path
+    mock_fd.getOpenFileName.assert_called_once_with(
+        w.widget, 'Open file', 'micropython', '*.py *.hex *.PY *.HEX')
 
 
 def test_Window_get_save_path():

--- a/tests/modes/test_base.py
+++ b/tests/modes/test_base.py
@@ -179,6 +179,16 @@ def test_base_on_data_flood():
     assert view.show_message.call_count == 1
 
 
+def test_base_mode_open_file():
+    """
+    Ensure the the base class returns None to indicate it can't open the file.
+    """
+    editor = mock.MagicMock()
+    view = mock.MagicMock()
+    bm = BaseMode(editor, view)
+    assert bm.open_file('unused/path') is None
+
+
 def test_micropython_mode_find_device():
     """
     Ensure it's possible to detect a device and return the expected port.


### PR DESCRIPTION
Related to https://github.com/mu-editor/mu/pull/452, I wasn't sure if this approach was preferable instead of just doing the check in `Editor._load()`, so I thought I should check before I update the tests.

In essence, this extends the `BaseMode` class to have an `open` method, so `Editor._load()` only tries to open `.py` files, if the selected file has a different extension it then goes through each mode and sees if they can open the file.

It a mode opens the file it then asks the user if they'd like to change to that mode (if they are not there already).