### PR TITLE
Update snapcraft.yaml

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,7 +1,8 @@
 name: mu-editor
+license: GNU General Public License v3.0
 version: 1.0.1
 summary: A simple Python code editor
-description: |
+description: | 
     Mu is a simple code editor for beginner programmers based on extensive
     feedback from teachers and learners. Having said that, Mu is for anyone who
     wants to use a simple "no frills" editor.


### PR DESCRIPTION
Just update the license so when someone types `snap info mu-editor` get' s:

 ```
name:      mu-editor
summary:   A simple Python code editor
publisher: Ben Nuttall (bennuttall)
license:  GNU General Public License v3.0  ; not unset 
description: |
  Mu is a simple code editor for beginner programmers based on extensive
  feedback from teachers and learners. Having said that, Mu is for anyone who
  wants to use a simple "no frills" editor.
commands:
  - mu-editor
snap-id:      frGDfj3qOH3kiCeCe7L0ImjFLxK6uBtw
tracking:     edge
refresh-date: today at 18:20 GMT
channels:                          
  stable:    –                 
  candidate: –                 
  beta:      –                 
  edge:      1.0.1 (4) 114MB - <
installed:   1.0.1 (4) 114MB - 

```