### PR TITLE
Fix reading of stdout from Python subprocess.

### DIFF
--- a/mu/interface/panes.py
+++ b/mu/interface/panes.py
@@ -921,6 +921,7 @@ class PythonProcessPane(QTextEdit):
             self.on_append_text.emit(data)
             cursor = self.textCursor()
             self.start_of_current_line = cursor.position()
+            QTimer.singleShot(2, self.read_from_stdout)
 
     def write_to_stdin(self, data):
         """

--- a/mu/interface/panes.py
+++ b/mu/interface/panes.py
@@ -921,7 +921,7 @@ class PythonProcessPane(QTextEdit):
             self.on_append_text.emit(data)
             cursor = self.textCursor()
             self.start_of_current_line = cursor.position()
-            QTimer.singleShot(2, self.read_from_stdout)
+            QTimer.singleShot(1, self.read_from_stdout)
 
     def write_to_stdin(self, data):
         """

--- a/tests/interface/test_panes.py
+++ b/tests/interface/test_panes.py
@@ -1727,11 +1727,14 @@ def test_PythonProcessPane_read_from_stdout():
     ppp.process = mock.MagicMock()
     ppp.process.read.return_value = b'hello world'
     ppp.on_append_text = mock.MagicMock()
-    ppp.read_from_stdout()
+    mock_timer = mock.MagicMock()
+    with mock.patch('mu.interface.panes.QTimer', mock_timer):
+        ppp.read_from_stdout()
     assert ppp.append.call_count == 1
     ppp.process.read.assert_called_once_with(256)
     assert ppp.start_of_current_line == 123
     ppp.on_append_text.emit.assert_called_once_with(b'hello world')
+    mock_timer.singleShot.assert_called_once_with(2, ppp.read_from_stdout)
 
 
 def test_PythonProcessPane_write_to_stdin():

--- a/tests/interface/test_panes.py
+++ b/tests/interface/test_panes.py
@@ -1734,7 +1734,7 @@ def test_PythonProcessPane_read_from_stdout():
     ppp.process.read.assert_called_once_with(256)
     assert ppp.start_of_current_line == 123
     ppp.on_append_text.emit.assert_called_once_with(b'hello world')
-    mock_timer.singleShot.assert_called_once_with(2, ppp.read_from_stdout)
+    mock_timer.singleShot.assert_called_once_with(1, ppp.read_from_stdout)
 
 
 def test_PythonProcessPane_write_to_stdin():

--- a/tests/interface/test_panes.py
+++ b/tests/interface/test_panes.py
@@ -1671,6 +1671,17 @@ def test_PythonProcessPane_parse_input_newline_with_cursor_midline():
     ppp.write_to_stdin.assert_called_with(b'abc\n')
 
 
+def test_PythonProcessPane_set_start_of_current_line():
+    """
+    Ensure the start of the current line is set to the current length of the
+    text in the editor pane.
+    """
+    ppp = mu.interface.panes.PythonProcessPane()
+    ppp.toPlainText = mock.MagicMock(return_value="Hello𠜎")
+    ppp.set_start_of_current_line()
+    assert ppp.start_of_current_line == len("Hello𠜎")
+
+
 def test_PythonProcessPane_history_back():
     """
     Ensure the current input line is replaced by the next item back in time


### PR DESCRIPTION
This single line change fixes #685, #683, #708, #707, #706, #674 (I've tested all the error conditions, and they now work with this change). I've also updated the tests to ensure the single line change is checked.

How does it work?

As @tim-mccurrach correctly pointed out, the `readyRead` signal is only emitted when *new* data is added to the buffer. Since the `read_from_stdout` method connected to this signal only reads 256 bytes, there may be more data left on the buffer and this will never get displayed since the process may have exited and there's no new data to trigger `readyRead`.

This single line creates a new QTimer which schedules a single shot event in the immediate future (i.e. next time round the event loop) to read again from stdout. If there's no data left in the buffer, the timer won't be rescheduled. If there is, it'll keep scheduling itself to read the next 256 bytes.

Nice and simple..! :-)

I'm going to merge this *right now* since it fixes a large number of bugs and I'd like to get it out for 1.0.2.