### PR TITLE
Let microfs manage its serial connection and other serial updates

### DIFF
--- a/mu/interface/main.py
+++ b/mu/interface/main.py
@@ -590,7 +590,7 @@ class Window(QMainWindow):
             self.repl.deleteLater()
             self.repl = None
             if not self.plotter:
-                self.serial = None
+                self.close_serial_link()
 
     def remove_plotter(self):
         """
@@ -602,7 +602,7 @@ class Window(QMainWindow):
             self.plotter.deleteLater()
             self.plotter = None
             if not self.repl:
-                self.serial = None
+                self.close_serial_link()
 
     def remove_python_runner(self):
         """

--- a/mu/modes/microbit.py
+++ b/mu/modes/microbit.py
@@ -114,8 +114,7 @@ class FileManager(QObject):
         or emit a failure signal.
         """
         try:
-            with microfs.get_serial() as serial:
-                result = tuple(microfs.ls(serial))
+            result = tuple(microfs.ls())
             self.on_list_files.emit(result)
         except Exception as ex:
             logger.exception(ex)
@@ -128,8 +127,7 @@ class FileManager(QObject):
         failure signal.
         """
         try:
-            with microfs.get_serial() as serial:
-                microfs.get(microbit_filename, local_filename, serial)
+            microfs.get(microbit_filename, local_filename)
             self.on_get_file.emit(microbit_filename)
         except Exception as ex:
             logger.error(ex)
@@ -142,8 +140,7 @@ class FileManager(QObject):
         a failure signal.
         """
         try:
-            with microfs.get_serial() as serial:
-                microfs.put(local_filename, target=None, serial=serial)
+            microfs.put(local_filename, target=None)
             self.on_put_file.emit(os.path.basename(local_filename))
         except Exception as ex:
             logger.error(ex)
@@ -155,8 +152,7 @@ class FileManager(QObject):
         of the file when complete, or emit a failure signal.
         """
         try:
-            with microfs.get_serial() as serial:
-                microfs.rm(microbit_filename, serial)
+            microfs.rm(microbit_filename)
             self.on_delete_file.emit(microbit_filename)
         except Exception as ex:
             logger.error(ex)
@@ -429,10 +425,7 @@ class MicrobitMode(MicroPythonMode):
         Add the file system navigator to the UI.
         """
         # Check for micro:bit
-        try:
-            microfs.get_serial()
-        except IOError:
-            # abort
+        if not microfs.find_microbit():
             message = _('Could not find an attached BBC micro:bit.')
             information = _("Please make sure the device is plugged "
                             "into this computer.\n\nThe device must "

--- a/tests/modes/test_microbit.py
+++ b/tests/modes/test_microbit.py
@@ -69,8 +69,7 @@ def test_FileManager_ls():
     fm = FileManager()
     fm.on_list_files = mock.MagicMock()
     mock_ls = mock.MagicMock(return_value=['foo.py', 'bar.py', ])
-    with mock.patch('mu.modes.microbit.microfs.ls', mock_ls),\
-            mock.patch('mu.modes.microbit.microfs.get_serial'):
+    with mock.patch('mu.modes.microbit.microfs.ls', mock_ls):
         fm.ls()
     fm.on_list_files.emit.assert_called_once_with(('foo.py', 'bar.py'))
 
@@ -95,12 +94,9 @@ def test_fileManager_get():
     fm = FileManager()
     fm.on_get_file = mock.MagicMock()
     mock_get = mock.MagicMock()
-    mock_serial = mock.MagicMock()
-    with mock.patch('mu.modes.microbit.microfs.get', mock_get),\
-            mock.patch('mu.modes.microbit.microfs.get_serial', mock_serial):
+    with mock.patch('mu.modes.microbit.microfs.get', mock_get):
         fm.get('foo.py', 'bar.py')
-    mock_get.assert_called_once_with('foo.py', 'bar.py',
-                                     mock_serial().__enter__())
+    mock_get.assert_called_once_with('foo.py', 'bar.py')
     fm.on_get_file.emit.assert_called_once_with('foo.py')
 
 
@@ -110,7 +106,7 @@ def test_FileManager_get_fail():
     """
     fm = FileManager()
     fm.on_get_fail = mock.MagicMock()
-    with mock.patch('mu.modes.microbit.microfs.get_serial',
+    with mock.patch('mu.modes.microbit.microfs.get',
                     side_effect=Exception('boom')):
         fm.get('foo.py', 'bar.py')
     fm.on_get_fail.emit.assert_called_once_with('foo.py')
@@ -124,13 +120,10 @@ def test_FileManager_put():
     fm = FileManager()
     fm.on_put_file = mock.MagicMock()
     mock_put = mock.MagicMock()
-    mock_serial = mock.MagicMock()
     path = os.path.join('directory', 'foo.py')
-    with mock.patch('mu.modes.microbit.microfs.put', mock_put),\
-            mock.patch('mu.modes.microbit.microfs.get_serial', mock_serial):
+    with mock.patch('mu.modes.microbit.microfs.put', mock_put):
         fm.put(path)
-    mock_put.assert_called_once_with(path, target=None,
-                                     serial=mock_serial().__enter__())
+    mock_put.assert_called_once_with(path, target=None)
     fm.on_put_file.emit.assert_called_once_with('foo.py')
 
 
@@ -140,7 +133,7 @@ def test_FileManager_put_fail():
     """
     fm = FileManager()
     fm.on_put_fail = mock.MagicMock()
-    with mock.patch('mu.modes.microbit.microfs.get_serial',
+    with mock.patch('mu.modes.microbit.microfs.put',
                     side_effect=Exception('boom')):
         fm.put('foo.py')
     fm.on_put_fail.emit.assert_called_once_with('foo.py')
@@ -154,11 +147,9 @@ def test_FileManager_delete():
     fm = FileManager()
     fm.on_delete_file = mock.MagicMock()
     mock_rm = mock.MagicMock()
-    mock_serial = mock.MagicMock()
-    with mock.patch('mu.modes.microbit.microfs.rm', mock_rm),\
-            mock.patch('mu.modes.microbit.microfs.get_serial', mock_serial):
+    with mock.patch('mu.modes.microbit.microfs.rm', mock_rm):
         fm.delete('foo.py')
-    mock_rm.assert_called_once_with('foo.py', mock_serial().__enter__())
+    mock_rm.assert_called_once_with('foo.py')
     fm.on_delete_file.emit.assert_called_once_with('foo.py')
 
 
@@ -168,7 +159,7 @@ def test_FileManager_delete_fail():
     """
     fm = FileManager()
     fm.on_delete_fail = mock.MagicMock()
-    with mock.patch('mu.modes.microbit.microfs.get_serial',
+    with mock.patch('mu.modes.microbit.microfs.rm',
                     side_effect=Exception('boom')):
         fm.delete('foo.py')
     fm.on_delete_fail.emit.assert_called_once_with('foo.py')
@@ -567,7 +558,7 @@ def test_add_fs():
     mm = MicrobitMode(editor, view)
     with mock.patch('mu.modes.microbit.FileManager') as mock_fm,\
             mock.patch('mu.modes.microbit.QThread'),\
-            mock.patch('mu.modes.microbit.microfs.get_serial',
+            mock.patch('mu.modes.microbit.microfs.find_microbit',
                        return_value=True):
         mm.add_fs()
         workspace = mm.workspace_dir()
@@ -581,10 +572,10 @@ def test_add_fs_no_device():
     """
     view = mock.MagicMock()
     view.show_message = mock.MagicMock()
-    ex = IOError('BOOM')
     editor = mock.MagicMock()
     mm = MicrobitMode(editor, view)
-    with mock.patch('mu.modes.microbit.microfs.get_serial', side_effect=ex):
+    with mock.patch('mu.modes.microbit.microfs.find_microbit',
+                    return_value=False):
         mm.add_fs()
     assert view.show_message.call_count == 1
 


### PR DESCRIPTION
Since microfs is a lot more aware of timings required for the serial port opening and closing, let that module manage its own serial instances.

Replace the test for microbit presence by trying to open a serial connection, by just scanning available usb ports instead.

Set the Window class to close Qserial connections when panes are removed instead of relying  on the destructor to do it.