### PR TITLE
Add nudatus to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ install_requires = ['pycodestyle==2.4.0', 'pyflakes==2.0.0',
                     'pgzero==1.2', 'PyQtChart==5.11.2', 'appdirs>=1.4.3',
                     'gpiozero>=1.4.1', 'guizero>=0.5.2',
                     'pigpio>=1.40.post1', 'Pillow>=5.2.0',
-                    'requests>=2.19.1', 'semver>=2.8.0', ]
+                    'requests>=2.19.1', 'semver>=2.8.0', 'nudatus>=0.0.3', ]
 
 # Exclude packages not available for ARM in PyPI/piwheels (Raspberry Pi)
 try:


### PR DESCRIPTION
Fixes #629.

Test App Bundle: https://s3-eu-west-2.amazonaws.com/mu-builds/osx/mu-editor_2018-08-27_18_56_nudatus_4a40764.zip

In the Python3 REPL:

```
Jupyter QtConsole 4.3.1
Python 3.6.5 (default, Jun 18 2018, 16:31:56) 
Type 'copyright', 'credits' or 'license' for more information
IPython 6.5.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: import nudatus

In [2]: nudatus
Out[2]: <module 'nudatus' from '/private/var/folders/l1/szsxrhfj7v1fglxfv9b35lz80000gn/T/AppTranslocation/2179BBE1-9451-4390-9099-B8A05687AC6F/d/mu-editor.app/Contents/Resources/app_packages/nudatus.py'>

In [3]: nudatus.get_version()
Out[3]: '0.0.3'

```
