### PR TITLE
Restore keyboard focus to current tab

### DIFF
--- a/mu/modes/base.py
+++ b/mu/modes/base.py
@@ -134,6 +134,14 @@ class BaseMode(QObject):
             if k in self.view.button_bar.slots:
                 self.view.button_bar.slots[k].setEnabled(bool(v))
 
+    def return_focus_to_current_tab(self):
+        """
+        After, eg, stopping the plotter or closing the REPL return the focus
+        to the currently-active tab is there is one.
+        """
+        if self.view.current_tab:
+            self.view.current_tab.setFocus()
+
     def add_plotter(self):
         """
         Mode specific implementation of adding and connecting a plotter to
@@ -162,6 +170,7 @@ class BaseMode(QObject):
         self.view.remove_plotter()
         self.plotter = None
         logger.info('Removing plotter')
+        self.return_focus_to_current_tab()
 
     def on_data_flood(self):
         """

--- a/mu/modes/python3.py
+++ b/mu/modes/python3.py
@@ -211,6 +211,7 @@ class PythonMode(BaseMode):
             self.runner = None
         self.view.remove_python_runner()
         self.set_buttons(plotter=True, repl=True)
+        self.return_focus_to_current_tab()
 
     def debug(self, event):
         """
@@ -260,6 +261,7 @@ class PythonMode(BaseMode):
         self.set_buttons(repl=False)
         # Don't block the GUI
         self.stop_kernel.emit()
+        self.return_focus_to_current_tab()
 
     def toggle_plotter(self):
         """

--- a/tests/modes/test_python3.py
+++ b/tests/modes/test_python3.py
@@ -252,7 +252,20 @@ def test_python_stop_script():
     mock_runner.process.kill.assert_called_once_with()
     mock_runner.process.waitForFinished.assert_called_once_with()
     assert pm.runner is None
-    view.remove_python_runner.assert_called_once_with()
+
+
+def test_python_stop_resets_focus():
+    """
+    Check that, when a child process is killed, the current
+    tab regains focus.
+    """
+    editor = mock.MagicMock()
+    view = mock.MagicMock()
+    pm = PythonMode(editor, view)
+    mock_runner = mock.MagicMock()
+    pm.runner = mock_runner
+    pm.stop_script()
+    view.current_tab.setFocus.assert_called_once_with()
 
 
 def test_python_stop_script_no_runner():
@@ -347,6 +360,21 @@ def test_python_remove_repl():
     pm.set_buttons.assert_called_once_with(repl=False)
 
 
+def test_python_remove_repl_reset_focus():
+    """
+    Make sure the REPL is removed properly.
+    """
+    editor = mock.MagicMock()
+    view = mock.MagicMock()
+    pm = PythonMode(editor, view)
+    pm.set_buttons = mock.MagicMock()
+    pm.stop_kernel = mock.MagicMock()
+    pm.remove_repl()
+    pm.stop_kernel.emit.assert_called_once_with()
+    pm.set_buttons.assert_called_once_with(repl=False)
+    view.current_tab.setFocus.assert_called_once_with()
+
+
 def test_python_toggle_plotter():
     """
     Ensure toggling the plotter causes it to be added/removed.
@@ -408,6 +436,18 @@ def test_python_remove_plotter():
         pm.remove_plotter()
         pm.set_buttons.assert_called_once_with(run=True, repl=True, debug=True)
         mock_super().remove_plotter.assert_called_once_with()
+
+
+def test_python_remove_plotter_reset_focus():
+    """
+    Ensure the button states are returned to normal before calling super
+    method.
+    """
+    editor = mock.MagicMock()
+    view = mock.MagicMock()
+    pm = PythonMode(editor, view)
+    pm.remove_plotter()
+    view.current_tab.setFocus.assert_called_once_with()
 
 
 def test_python_on_data_flood():


### PR DESCRIPTION
cf Issue #715 

Check that, when one of the auxiliary windows is closed (running output, plotter, REPL) the keyboard focus is handed back to the current tabe.