### PR TITLE
makep.py: Check for return codes

### DIFF
--- a/make.py
+++ b/make.py
@@ -166,10 +166,17 @@ def check():
     """Run all the checkers and tests
     """
     print("\nCheck")
-    clean()
-    pyflakes()
-    pycodestyle()
-    coverage()
+    funcs = [
+        clean,
+        pyflakes,
+        pycodestyle,
+        coverage
+    ]
+    for func in funcs:
+        return_code = func()
+        if return_code != 0:
+            return return_code
+    return 0
 
 
 @export
@@ -185,6 +192,7 @@ def clean():
     _rmtree("lib")
     _rmtree("pynsist_pkgs")
     _rmfiles(".", "*.pyc")
+    return 0
 
 
 @export
@@ -226,7 +234,7 @@ def run():
     if not os.environ.get("VIRTUAL_ENV"):
         raise RuntimeError("Cannot run Mu;"
                            "your Python virtualenv is not activated")
-    subprocess.run(["python", "-m", "mu"]).returncode
+    return subprocess.run(["python", "-m", "mu"]).returncode
 
 
 @export
@@ -235,7 +243,9 @@ def dist():
     """
     check()
     print("Checks pass; good to package")
-    subprocess.run(["python", "setup.py", "sdist", "bdist_wheel"]).returncode
+    return subprocess.run(
+        ["python", "setup.py", "sdist", "bdist_wheel"]
+    ).returncode
 
 
 @export
@@ -285,6 +295,8 @@ def docs():
     os.chdir("docs")
     try:
         return subprocess.run(["cmd", "/c", "make.bat", "html"]).returncode
+    except Exception:
+        return 1
     finally:
         os.chdir(cwd)
 

--- a/mu/debugger/client.py
+++ b/mu/debugger/client.py
@@ -232,7 +232,7 @@ class Debugger(QObject):
         try:
             if isinstance(breakpoint, tuple):
                 filename, line = breakpoint
-                filename = os.path.abspath(os.path.abspath(filename))
+                filename = os.path.normcase(os.path.abspath(filename))
                 return self.bp_index[filename][line]
             else:
                 return self.bp_list[breakpoint]

--- a/tests/interface/test_panes.py
+++ b/tests/interface/test_panes.py
@@ -631,7 +631,7 @@ def test_LocalFileList_contextMenuEvent():
     with mock.patch('mu.interface.panes.QMenu', return_value=mock_menu):
         mfs.contextMenuEvent(mock_event)
     assert mfs.set_message.emit.call_count == 0
-    mock_open.assert_called_once_with('homepath/foo.py')
+    mock_open.assert_called_once_with(os.path.join('homepath', 'foo.py'))
 
 
 def test_LocalFileList_contextMenuEvent_external():

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -3,6 +3,7 @@
 Tests for the module __init__ file.
 """
 import os
+import sys
 import importlib
 from unittest import mock
 
@@ -14,6 +15,9 @@ def test_gettext_translation():
     Test the right translation is set based on the LC_ALL environmental
     variable.
     """
+    if sys.platform == 'win32':
+        # Unix only test.
+        return
     old_lc_all = os.environ.get('LC_ALL', None)
     os.environ['LC_ALL'] = 'es_ES.UTF-8'
 


### PR DESCRIPTION
Fixes https://github.com/mu-editor/mu/issues/464.

check() in make.py wasn't stopping on errors, causing failing builds in AppVeyor to be set as "passed all tests". This PR updates the script to check for the return value of each step in check() and exits early with the correct error code if there is a problem.