### PR TITLE
Update PyQt5 versions to restore Py3.5 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,18 @@ matrix:
       dist: trusty
       sudo: required
       language: python
+      python: 3.5
+    - os: linux
+      dist: trusty
+      sudo: required
+      language: python
       python: 3.6
+    # Py 3.7 needs xenial https://github.com/travis-ci/travis-ci/issues/9069
+    - os: linux
+      dist: xenial
+      sudo: required
+      language: python
+      python: 3.7
 
     # To maximise compatibility pick earliest image, OS X 10.10 Yosemite
     - os: osx

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 import platform
-import sys
 from setuptools import setup
 from mu import __version__
 
@@ -13,9 +12,9 @@ with open('CHANGES.rst') as f:
     changes = f.read()
 
 install_requires = ['pycodestyle==2.4.0', 'pyflakes==2.0.0',
-                    'pyserial==3.4', 'pyqt5==5.11.2', 'qscintilla==2.10.7',
+                    'pyserial==3.4', 'pyqt5==5.11.3', 'qscintilla==2.10.8',
                     'qtconsole==4.3.1', 'matplotlib==2.2.2',
-                    'pgzero==1.2', 'PyQtChart==5.11.2', 'appdirs>=1.4.3',
+                    'pgzero==1.2', 'PyQtChart==5.11.3', 'appdirs>=1.4.3',
                     'gpiozero>=1.4.1', 'guizero>=0.5.2',
                     'pigpio>=1.40.post1', 'Pillow>=5.2.0',
                     'requests>=2.19.1', 'semver>=2.8.0', 'nudatus>=0.0.3', ]
@@ -30,13 +29,6 @@ try:
 except Exception:
     # Something unexpected happened, so simply keep all requires
     pass
-
-if not hasattr(sys, 'version_info') or sys.version_info < (3, 6):
-    raise SystemExit(
-        'Mu only works with Python version 3.6 or above. '
-        'For more information see: '
-        'https://codewith.mu/en/howto/install_with_python'
-    )
 
 
 setup(


### PR DESCRIPTION
Fixes https://github.com/mu-editor/mu/issues/575.

New PyQt5 wheel are available and fix the current issue with missing symbols.

Replicated the issue in Python 3.5.2 on macOS and Windows and then tested this PR to ensure the new versions fix it.

I've also added Python 3.5 and 3.7 to the travis tests.