### PR TITLE
Ensure embedded process is run with UTF-8 encoding on stdout/err

### DIFF
--- a/mu/interface/panes.py
+++ b/mu/interface/panes.py
@@ -625,6 +625,7 @@ class PythonProcessPane(QTextEdit):
         # Force buffers to flush immediately.
         env = QProcessEnvironment.systemEnvironment()
         env.insert('PYTHONUNBUFFERED', '1')
+        env.insert('PYTHONIOENCODING', 'utf-8')
         if envars:
             logger.info('Running with environment variables: '
                         '{}'.format(envars))


### PR DESCRIPTION
This PR -- currently without tests -- addresses issue #401. The stdout encoding defaults to something which couldn't handle the full range of codepoints. Attempting to print, eg, Chinese characters failed noisily with a UnicodeEncodeError.

By setting the PYTHONIOENCODING env var for the process to UTF-8 the bytes are able to be encoded to be picked up by the output handler.

Submitting the PR without tests for now so that it's out there and not going mouldy on my hard disk. Hopefully I'll come back later to test.