### PR TITLE
Address issues raised with appstreamcli validation

### DIFF
--- a/conf/mu.appdata.xml
+++ b/conf/mu.appdata.xml
@@ -4,7 +4,7 @@
 	<metadata_license>CC0-1.0</metadata_license>
 	<project_license>GPL-3.0</project_license>
 	<name>Mu</name>
-	<summary>A simple Python editor for beginner programmers.</summary>
+	<summary>A simple Python editor for beginner programmers</summary>
 	<description>
         <p>Mu is a Python code editor for beginner programmers based on
         extensive feedback given by teachers and learners.</p>
@@ -18,14 +18,12 @@
         REPL (either running on the connected CircuitPython or MicroPython
         device or as a Jupyter based iPython session in Python3 mode).</p>
         <p>Mu is written in Python and works on Windows, OSX, Linux and
-        Raspberry Pi. The project's public facing website is
-        https://codewith.mu/. We celebrate the work done by users of mu at
-        https://madewith.mu/.</p>
+        Raspberry Pi.</p>
 	</description>
 	<url type="homepage">http://codewith.mu/</url>
 	<url type="help">http://codewith.mu/tutorials/</url>
 	<url type="bugtracker">https://github.com/mu-editor/mu/issues</url>
 	<project_group>mu-editor</project_group>
-	<_developer_name>Nicholas H.Tollervey</_developer_name>
+	<x-developer_name>Nicholas H.Tollervey</x-developer_name>
 	<translation type="gettext">mu</translation>
 </component>

--- a/conf/mu.appdata.xml
+++ b/conf/mu.appdata.xml
@@ -24,6 +24,6 @@
 	<url type="help">http://codewith.mu/tutorials/</url>
 	<url type="bugtracker">https://github.com/mu-editor/mu/issues</url>
 	<project_group>mu-editor</project_group>
-	<x-developer_name>Nicholas H.Tollervey</x-developer_name>
+	<developer_name>Nicholas H.Tollervey</developer_name>
 	<translation type="gettext">mu</translation>
 </component>


### PR DESCRIPTION
Validating the appdata with appstreamcli version 0.12.2 results in the following output:

$ appstreamcli validate conf/mu.appdata.xml                                                                                                                                                   
W - mu.appdata.xml:mu.codewith.editor.desktop:29                                                                                                                                              
    Found invalid tag: '_developer_name'. Non-standard tags must be prefixed with 
    "x-".

I - mu.appdata.xml:mu.codewith.editor.desktop:7
    The component summary should not end with a "." [A simple Python editor for 
    beginner programmers.]

E - mu.appdata.xml:mu.codewith.editor.desktop:20
    The description contains an URL. This is not allowed, please use the <url/> tag 
    to share links.

Validation failed: errors: 1, warnings: 1, infos: 1

This update corrects these issues