### PR TITLE
File dialog boxes remember previous folder used

### DIFF
--- a/mu/interface/main.py
+++ b/mu/interface/main.py
@@ -190,6 +190,7 @@ class Window(QMainWindow):
     data_received = pyqtSignal(bytes)
     open_file = pyqtSignal(str)
     load_theme = pyqtSignal(str)
+    previous_folder = None
 
     def zoom_in(self):
         """
@@ -230,8 +231,11 @@ class Window(QMainWindow):
         Displays a dialog for selecting a file to load. Returns the selected
         path. Defaults to start in the referenced folder.
         """
-        path, _ = QFileDialog.getOpenFileName(self.widget, 'Open file', folder,
-                                              extensions)
+        path, _ = QFileDialog.getOpenFileName(
+            self.widget, 'Open file',
+            folder if self.previous_folder is None else self.previous_folder,
+            extensions)
+        self.previous_folder = os.path.dirname(path)
         logger.debug('Getting load path: {}'.format(path))
         return path
 
@@ -240,7 +244,10 @@ class Window(QMainWindow):
         Displays a dialog for selecting a file to save. Returns the selected
         path. Defaults to start in the referenced folder.
         """
-        path, _ = QFileDialog.getSaveFileName(self.widget, 'Save file', folder)
+        path, _ = QFileDialog.getSaveFileName(
+            self.widget, 'Save file',
+            folder if self.previous_folder is None else self.previous_folder)
+        self.previous_folder = os.path.dirname(path)
         logger.debug('Getting save path: {}'.format(path))
         return path
 
@@ -250,9 +257,11 @@ class Window(QMainWindow):
         host computer's filesystem. Returns the selected path. Defaults to
         start in the referenced folder.
         """
-        path = QFileDialog.getExistingDirectory(self.widget,
-                                                'Locate BBC micro:bit', folder,
-                                                QFileDialog.ShowDirsOnly)
+        path = QFileDialog.getExistingDirectory(
+            self.widget, 'Locate BBC micro:bit',
+            folder if self.previous_folder is None else self.previous_folder,
+            QFileDialog.ShowDirsOnly)
+        self.previous_folder = os.path.dirname(path)
         logger.debug('Getting micro:bit path: {}'.format(path))
         return path
 


### PR DESCRIPTION
Hello,

I recently started using Mu for little projects and am enjoying it immensely. However, a tiny annoyance I have with it is the file dialog boxes always open on `~/mu_code`. This commit implements a shared memory for the save and open file dialog boxes across the editor whilst defaulting the `~/mu_code` if nothing has been opened/saved before during the lifetime of the editor.

Happy to hear any feedback you might have