### PR TITLE
Save and encode all the things

### DIFF
--- a/docs/design/file_reading_and_writing.rst
+++ b/docs/design/file_reading_and_writing.rst
@@ -70,3 +70,4 @@ Discussion in:
 
 (Later)
 * https://github.com/mu-editor/mu/issues/402
+* https://github.com/mu-editor/mu/issues/696

--- a/mu/modes/debugger.py
+++ b/mu/modes/debugger.py
@@ -105,11 +105,8 @@ class DebugMode(BaseMode):
         if tab.path:
             # If needed, save the script.
             if tab.isModified():
-                with open(tab.path, 'w', newline='') as f:
-                    logger.info('Saving script to: {}'.format(tab.path))
-                    logger.debug(tab.text())
-                    write_and_flush(f, tab.text())
-                    tab.setModified(False)
+                self.editor.save_tab_to_file(tab)
+                tab.setModified(False)
             logger.debug(tab.text())
             self.set_buttons(modes=False)
             envars = self.editor.envars

--- a/mu/modes/debugger.py
+++ b/mu/modes/debugger.py
@@ -106,7 +106,6 @@ class DebugMode(BaseMode):
             # If needed, save the script.
             if tab.isModified():
                 self.editor.save_tab_to_file(tab)
-                tab.setModified(False)
             logger.debug(tab.text())
             self.set_buttons(modes=False)
             envars = self.editor.envars

--- a/mu/modes/debugger.py
+++ b/mu/modes/debugger.py
@@ -19,7 +19,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import logging
 import os.path
 from mu.modes.base import BaseMode
-from mu.logic import DEBUGGER_PORT, write_and_flush
+from mu.logic import DEBUGGER_PORT
 from mu.debugger.client import Debugger
 from mu.debugger.utils import is_breakpoint_line
 

--- a/mu/modes/pygamezero.py
+++ b/mu/modes/pygamezero.py
@@ -126,11 +126,7 @@ class PyGameZeroMode(BaseMode):
         if tab.path:
             # If needed, save the script.
             if tab.isModified():
-                with open(tab.path, 'w', newline='') as f:
-                    logger.info('Saving script to: {}'.format(tab.path))
-                    logger.debug(tab.text())
-                    write_and_flush(f, tab.text())
-                    tab.setModified(False)
+                self.editor.save_tab_to_file(tab)
             logger.debug(tab.text())
             envars = self.editor.envars
             args = ['-m', 'pgzero']

--- a/mu/modes/pygamezero.py
+++ b/mu/modes/pygamezero.py
@@ -20,7 +20,6 @@ import os
 import logging
 from mu.modes.base import BaseMode
 from mu.modes.api import PYTHON3_APIS, SHARED_APIS, PI_APIS, PYGAMEZERO_APIS
-from mu.logic import write_and_flush
 from mu.resources import load_icon
 
 

--- a/mu/modes/python3.py
+++ b/mu/modes/python3.py
@@ -21,7 +21,6 @@ import os
 import logging
 from mu.modes.base import BaseMode
 from mu.modes.api import PYTHON3_APIS, SHARED_APIS, PI_APIS
-from mu.logic import write_and_flush
 from mu.resources import load_icon
 from mu.interface.panes import CHARTS
 from qtconsole.manager import QtKernelManager
@@ -173,22 +172,26 @@ class PythonMode(BaseMode):
         """
         # Grab the Python file.
         tab = self.view.current_tab
+        print("Tab is", tab)
         if tab is None:
+            print("Tab is None")
             logger.debug('There is no active text editor.')
             self.stop_script()
             return
         if tab.path is None:
+            print("Tab.path is None")
             # Unsaved file.
             self.editor.save()
         if tab.path:
+            print("Tab path is", tab.path)
             # If needed, save the script.
             if tab.isModified():
-                with open(tab.path, 'w', newline='') as f:
-                    logger.info('Saving script to: {}'.format(tab.path))
-                    logger.debug(tab.text())
-                    write_and_flush(f, tab.text())
-                    tab.setModified(False)
-            logger.debug(tab.text())
+                print("Tab is modified")
+                self.editor.save_tab_to_file(tab)
+                # logger.info('Saving script to: {}'.format(tab.path))
+                # logger.debug(tab.text())
+                # save_and_encode(tab.text())
+                # tab.setModified(False)
             envars = self.editor.envars
             self.runner = self.view.add_python3_runner(tab.path,
                                                        self.workspace_dir(),

--- a/mu/modes/python3.py
+++ b/mu/modes/python3.py
@@ -172,26 +172,17 @@ class PythonMode(BaseMode):
         """
         # Grab the Python file.
         tab = self.view.current_tab
-        print("Tab is", tab)
         if tab is None:
-            print("Tab is None")
             logger.debug('There is no active text editor.')
             self.stop_script()
             return
         if tab.path is None:
-            print("Tab.path is None")
             # Unsaved file.
             self.editor.save()
         if tab.path:
-            print("Tab path is", tab.path)
             # If needed, save the script.
             if tab.isModified():
-                print("Tab is modified")
                 self.editor.save_tab_to_file(tab)
-                # logger.info('Saving script to: {}'.format(tab.path))
-                # logger.debug(tab.text())
-                # save_and_encode(tab.text())
-                # tab.setModified(False)
             envars = self.editor.envars
             self.runner = self.view.add_python3_runner(tab.path,
                                                        self.workspace_dir(),

--- a/tests/modes/__init__.py
+++ b/tests/modes/__init__.py
@@ -1,2 +1,0 @@
-BYTES_TEST_STRING = bytes(range(0x20, 0x80)) + bytes(range(0xa0, 0xff))
-UNICODE_TEST_STRING = BYTES_TEST_STRING.decode("iso-8859-1")

--- a/tests/modes/__init__.py
+++ b/tests/modes/__init__.py
@@ -1,0 +1,2 @@
+BYTES_TEST_STRING = bytes(range(0x20, 0x80)) + bytes(range(0xa0, 0xff))
+UNICODE_TEST_STRING = BYTES_TEST_STRING.decode("iso-8859-1")

--- a/tests/modes/test_debug.py
+++ b/tests/modes/test_debug.py
@@ -53,11 +53,9 @@ def test_debug_start():
     mock_debugger_class = mock.MagicMock(return_value=mock_debugger)
     dm = DebugMode(editor, view)
     dm.workspace_dir = mock.MagicMock(return_value='/bar')
-    with mock.patch('builtins.open') as oa, \
-            mock.patch('mu.modes.debugger.Debugger', mock_debugger_class), \
-            mock.patch('mu.modes.debugger.write_and_flush'):
+    with mock.patch('mu.modes.debugger.Debugger', mock_debugger_class):
         dm.start()
-        oa.assert_called_once_with('/foo', 'w', newline='')
+    editor.save_tab_to_file.called_once_with(view.current_tab)
     view.add_python3_runner.assert_called_once_with('/foo', '/bar',
                                                     debugger=True,
                                                     envars=[['name', 'value']])

--- a/tests/modes/test_pygamezero.py
+++ b/tests/modes/test_pygamezero.py
@@ -121,10 +121,8 @@ def test_pgzero_run_game():
     view.add_python3_runner.return_value = mock_runner
     pm = PyGameZeroMode(editor, view)
     pm.workspace_dir = mock.MagicMock(return_value='/bar')
-    with mock.patch('builtins.open') as oa, \
-            mock.patch('mu.modes.pygamezero.write_and_flush'):
-        pm.run_game()
-        oa.assert_called_once_with('/foo', 'w', newline='')
+    pm.run_game()
+    editor.save_tab_to_file.called_once_with(view.current_tab)
     py_args = ['-m', 'pgzero']
     view.add_python3_runner.assert_called_once_with('/foo', '/bar',
                                                     interactive=False,

--- a/tests/modes/test_python3.py
+++ b/tests/modes/test_python3.py
@@ -6,9 +6,7 @@ import sys
 from mu.modes.python3 import PythonMode, KernelRunner
 from mu.modes.api import PYTHON3_APIS, SHARED_APIS, PI_APIS
 from unittest import mock
-import tempfile
 
-from . import UNICODE_TEST_STRING
 
 def test_kernel_runner_start_kernel():
     """
@@ -239,8 +237,6 @@ def test_python_run_script_uses_editor_save():
     """The run code uses the common editor save code, invoking
     encoding checks and useful messages
     """
-    filepath = "foo"
-    
     editor = mock.MagicMock()
     view = mock.MagicMock()
     view.current_tab.IsModified.return_value = True


### PR DESCRIPTION
This change ensures that all the modes hand off to the existing editor.save_to_to_file logic which handles encoding, line-ending, and error popups consistently.

This should address #696, #705, #656 and any other issue where Mu crashes when the user hits the [Run] button and the file contents contain unicode characters which can't be encoded in the filesystem's default encoding (for Western Windows, typically cp1252).

NB I can't actually reproduce those issues in released Mu from 1.0.1 onwards. It's possible that we've inadvertently fixed the problem elsewhere. But this change still makes sense for consistency, and in case it's my own environment which is somehow hiding the issue.