### PR TITLE
Use off-white and dark-grey in day theme

### DIFF
--- a/mu/interface/themes.py
+++ b/mu/interface/themes.py
@@ -73,7 +73,8 @@ class Font:
     """
     _DATABASE = None
 
-    def __init__(self, color='black', paper='white', bold=False, italic=False):
+    def __init__(self, color='#181818', paper='#FEFEF7', bold=False,
+                 italic=False):
         self.color = color
         self.paper = paper
         self.bold = bold
@@ -154,8 +155,8 @@ class DayTheme(Theme):
     Default = Identifier = Font()
     Operator = Font(color='#400040')
     HighlightedIdentifier = Font(color='#0000a0')
-    Paper = QColor('white')
-    Caret = QColor('black')
+    Paper = QColor('#FEFEF7')
+    Caret = QColor('#181818')
     Margin = QColor('#EEE')
     IndicatorError = QColor('red')
     IndicatorStyle = QColor('blue')

--- a/mu/resources/css/day.css
+++ b/mu/resources/css/day.css
@@ -20,8 +20,8 @@ QDockWidget::title, QHeaderView, QHeaderView::section {
 }
 
 QTextEdit, QPlainTextEdit, QLineEdit {
-    background-color: white;
-    color: black;
+    background-color: #FEFEF7;
+    color: #181818;
 }
 
 QTabBar, QToolBar, QToolButton, QTextEdit, QPlainTextEdit, QLineEdit,

--- a/tests/interface/test_themes.py
+++ b/tests/interface/test_themes.py
@@ -31,8 +31,8 @@ def test_Font():
     """
     f = mu.interface.themes.Font()
     # Defaults
-    assert f.color == 'black'
-    assert f.paper == 'white'
+    assert f.color == '#181818'
+    assert f.paper == '#FEFEF7'
     assert f.bold is False
     assert f.italic is False
     # Passed in arguments


### PR DESCRIPTION
I don’t think this fully addresses difficulties many users who find reading difficult due to ‘visual stress’ (pure white with pure black background can be very difficult for some to read) but it should make it slightly easier for most users. See issue #633 