### PR TITLE
Make toolbar icons crisp on OSX / HiDPI displays

### DIFF
--- a/mu/app.py
+++ b/mu/app.py
@@ -120,6 +120,9 @@ def run():
     app.setDesktopFileName('mu.codewith.editor')
     app.setApplicationVersion(__version__)
     app.setAttribute(Qt.AA_DontShowIconsInMenus)
+    # Images (such as toolbar icons) aren't scaled nicely on retina/4k displays
+    # unless this flag is set
+    app.setAttribute(Qt.AA_UseHighDpiPixmaps)
 
     # Create the "window" we'll be looking at.
     editor_window = Window()

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -75,7 +75,7 @@ def test_run():
         # foo.call_count is instantiating the class
         assert qa.call_count == 1
         # foo.mock_calls are method calls on the object
-        assert len(qa.mock_calls) == 7
+        assert len(qa.mock_calls) == 8
         assert qsp.call_count == 1
         assert len(qsp.mock_calls) == 2
         assert timer.call_count == 1


### PR DESCRIPTION
Oh High-DPI monitors (4k/OSX), QT does a great job of managing display scaling so that the text of MU looks crisp.  Unfortunately, this doesn't happen for images (pixmaps) by default.

This bug comment:  https://bugreports.qt.io/browse/QTBUG-45330?focusedCommentId=383350&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-383350
notes that you have to set an app-level flag to enable high-resolution image handling on these displays.

Before:
<img width="305" alt="screenshot 2018-06-11 at 18 33 20" src="https://user-images.githubusercontent.com/704526/41247685-a5b79ae6-6da6-11e8-9658-703106116863.png">

After:
<img width="300" alt="screenshot 2018-06-11 at 18 33 36" src="https://user-images.githubusercontent.com/704526/41247692-a9c8dc76-6da6-11e8-85d2-445233562728.png">

Note, I haven't been able to test this change on a non-retina display yet (will try later)