### PR TITLE
Make Toolbar separators visible in all themes

### DIFF
--- a/mu/resources/css/contrast.css
+++ b/mu/resources/css/contrast.css
@@ -13,6 +13,12 @@ QToolButton:hover, QMenu::item:selected  {
     color: yellow;
 }
 
+QToolBar::separator {
+    background: #555;
+    width:1px;
+    margin:2px;
+}
+
 QStackedWidget, QWidget, QApplication, QDialog,
 QLabel, QStatusBar, QTabBar, QMenu,
 QDockWidget::title, QHeaderView, QHeaderView::section,

--- a/mu/resources/css/day.css
+++ b/mu/resources/css/day.css
@@ -12,6 +12,12 @@ QToolButton:hover, QMenu::item:selected {
     background-color: #cccccc;
 }
 
+QToolBar::separator {
+    background: #b4b4b4;
+    width:1px;
+    margin:2px;
+}
+
 QStackedWidget, QWidget, QApplication, QDialog,
 QLabel, QStatusBar, QTabBar, QMenu,
 QDockWidget::title, QHeaderView, QHeaderView::section {

--- a/mu/resources/css/night.css
+++ b/mu/resources/css/night.css
@@ -12,6 +12,12 @@ QToolButton:hover, QMenu::item:selected {
     background-color: #333;
 }
 
+QToolBar::separator {
+    background: #6b6b6b;
+    width:1px;
+    margin:2px;
+}
+
 QStackedWidget, QWidget, QApplication, QDialog,
 QLabel, QStatusBar, QTabBar, QMenu,
 QDockWidget::title, QHeaderView, QHeaderView::section,


### PR DESCRIPTION
Addresses point 4 of issue #633 