### PR TITLE
Fix: Qt console theme / zoom interaction

### DIFF
--- a/mu/interface/panes.py
+++ b/mu/interface/panes.py
@@ -72,9 +72,9 @@ class JupyterREPLPane(RichJupyterWidget):
         """
         Sets the font size for all the textual elements in this pane.
         """
-        stylesheet = ("QWidget{font-size: " + str(new_size) +
-                      "pt; font-family: Monospace;}")
-        self.setStyleSheet(stylesheet)
+        font = self.font
+        font.setPointSize(new_size)
+        self._set_font(font)
 
     def zoomIn(self, delta=2):
         """

--- a/tests/interface/test_panes.py
+++ b/tests/interface/test_panes.py
@@ -862,14 +862,11 @@ def test_JupyterREPLPane_append_plain_text():
 
 def test_JupyterREPLPane_set_font_size():
     """
-    Check the correct stylesheet values are being set.
+    Check the new point size is succesfully applied.
     """
     jw = mu.interface.panes.JupyterREPLPane()
-    jw.setStyleSheet = mock.MagicMock()
     jw.set_font_size(16)
-    style = jw.setStyleSheet.call_args[0][0]
-    assert 'font-size: 16pt;' in style
-    assert 'font-family: Monospace;' in style
+    assert jw.font.pointSize() == 16
 
 
 def test_JupyterREPLPane_zoomIn():


### PR DESCRIPTION
Both the `set_theme` and `set_font_size` methods (in the JupyterREPL) call (either directly or indirectly) `self.setStyleSheet(some_stylesheet)`. The problem is that: 
```
stylesheet = ("QWidget{font-size: " + str(new_size) +
                      "pt; font-family: Monospace;}")
        self.setStyleSheet(stylesheet)
```
doesn’t have any of the information (such as background colour) used in `set_default_style`, and consequently it inherits such information from higher up in the app. To see this:

1. start the REPL
2. Switch to night mode, and the ‘nocolor’ style will be applied to the JupyterREPL.
3. click zoom in/zoom out
4. When the zooming is applied and setStyleSheet is called, the background will turn grey. This leaves difficult to read error messages. (Notice also that on windows at least the font-family changes when you zoom, since it was previously set to Courier).

Likewise, when `set_theme` is called the stylesheet that is applied under the qtconsole bonnet does not contain any styling on font-size. The font-size is effectively reset. To see:

1. Start the REPL
2. Zoom in
3. switch between themes, switching between contrast and day themes will cause the font-size to reset.

I have changed the `set_font_size`  method to use qtconsole’s `_set_font` method instead of `setStyleSheet` to avoid this problem.
