### PR TITLE
Context menu for local files in micro:bit mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ pyflakes:
 	find . \( -name _build -o -name var -o -path ./docs -o -path ./mu/contrib -o -path ./utils -o -path ./venv \) -type d -prune -o -name '*.py' -print0 | $(XARGS) pyflakes
 
 pycodestyle:
-	find . \( -name _build -o -name var \) -type d -prune -o -name '*.py' -print0 | $(XARGS) -n 1 pycodestyle --repeat --exclude=build/*,docs/*,mu/contrib*,mu/modes/api/*,utils/*,venv/* --ignore=E731,E402,W504
+	find . \( -name _build -o -name var \) -type d -prune -o -name '*.py' -print0 | $(XARGS) -n 1 pycodestyle --repeat --exclude=build/*,docs/*,mu/contrib*,mu/modes/api/*,utils/*,venv/*,.vscode/* --ignore=E731,E402,W504
 
 test: clean
 	pytest

--- a/mu/interface/main.py
+++ b/mu/interface/main.py
@@ -365,6 +365,7 @@ class Window(QMainWindow):
         Adds the file system pane to the application.
         """
         self.fs_pane = FileSystemPane(home)
+
         @self.fs_pane.open_file.connect
         def on_open_file(file):
             # Bubble the signal up

--- a/mu/interface/main.py
+++ b/mu/interface/main.py
@@ -365,6 +365,11 @@ class Window(QMainWindow):
         Adds the file system pane to the application.
         """
         self.fs_pane = FileSystemPane(home)
+        @self.fs_pane.open_file.connect
+        def on_open_file(file):
+            # Bubble the signal up
+            self.open_file.emit(file)
+
         self.fs = QDockWidget(_('Filesystem on micro:bit'))
         self.fs.setWidget(self.fs_pane)
         self.fs.setFeatures(QDockWidget.DockWidgetMovable)

--- a/mu/interface/panes.py
+++ b/mu/interface/panes.py
@@ -457,6 +457,7 @@ class FileSystemPane(QFrame):
         self.font = Font().load()
         microbit_fs = MicrobitFileList(home)
         local_fs = LocalFileList(home)
+
         @local_fs.open_file.connect
         def on_open_file(file):
             # Bubble the signal up

--- a/mu/interface/panes.py
+++ b/mu/interface/panes.py
@@ -25,12 +25,14 @@ import signal
 import string
 import bisect
 import os.path
-from PyQt5.QtCore import Qt, QProcess, QProcessEnvironment, pyqtSignal, QTimer
+from PyQt5.QtCore import (Qt, QProcess, QProcessEnvironment, pyqtSignal,
+                          QTimer, QUrl)
 from collections import deque
 from PyQt5.QtWidgets import (QMessageBox, QTextEdit, QFrame, QListWidget,
                              QGridLayout, QLabel, QMenu, QApplication,
                              QTreeView)
-from PyQt5.QtGui import QKeySequence, QTextCursor, QCursor, QPainter
+from PyQt5.QtGui import (QKeySequence, QTextCursor, QCursor, QPainter,
+                         QDesktopServices)
 from qtconsole.rich_jupyter_widget import RichJupyterWidget
 from mu.interface.themes import Font
 from mu.interface.themes import (DEFAULT_FONT_SIZE, NIGHT_STYLE, DAY_STYLE,
@@ -374,6 +376,7 @@ class LocalFileList(MuFileList):
     """
 
     get = pyqtSignal(str, str)
+    open_file = pyqtSignal(str)
 
     def __init__(self, home):
         super().__init__()
@@ -407,6 +410,34 @@ class LocalFileList(MuFileList):
         self.set_message.emit(msg)
         self.list_files.emit()
 
+    def contextMenuEvent(self, event):
+        menu = QMenu(self)
+        local_filename = self.currentItem().text()
+        # Get the file extension
+        ext = os.path.splitext(local_filename)[1].lower()
+        open_internal_action = None
+        # Mu micro:bit mode only handles .py & .hex
+        if ext == '.py' or ext == '.hex':
+            open_internal_action = menu.addAction(_("Open in Mu"))
+        # Open outside Mu (things get meta if Mu is the default application)
+        open_action = menu.addAction(_("Open"))
+        action = menu.exec_(self.mapToGlobal(event.pos()))
+        if action == open_action:
+            # Get the file's path
+            path = os.path.join(self.home, local_filename)
+            logger.info("Opening {}".format(path))
+            msg = _("Opening '{}'").format(local_filename)
+            logger.info(msg)
+            self.set_message.emit(msg)
+            # Let Qt work out how to open it
+            QDesktopServices.openUrl(QUrl.fromLocalFile(path))
+        elif action == open_internal_action:
+            logger.info("Open {} internally".format(local_filename))
+            # Get the file's path
+            path = os.path.join(self.home, local_filename)
+            # Send the signal bubbling up the tree
+            self.open_file.emit(path)
+
 
 class FileSystemPane(QFrame):
     """
@@ -418,6 +449,7 @@ class FileSystemPane(QFrame):
     set_message = pyqtSignal(str)
     set_warning = pyqtSignal(str)
     list_files = pyqtSignal()
+    open_file = pyqtSignal(str)
 
     def __init__(self, home):
         super().__init__()
@@ -425,6 +457,11 @@ class FileSystemPane(QFrame):
         self.font = Font().load()
         microbit_fs = MicrobitFileList(home)
         local_fs = LocalFileList(home)
+        @local_fs.open_file.connect
+        def on_open_file(file):
+            # Bubble the signal up
+            self.open_file.emit(file)
+
         layout = QGridLayout()
         self.setLayout(layout)
         microbit_label = QLabel()

--- a/tests/interface/test_main.py
+++ b/tests/interface/test_main.py
@@ -674,6 +674,16 @@ def test_Window_add_filesystem():
     w.connect_zoom.assert_called_once_with(mock_fs)
 
 
+def test_Window_add_filesystem_open_signal():
+    w = mu.interface.main.Window()
+    w.open_file = mock.MagicMock()
+    mock_open_emit = mock.MagicMock()
+    w.open_file.emit = mock_open_emit
+    pane = w.add_filesystem('homepath', mock.MagicMock())
+    pane.open_file.emit('test')
+    mock_open_emit.assert_called_once_with('test')
+
+
 def test_Window_add_micropython_repl():
     """
     Ensure the expected object is instantiated and add_repl is called for a

--- a/tests/interface/test_panes.py
+++ b/tests/interface/test_panes.py
@@ -633,6 +633,7 @@ def test_LocalFileList_contextMenuEvent():
     assert mfs.set_message.emit.call_count == 0
     mock_open.assert_called_once_with('homepath/foo.py')
 
+
 def test_LocalFileList_contextMenuEvent_external():
     """
     Ensure that the menu displayed when a local file is

--- a/tests/interface/test_panes.py
+++ b/tests/interface/test_panes.py
@@ -861,6 +861,18 @@ def test_FileSystemPane_zoom_in():
     fsp.set_font_size.assert_called_once_with(expected)
 
 
+def test_FileSystemPane_open_file():
+    """
+    FileSystemPane should propogate the open_file signal
+    """
+    fsp = mu.interface.panes.FileSystemPane('homepath')
+    fsp.open_file = mock.MagicMock()
+    mock_open_emit = mock.MagicMock()
+    fsp.open_file.emit = mock_open_emit
+    fsp.local_fs.open_file.emit('test')
+    mock_open_emit.assert_called_once_with('test')
+
+
 def test_FileSystemPane_zoom_out():
     """
     Ensure the font is re-set smaller when zooming out.

--- a/tests/interface/test_panes.py
+++ b/tests/interface/test_panes.py
@@ -607,6 +607,30 @@ def test_LocalFileList_on_get():
     lfs.list_files.emit.assert_called_once_with()
 
 
+def test_LocalFileList_contextMenuEvent():
+    """
+    Ensure that the menu displayed when a local file is
+    right-clicked works as expected when activated.
+    """
+    mock_menu = mock.MagicMock()
+    mock_action = mock.MagicMock()
+    mock_menu.addAction.return_value = mock_action
+    mock_menu.exec_.return_value = mock_action
+    mfs = mu.interface.panes.LocalFileList('homepath')
+    mock_open = mock.MagicMock()
+    mfs.open_file.connect(mock_open)
+    mock_current = mock.MagicMock()
+    mock_current.text.return_value = 'foo.py'
+    mfs.currentItem = mock.MagicMock(return_value=mock_current)
+    mfs.set_message = mock.MagicMock()
+    mfs.mapToGlobal = mock.MagicMock()
+    mock_event = mock.MagicMock()
+    with mock.patch('mu.interface.panes.QMenu', return_value=mock_menu):
+        mfs.contextMenuEvent(mock_event)
+    assert mfs.set_message.emit.call_count == 1
+    mock_open.assert_called_once_with('foo.py')
+
+
 def test_FileSystemPane_init():
     """
     Check things are set up as expected.


### PR DESCRIPTION
Finally resolve #174, when I said I'd look into it later I had intended a few days, not 16 months! (sorry @whaleygeek)

All local files gain an "Open" command which basically gives the file to Qt to *do the right thing™*
![screenshot from 2018-06-21 23-16-31](https://user-images.githubusercontent.com/17074021/41748413-b4ab7116-75a9-11e8-8750-3c44bad0725d.png)

Files with a `.py` or `.hex` extension have an additional "Open in Mu" which *does what it says on the tin™*
![screenshot from 2018-06-21 23-16-38](https://user-images.githubusercontent.com/17074021/41748415-b4ccc852-75a9-11e8-8317-9f64adadc8d1.png)

And I was right, it wasn't too difficult! (apart from a moment of silliness with the tests)