### PR TITLE
Temporary fix for issue 622

### DIFF
--- a/mu/interface/panes.py
+++ b/mu/interface/panes.py
@@ -860,9 +860,15 @@ class PythonProcessPane(QTextEdit):
             self.backspace()
         if key == Qt.Key_Delete:
             self.delete()
-        if not self.isReadOnly() and msg:
-            self.insert(msg)
         if key == Qt.Key_Enter or key == Qt.Key_Return:
+            # First move cursor to the end of the line and insert newline in
+            # case return/enter is pressed while the cursor is in the
+            # middle of the line
+            cursor = self.textCursor()
+            cursor.movePosition(QTextCursor.End)
+            self.setTextCursor(cursor)
+            self.insert(msg)
+            # Then write line to std_in and add to history
             content = self.toPlainText()
             line = content[self.start_of_current_line:].encode('utf-8')
             self.write_to_stdin(line)
@@ -870,6 +876,8 @@ class PythonProcessPane(QTextEdit):
                 self.input_history.append(line.replace(b'\n', b''))
             self.history_position = 0
             self.start_of_current_line = self.textCursor().position()
+        elif not self.isReadOnly() and msg:
+            self.insert(msg)
 
     def history_back(self):
         """

--- a/tests/interface/test_panes.py
+++ b/tests/interface/test_panes.py
@@ -1610,6 +1610,7 @@ def test_PythonProcessPane_parse_input_newline():
     ppp.start_of_current_line = 0
     ppp.textCursor = mock.MagicMock()
     ppp.textCursor().position.return_value = 666
+    ppp.setTextCursor = mock.MagicMock()
     ppp.insert = mock.MagicMock()
     ppp.write_to_stdin = mock.MagicMock()
     key = Qt.Key_Enter
@@ -1640,6 +1641,19 @@ def test_PythonProcessPane_parse_input_newline_ignore_empty_input_in_history():
     ppp.write_to_stdin.assert_called_once_with(b'   \n')
     assert len(ppp.input_history) == 0
     assert ppp.history_position == 0
+
+
+def test_PythonProcessPane_parse_input_newline_with_cursor_midline():
+    """
+    Ensure that when the cursor is placed in the middle of a line and enter is
+    pressed the whole line is sent to std_in.
+    """
+    ppp = mu.interface.panes.PythonProcessPane()
+    ppp.write_to_stdin = mock.MagicMock()
+    ppp.parse_input(None, "abc", None)
+    ppp.parse_input(Qt.Key_Left, None, None)
+    ppp.parse_input(Qt.Key_Enter, '\r', None)
+    ppp.write_to_stdin.assert_called_with(b'abc\n')
 
 
 def test_PythonProcessPane_history_back():


### PR DESCRIPTION
To give full multi-line statement support as is in the Jupyter REPL, would need a significant re-write as currently, once we move on to the next line, the previous line becomes un-editable. This however is a temporary fix (which definitely improves the current behaviour), by moving the cursor to the end and then writing the whole line to std_out.

I felt a test should be added for this. I'm not sure if it has been done the best way, but have tried to follow approaches used in the surrounding tests.