### PR TITLE
Edit checks for OSX app bundles to be independent of app name

### DIFF
--- a/mu/interface/panes.py
+++ b/mu/interface/panes.py
@@ -653,7 +653,7 @@ class PythonProcessPane(QTextEdit):
         env.insert('PYTHONIOENCODING', 'utf-8')
         if sys.platform == 'darwin':
             parent_dir = os.path.dirname(__file__)
-            if '/mu-editor.app/Contents/Resources/app/mu' in parent_dir:
+            if '.app/Contents/Resources/app/mu' in parent_dir:
                 # Mu is running as a macOS app bundle. Ensure the expected
                 # paths are in PYTHONPATH of the subprocess.
                 env.insert('PYTHONPATH', ':'.join(sys.path))

--- a/mu/modes/python3.py
+++ b/mu/modes/python3.py
@@ -65,7 +65,7 @@ class KernelRunner(QObject):
             os.environ[k] = v
         if sys.platform == 'darwin':
             parent_dir = os.path.dirname(__file__)
-            if '/mu-editor.app/Contents/Resources/app/mu' in parent_dir:
+            if '.app/Contents/Resources/app/mu' in parent_dir:
                 # Mu is running as a macOS app bundle. Ensure the expected
                 # paths are in PYTHONPATH of the subprocess so the kernel can
                 # be found.


### PR DESCRIPTION
Fixes https://github.com/mu-editor/mu/issues/585.
In case the suggested fix from the comments is accepted, this PR is the simple implementation.
There is no need to edit the tests as they still apply with this reduced string.

I've also successfully tested the built app bundle, which can be found in: https://s3-eu-west-2.amazonaws.com/mu-builds/osx/mu-editor_2018-07-29_14_33_nameless_app_bundle_80e9568.zip