### PR TITLE
Add to the log the detected language code

### DIFF
--- a/mu/app.py
+++ b/mu/app.py
@@ -29,7 +29,7 @@ import sys
 from PyQt5.QtCore import QTimer, Qt
 from PyQt5.QtWidgets import QApplication, QSplashScreen
 
-from mu import __version__
+from mu import __version__, language_code
 from mu.logic import Editor, LOG_FILE, LOG_DIR, DEBUGGER_PORT, ENCODING
 from mu.interface import Window
 from mu.resources import load_pixmap, load_icon
@@ -112,6 +112,7 @@ def run():
     logging.info('\n\n-----------------\n\nStarting Mu {}'.format(__version__))
     logging.info(platform.uname())
     logging.info('Python path: {}'.format(sys.path))
+    logging.info('Language code: {}'.format(language_code))
 
     # The app object is the application running on your computer.
     app = QApplication(sys.argv)


### PR DESCRIPTION
Tiny addition to add to the log the detected language code. This should be useful in cases where translation don't seem to be automatically loaded in operating systems configured in a supported language.