### PR TITLE
Error message in the setup.py for when python version is too old.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 import platform
+import sys
 from setuptools import setup
 from mu import __version__
 
@@ -29,6 +30,13 @@ try:
 except Exception:
     # Something unexpected happened, so simply keep all requires
     pass
+
+if not hasattr(sys, 'version_info') or sys.version_info < (3, 5):
+    raise SystemExit(
+        'Mu only works with Python version 3.5 or above. '
+        'For more information see: '
+        'https://codewith.mu/en/howto/install_with_python'
+    )
 
 
 setup(


### PR DESCRIPTION
Gives people a hint if they install from source with python2.

For https://github.com/mu-editor/mu/issues/610#issuecomment-411357236