### PR TITLE
Modal dialogs

### DIFF
--- a/mu/interface/dialogs.py
+++ b/mu/interface/dialogs.py
@@ -48,6 +48,9 @@ class ModeSelector(QDialog):
     Defines a UI for selecting the mode for Mu.
     """
 
+    def __init__(self, parent):
+        super().__init__(parent)
+
     def setup(self, modes, current_mode, theme):
         if theme == 'day':
             self.setStyleSheet(DAY_STYLE)
@@ -168,6 +171,9 @@ class AdminDialog(QDialog):
     Displays administrative related information and settings (logs, environment
     variables etc...).
     """
+
+    def __init__(self, parent):
+        super().__init__(parent)
 
     def setup(self, log, settings, theme):
         if theme == 'day':

--- a/mu/interface/dialogs.py
+++ b/mu/interface/dialogs.py
@@ -48,7 +48,7 @@ class ModeSelector(QDialog):
     Defines a UI for selecting the mode for Mu.
     """
 
-    def __init__(self, parent):
+    def __init__(self, parent=None):
         super().__init__(parent)
 
     def setup(self, modes, current_mode, theme):
@@ -172,7 +172,7 @@ class AdminDialog(QDialog):
     variables etc...).
     """
 
-    def __init__(self, parent):
+    def __init__(self, parent=None):
         super().__init__(parent)
 
     def setup(self, log, settings, theme):

--- a/mu/interface/main.py
+++ b/mu/interface/main.py
@@ -229,7 +229,7 @@ class Window(QMainWindow):
         Displays a dialog for selecting a file to load. Returns the selected
         path. Defaults to start in the referenced folder.
         """
-        path, _ = QFileDialog.getOpenFileName(self, 'Open file', folder,
+        path, _ = QFileDialog.getOpenFileName(self.widget, 'Open file', folder,
                                               extensions)
         logger.debug('Getting load path: {}'.format(path))
         return path
@@ -239,7 +239,7 @@ class Window(QMainWindow):
         Displays a dialog for selecting a file to save. Returns the selected
         path. Defaults to start in the referenced folder.
         """
-        path, _ = QFileDialog.getSaveFileName(self, 'Save file', folder)
+        path, _ = QFileDialog.getSaveFileName(self.widget, 'Save file', folder)
         logger.debug('Getting save path: {}'.format(path))
         return path
 
@@ -249,7 +249,7 @@ class Window(QMainWindow):
         host computer's filesystem. Returns the selected path. Defaults to
         start in the referenced folder.
         """
-        path = QFileDialog.getExistingDirectory(self,
+        path = QFileDialog.getExistingDirectory(self.widget,
                                                 'Locate BBC micro:bit', folder,
                                                 QFileDialog.ShowDirsOnly)
         logger.debug('Getting micro:bit path: {}'.format(path))

--- a/mu/interface/main.py
+++ b/mu/interface/main.py
@@ -229,7 +229,7 @@ class Window(QMainWindow):
         Displays a dialog for selecting a file to load. Returns the selected
         path. Defaults to start in the referenced folder.
         """
-        path, _ = QFileDialog.getOpenFileName(self.widget, 'Open file', folder,
+        path, _ = QFileDialog.getOpenFileName(self, 'Open file', folder,
                                               extensions)
         logger.debug('Getting load path: {}'.format(path))
         return path
@@ -249,7 +249,7 @@ class Window(QMainWindow):
         host computer's filesystem. Returns the selected path. Defaults to
         start in the referenced folder.
         """
-        path = QFileDialog.getExistingDirectory(self.widget,
+        path = QFileDialog.getExistingDirectory(self,
                                                 'Locate BBC micro:bit', folder,
                                                 QFileDialog.ShowDirsOnly)
         logger.debug('Getting micro:bit path: {}'.format(path))

--- a/mu/interface/main.py
+++ b/mu/interface/main.py
@@ -239,7 +239,7 @@ class Window(QMainWindow):
         Displays a dialog for selecting a file to save. Returns the selected
         path. Defaults to start in the referenced folder.
         """
-        path, _ = QFileDialog.getSaveFileName(self.widget, 'Save file', folder)
+        path, _ = QFileDialog.getSaveFileName(self, 'Save file', folder)
         logger.debug('Getting save path: {}'.format(path))
         return path
 
@@ -665,7 +665,7 @@ class Window(QMainWindow):
         and settings. Return a dictionary of the settings that may have been
         changed by the admin dialog.
         """
-        admin_box = AdminDialog()
+        admin_box = AdminDialog(self)
         admin_box.setup(log, settings, theme)
         admin_box.exec()
         return admin_box.settings()
@@ -806,7 +806,7 @@ class Window(QMainWindow):
         """
         Display the mode selector dialog and return the result.
         """
-        mode_select = ModeSelector()
+        mode_select = ModeSelector(self)
         mode_select.setup(modes, current_mode, theme)
         mode_select.exec()
         try:

--- a/tests/interface/test_dialogs.py
+++ b/tests/interface/test_dialogs.py
@@ -57,7 +57,7 @@ def test_ModeSelector_setup():
     current_mode = 'python'
     mock_item = mock.MagicMock()
     with mock.patch('mu.interface.dialogs.ModeItem', mock_item):
-        ms = mu.interface.dialogs.ModeSelector()
+        ms = mu.interface.dialogs.ModeSelector(None)
         ms.setup(modes, current_mode, 'day')
     assert mock_item.call_count == 3
 
@@ -77,7 +77,7 @@ def test_ModeSelector_setup_night_theme():
     mock_item = mock.MagicMock()
     mock_css = mock.MagicMock()
     with mock.patch('mu.interface.dialogs.ModeItem', mock_item):
-        ms = mu.interface.dialogs.ModeSelector()
+        ms = mu.interface.dialogs.ModeSelector(None)
         ms.setStyleSheet = mock_css
         ms.setup(modes, current_mode, 'night')
     assert mock_item.call_count == 3
@@ -99,7 +99,7 @@ def test_ModeSelector_setup_contrast_theme():
     mock_item = mock.MagicMock()
     mock_css = mock.MagicMock()
     with mock.patch('mu.interface.dialogs.ModeItem', mock_item):
-        ms = mu.interface.dialogs.ModeSelector()
+        ms = mu.interface.dialogs.ModeSelector(None)
         ms.setStyleSheet = mock_css
         ms.setup(modes, current_mode, 'contrast')
     assert mock_item.call_count == 3
@@ -110,7 +110,7 @@ def test_ModeSelector_select_and_accept():
     """
     Ensure the accept slot is fired when this event handler is called.
     """
-    ms = mu.interface.dialogs.ModeSelector()
+    ms = mu.interface.dialogs.ModeSelector(None)
     ms.accept = mock.MagicMock()
     ms.select_and_accept()
     ms.accept.assert_called_once_with()
@@ -121,7 +121,7 @@ def test_ModeSelector_get_mode():
     Ensure that the ModeSelector will correctly return a selected mode (or
     raise the expected exception if cancelled).
     """
-    ms = mu.interface.dialogs.ModeSelector()
+    ms = mu.interface.dialogs.ModeSelector(None)
     ms.result = mock.MagicMock(return_value=QDialog.Accepted)
     item = mock.MagicMock()
     item.icon = 'name'
@@ -182,7 +182,7 @@ def test_AdminDialog_setup():
         'minify': True,
         'microbit_runtime': '/foo/bar',
     }
-    ad = mu.interface.dialogs.AdminDialog()
+    ad = mu.interface.dialogs.AdminDialog(None)
     ad.setStyleSheet = mock.MagicMock()
     ad.setup(log, settings, 'day')
     assert ad.log_widget.log_text_area.toPlainText() == log
@@ -200,7 +200,7 @@ def test_AdminDialog_setup_night():
         'minify': True,
         'microbit_runtime': '/foo/bar',
     }
-    ad = mu.interface.dialogs.AdminDialog()
+    ad = mu.interface.dialogs.AdminDialog(None)
     ad.setStyleSheet = mock.MagicMock()
     ad.setup(log, settings, 'night')
     ad.setStyleSheet.assert_called_once_with(mu.interface.themes.NIGHT_STYLE)
@@ -216,7 +216,7 @@ def test_LogDisplay_setup_contrast():
         'minify': True,
         'microbit_runtime': '/foo/bar',
     }
-    ad = mu.interface.dialogs.AdminDialog()
+    ad = mu.interface.dialogs.AdminDialog(None)
     ad.setStyleSheet = mock.MagicMock()
     ad.setup(log, settings, 'contrast')
     ad.setStyleSheet.\

--- a/tests/interface/test_dialogs.py
+++ b/tests/interface/test_dialogs.py
@@ -57,7 +57,7 @@ def test_ModeSelector_setup():
     current_mode = 'python'
     mock_item = mock.MagicMock()
     with mock.patch('mu.interface.dialogs.ModeItem', mock_item):
-        ms = mu.interface.dialogs.ModeSelector(None)
+        ms = mu.interface.dialogs.ModeSelector()
         ms.setup(modes, current_mode, 'day')
     assert mock_item.call_count == 3
 
@@ -77,7 +77,7 @@ def test_ModeSelector_setup_night_theme():
     mock_item = mock.MagicMock()
     mock_css = mock.MagicMock()
     with mock.patch('mu.interface.dialogs.ModeItem', mock_item):
-        ms = mu.interface.dialogs.ModeSelector(None)
+        ms = mu.interface.dialogs.ModeSelector()
         ms.setStyleSheet = mock_css
         ms.setup(modes, current_mode, 'night')
     assert mock_item.call_count == 3
@@ -99,7 +99,7 @@ def test_ModeSelector_setup_contrast_theme():
     mock_item = mock.MagicMock()
     mock_css = mock.MagicMock()
     with mock.patch('mu.interface.dialogs.ModeItem', mock_item):
-        ms = mu.interface.dialogs.ModeSelector(None)
+        ms = mu.interface.dialogs.ModeSelector()
         ms.setStyleSheet = mock_css
         ms.setup(modes, current_mode, 'contrast')
     assert mock_item.call_count == 3
@@ -110,7 +110,7 @@ def test_ModeSelector_select_and_accept():
     """
     Ensure the accept slot is fired when this event handler is called.
     """
-    ms = mu.interface.dialogs.ModeSelector(None)
+    ms = mu.interface.dialogs.ModeSelector()
     ms.accept = mock.MagicMock()
     ms.select_and_accept()
     ms.accept.assert_called_once_with()
@@ -121,7 +121,7 @@ def test_ModeSelector_get_mode():
     Ensure that the ModeSelector will correctly return a selected mode (or
     raise the expected exception if cancelled).
     """
-    ms = mu.interface.dialogs.ModeSelector(None)
+    ms = mu.interface.dialogs.ModeSelector()
     ms.result = mock.MagicMock(return_value=QDialog.Accepted)
     item = mock.MagicMock()
     item.icon = 'name'
@@ -182,7 +182,7 @@ def test_AdminDialog_setup():
         'minify': True,
         'microbit_runtime': '/foo/bar',
     }
-    ad = mu.interface.dialogs.AdminDialog(None)
+    ad = mu.interface.dialogs.AdminDialog()
     ad.setStyleSheet = mock.MagicMock()
     ad.setup(log, settings, 'day')
     assert ad.log_widget.log_text_area.toPlainText() == log
@@ -200,7 +200,7 @@ def test_AdminDialog_setup_night():
         'minify': True,
         'microbit_runtime': '/foo/bar',
     }
-    ad = mu.interface.dialogs.AdminDialog(None)
+    ad = mu.interface.dialogs.AdminDialog()
     ad.setStyleSheet = mock.MagicMock()
     ad.setup(log, settings, 'night')
     ad.setStyleSheet.assert_called_once_with(mu.interface.themes.NIGHT_STYLE)
@@ -216,7 +216,7 @@ def test_LogDisplay_setup_contrast():
         'minify': True,
         'microbit_runtime': '/foo/bar',
     }
-    ad = mu.interface.dialogs.AdminDialog(None)
+    ad = mu.interface.dialogs.AdminDialog()
     ad.setStyleSheet = mock.MagicMock()
     ad.setup(log, settings, 'contrast')
     ad.setStyleSheet.\

--- a/tests/interface/test_main.py
+++ b/tests/interface/test_main.py
@@ -1129,7 +1129,7 @@ def test_Window_show_admin():
     with mock.patch('mu.interface.main.AdminDialog', mock_admin_display):
         w = mu.interface.main.Window()
         result = w.show_admin('log', 'envars', 'day')
-        mock_admin_display.assert_called_once_with()
+        mock_admin_display.assert_called_once_with(w)
         mock_admin_box.setup.assert_called_once_with('log', 'envars', 'day')
         mock_admin_box.exec.assert_called_once_with()
         assert result == 'this is the expected result'


### PR DESCRIPTION
Mode & Admin were showing some odd behaviours (at least on mutter/GNOME but I suspect others are affected) largely because they were being modal to an unset parent

This is slightly WIP as FileDialogs still aren't working properly but I'm 99% sure that's a problem in `QGtk3FileDialogHelper` (aka upstream)