### PR TITLE
Fix issue where the margin background doesn't update when theme changes

### DIFF
--- a/mu/interface/editor.py
+++ b/mu/interface/editor.py
@@ -175,8 +175,6 @@ class EditorPane(QsciScintilla):
         theme.apply_to(self.lexer)
         self.lexer.setDefaultPaper(theme.Paper)
         self.setCaretForegroundColor(theme.Caret)
-        self.setMarginsBackgroundColor(theme.Margin)
-        self.setMarginsForegroundColor(theme.Caret)
         self.setIndicatorForegroundColor(theme.IndicatorError,
                                          self.check_indicators['error']['id'])
         self.setIndicatorForegroundColor(theme.IndicatorStyle,
@@ -189,6 +187,8 @@ class EditorPane(QsciScintilla):
         self.setAutoCompletionThreshold(2)
         self.setAutoCompletionSource(QsciScintilla.AcsAll)
         self.setLexer(self.lexer)
+        self.setMarginsBackgroundColor(theme.Margin)
+        self.setMarginsForegroundColor(theme.Caret)
         self.setMatchedBraceBackgroundColor(theme.BraceBackground)
         self.setMatchedBraceForegroundColor(theme.BraceForeground)
         self.setUnmatchedBraceBackgroundColor(theme.UnmatchedBraceBackground)


### PR DESCRIPTION
As per jacobslusser/ScintillaNET#279, scintilla is quite sensitive to when the margin colors are set. 

By moving the call to setMarginsBackgroundColor() after
setLexer(), changing the theme now updates the margin background and foreground colours

An example of current behaviour on mu latest:
<img width="1434" alt="screenshot 2018-06-09 at 16 51 09" src="https://user-images.githubusercontent.com/704526/41193547-6090c8c2-6c05-11e8-9250-8b823fc0a357.png">

After this change (on master):
<img width="1135" alt="screenshot 2018-06-09 at 16 52 18" src="https://user-images.githubusercontent.com/704526/41193558-a3e4a7ec-6c05-11e8-941a-cf745bf02086.png">

(Note, the main editor text color issue is separate)
