### PR TITLE
Temporary workaround for #552

### DIFF
--- a/mu/interface/themes.py
+++ b/mu/interface/themes.py
@@ -37,7 +37,7 @@ def should_patch_osx_mojave_font():
     update FONT_NAME to use the default terminal font in OSX on mojave.
 
     This patch should be removed once the underlying issue has been resolved
-    
+
     github issue #552
     """
     return platform.platform().startswith("Darwin-18.")

--- a/mu/interface/themes.py
+++ b/mu/interface/themes.py
@@ -37,7 +37,8 @@ def should_patch_osx_mojave_font():
     update FONT_NAME to use the default terminal font in OSX on mojave.
 
     This patch should be removed once the underlying issue has been resolved
-    ~github issue #552
+    
+    github issue #552
     """
     return platform.platform().startswith("Darwin-18.")
 

--- a/mu/interface/themes.py
+++ b/mu/interface/themes.py
@@ -17,14 +17,40 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 import logging
+import platform
+
 from PyQt5.QtGui import QColor, QFontDatabase
 from mu.resources import load_stylesheet, load_font_data
+
+
+logger = logging.getLogger(__name__)
+
+
+def should_patch_osx_mojave_font():
+    """
+    OSX mojave and qt5/qtscintilla has a bug where non-system installed fonts
+    are always rendered as black, regardless of the theme color.
+
+    This is inconvenient for light themes, but makes dark themes unusable.
+
+    Using a system-installed font doesn't exhibit this behaviour, so
+    update FONT_NAME to use the default terminal font in OSX on mojave.
+
+    This patch should be removed once the underlying issue has been resolved
+    ~github issue #552
+    """
+    return platform.platform().startswith("Darwin-18.")
 
 
 # The default font size.
 DEFAULT_FONT_SIZE = 14
 # All editor windows use the same font
-FONT_NAME = "Source Code Pro"
+if should_patch_osx_mojave_font():
+    logger.warn("Overriding built-in editor font due to Issue #552")
+    FONT_NAME = "Monaco"
+else:
+    FONT_NAME = "Source Code Pro"
+
 FONT_FILENAME_PATTERN = "SourceCodePro-{variant}.otf"
 FONT_VARIANTS = ("Bold", "BoldIt", "It", "Regular", "Semibold", "SemiboldIt")
 # Load the two themes from resources/css/[night|day].css

--- a/tests/interface/test_themes.py
+++ b/tests/interface/test_themes.py
@@ -7,6 +7,16 @@ import mu.interface.themes
 import mu.interface.editor
 
 
+def test_patch_osx_mojave_font_issue_552():
+    with mock.patch("platform.platform", return_value="Windows"):
+        assert not mu.interface.themes.should_patch_osx_mojave_font()
+    with mock.patch(
+        "platform.platform",
+        return_value="Darwin-18.0.0-x86_64-i386-64bit"
+    ):
+        assert mu.interface.themes.should_patch_osx_mojave_font()
+
+
 def test_constants():
     """
     Ensure the expected constant values exist.
@@ -53,19 +63,20 @@ def test_theme_apply_to():
 
 
 def test_Font_loading():
-    mu.interface.themes.Font._DATABASE = None
-    try:
-        with mock.patch("mu.interface.themes.QFontDatabase") as db:
-            mu.interface.themes.Font().load()
-            mu.interface.themes.Font(bold=True).load()
-            mu.interface.themes.Font(italic=True).load()
-            mu.interface.themes.Font(bold=True, italic=True).load()
-    finally:
+    with mock.patch("mu.interface.themes.FONT_NAME", "Source Code Pro"):
         mu.interface.themes.Font._DATABASE = None
-    db.assert_called_once_with()
-    db().font.assert_has_calls([
-        mock.call('Source Code Pro', 'Regular', 14),
-        mock.call('Source Code Pro', 'Semibold', 14),
-        mock.call('Source Code Pro', 'Italic', 14),
-        mock.call('Source Code Pro', 'Semibold Italic', 14),
-    ])
+        try:
+            with mock.patch("mu.interface.themes.QFontDatabase") as db:
+                mu.interface.themes.Font().load()
+                mu.interface.themes.Font(bold=True).load()
+                mu.interface.themes.Font(italic=True).load()
+                mu.interface.themes.Font(bold=True, italic=True).load()
+        finally:
+            mu.interface.themes.Font._DATABASE = None
+        db.assert_called_once_with()
+        db().font.assert_has_calls([
+            mock.call('Source Code Pro', 'Regular', 14),
+            mock.call('Source Code Pro', 'Semibold', 14),
+            mock.call('Source Code Pro', 'Italic', 14),
+            mock.call('Source Code Pro', 'Semibold Italic', 14),
+        ])


### PR DESCRIPTION
Not my best work, but puts in a temporary patch to change the editor font from Source code pro to Monaco when run on OSX Mojave

I'm matching on any "Darwin-18.*" version here (Mojave), which may be over-generous, but it's better (in my opinion) to use a slightly different font for too long on Mojave than have people randomly getting black on black text after an upgrade.

Before:
<img width="1009" alt="screenshot 2018-07-18 at 22 42 22" src="https://user-images.githubusercontent.com/704526/42909380-df87dcfc-8adb-11e8-90f3-44372429bae9.png">

After:
<img width="1187" alt="screenshot 2018-07-18 at 22 39 33" src="https://user-images.githubusercontent.com/704526/42909385-e3d3020a-8adb-11e8-8f19-e12799a4f4fa.png">

Tested on OSX Sierra (note - uses Source code pro still):
<img width="916" alt="screenshot 2018-07-18 at 22 32 02" src="https://user-images.githubusercontent.com/704526/42909431-0ab8a41a-8adc-11e8-9be5-f783ac74c05a.png">

I haven't been able to test on Windows or Linux yet, but I'm reasonably confident this hasn't broken anything there
