### PR TITLE
Fix 674, 683 and problem with 256 byte chunks

### DIFF
--- a/tests/interface/test_panes.py
+++ b/tests/interface/test_panes.py
@@ -1837,7 +1837,7 @@ def test_PythonProcessPane_on_data_flood_long_string():
     ppp.process.bytesAvailable.return_value = True
     ppp.data_flood = mock.MagicMock()
     ppp.on_data_flood()
-    assert ppp.data_flood.call_count == 1
+    assert ppp.data_flood.emit.call_count == 1
 
 
 def test_PythonProcessPane_on_data_flood_data_argument_given():

--- a/tests/interface/test_panes.py
+++ b/tests/interface/test_panes.py
@@ -1769,6 +1769,9 @@ def test_PythonProcessPane_handle_split_data_bad_string():
     with mock.patch('mu.interface.panes.logger') as mock_logger:
         data = ppp.handle_split_data(b'\xe2\xb2\x98\x98')
         assert mock_logger.info.call_count == 1
+        mock_logger.info.assert_called_once_with(
+            'Data from std_out ends with ill-formed utf-8 byte'
+            ' sequence: b\'\\xe2\\xb2\\x98\\x98\'')
         assert data == b''
 
 

--- a/tests/interface/test_panes.py
+++ b/tests/interface/test_panes.py
@@ -1784,7 +1784,7 @@ def test_PythonProcessPane_handle_split_data_split_newline():
     ppp.process = mock.MagicMock()
     ppp.process.getChar.return_value = (0, b'\n')
     data = ppp.handle_split_data(b'abc\r')
-    ppp.process.getChar.assert_called_once()
+    assert ppp.process.getChar.call_count == 1
     assert data == b'abc\r\n'
 
 
@@ -1837,7 +1837,7 @@ def test_PythonProcessPane_on_data_flood_long_string():
     ppp.process.bytesAvailable.return_value = True
     ppp.data_flood = mock.MagicMock()
     ppp.on_data_flood()
-    ppp.data_flood.emit.assert_called_once()
+    assert ppp.data_flood.call_count == 1
 
 
 def test_PythonProcessPane_on_data_flood_data_argument_given():


### PR DESCRIPTION
Addresses #674 and #683, as well as the fact that really long strings are not guaranteed to print to completion. `readyRead` is not emitted recursively, only when the data  is first added to stdout, so if `read_from_stdout` is still working whilst this signal is emitted, or if it is emitted following a block of data of more than 256 bytes being added to stdout, not all of the data is subsequently read. 

To address this, if more than 256 bytes is written, then after reading and appending, a queued data-flood signal is emitted if there are still bytes available to be written, which then reads the next 256 byte chunk. Whilst this process is going on, normal signals from `readyRead` are ignored for performance.

I guess this is quite a lot of changes, and I am aware we want to keep the code for mu simple, and that there might be better ways of doing this? 
Other questions:

- The function `detect_missing_utf8_bytes` doesn’t really have to belong to `PythonProcessPane`, is this an okay place to put it?

- At the moment if the end of a 256 byte string is genuinely ill-formed, as apposed to just cut in half in an inconvenient place, it is logged, and the whole ‘chunk’ is ignored. Is this an unnecessary complication? Especially as it doesn't pick up all ill-formed byte sequences – I know there is an aim to keep the codebase simple.

- The code:

```
            self.append(data)
            self.on_append_text.emit(data)
            cursor = self.textCursor()
            self.start_of_current_line = cursor.position()
```
is now repeated in the function `read_from_stdout`, `on_data_flood`, and `on_process_halt`. Would it be better to put it in a separate function?
