### PR TITLE
replaced deprecated logger.warn method with logger.warning

### DIFF
--- a/mu/modes/microbit.py
+++ b/mu/modes/microbit.py
@@ -361,7 +361,7 @@ class MicrobitMode(MicroPythonMode):
                 # device has a really old version of MicroPython or is running
                 # something else. In any case, flash MicroPython onto the
                 # device.
-                logger.warn('Could not detect version of MicroPython.')
+                logger.warning('Could not detect version of MicroPython.')
                 force_flash = True
             # Check use of custom runtime.
             rt_hex_path = self.editor.microbit_runtime.strip()


### PR DESCRIPTION
Replace deprecated logger.warn with logger.warning.

My apologize for the remarkably simple change. This is my first github pull request so I wanted to start with a change that could not break anything while figuring out the workflow.

david