### PR TITLE
Fixed bug with Jupyter REPL calltips under night and contrast themes

### DIFF
--- a/mu/logic.py
+++ b/mu/logic.py
@@ -666,9 +666,8 @@ class Editor:
         if paths and len(paths) > 0:
             self.load_cli(paths)
         if not self._view.tab_count:
-            py = _('# Write your code here :-)')+'\n'
+            py = _('# Write your code here :-)')
             self._view.add_tab(None, py, self.modes[self.mode].api(), NEWLINE)
-            self._view.current_tab.setSelection(1, 0, 1, 0)
             logger.info('Starting with blank file.')
         self.change_mode(self.mode)
         self._view.set_theme(self.theme)

--- a/mu/logic.py
+++ b/mu/logic.py
@@ -666,8 +666,9 @@ class Editor:
         if paths and len(paths) > 0:
             self.load_cli(paths)
         if not self._view.tab_count:
-            py = _('# Write your code here :-)')
+            py = _('# Write your code here :-)')+'\n'
             self._view.add_tab(None, py, self.modes[self.mode].api(), NEWLINE)
+            self._view.current_tab.setSelection(1, 0, 1, 0)
             logger.info('Starting with blank file.')
         self.change_mode(self.mode)
         self._view.set_theme(self.theme)

--- a/mu/resources/css/contrast.css
+++ b/mu/resources/css/contrast.css
@@ -21,6 +21,10 @@ QListWidget, QTreeView, QTreeView::branch {
     color: white;
 }
 
+CallTipWidget {
+    color:black;
+}
+
 QTextEdit, QPlainTextEdit, QLineEdit {
     background-color: white;
     color: black;

--- a/mu/resources/css/night.css
+++ b/mu/resources/css/night.css
@@ -20,6 +20,10 @@ QListWidget, QTreeView, QTreeView::branch {
     color: white;
 }
 
+CallTipWidget {
+    color:black;
+}
+
 QTextEdit, QPlainTextEdit, QLineEdit {
     background-color: #373737;
     color: white;


### PR DESCRIPTION
The calltips under night and contrast theme become unreadable as they have white text on a white background. This is because the CallTipWidget inherits the white styling from QLabel. I've added a seperate style for CallTipWidget.

![image](https://user-images.githubusercontent.com/34194722/44210964-c098bb00-a15f-11e8-93b2-0061ff48cf0c.png)