### PR TITLE
Ensure correct sys.path contents in Windows, for sub-processes launched by Mu

### DIFF
--- a/mu/interface/main.py
+++ b/mu/interface/main.py
@@ -194,6 +194,12 @@ class Window(QMainWindow):
     load_theme = pyqtSignal(str)
     previous_folder = None
 
+    def set_zoom(self):
+        """
+        Sets the zoom to current zoom_position level.
+        """
+        self._zoom_in.emit(self.zooms[self.zoom_position])
+
     def zoom_in(self):
         """
         Handles zooming in.

--- a/mu/interface/panes.py
+++ b/mu/interface/panes.py
@@ -676,6 +676,8 @@ class PythonProcessPane(QTextEdit):
             # working_directory, the directory containing the script to run.
             try:
                 if site.ENABLE_USER_SITE:
+                    # Ensure the USER_SITE directory exists.
+                    os.makedirs(site.getusersitepackages(), exist_ok=True)
                     site_path = site.USER_SITE
                     path_file = os.path.join(site_path, 'mu.pth')
                     logger.info('Python paths set via {}'.format(path_file))

--- a/mu/interface/panes.py
+++ b/mu/interface/panes.py
@@ -17,6 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 import sys
+import site
 import os
 import re
 import platform
@@ -665,6 +666,44 @@ class PythonProcessPane(QTextEdit):
                 # Mu is running as a macOS app bundle. Ensure the expected
                 # paths are in PYTHONPATH of the subprocess.
                 env.insert('PYTHONPATH', ':'.join(sys.path))
+        if sys.platform == 'win32' and 'pythonw.exe' in sys.executable:
+            # On Windows, if installed via NSIS then Python is always run in
+            # isolated mode via pythonw.exe so none of the expected directories
+            # are on sys.path. To mitigate, Mu attempts to drop a mu.pth file
+            # in a location taken from Windows based settings. This file will
+            # contain the "other" directories to include on the Python path,
+            # such as the working_directory and, if different from the
+            # working_directory, the directory containing the script to run.
+            try:
+                if site.ENABLE_USER_SITE:
+                    site_path = site.USER_SITE
+                    path_file = os.path.join(site_path, 'mu.pth')
+                    logger.info('Python paths set via {}'.format(path_file))
+                    # Copy current Python paths. Use a set to avoid
+                    # duplications.
+                    paths_to_use = set([os.path.normcase(p) for p in sys.path])
+                    # Add Mu's working directory.
+                    paths_to_use.add(os.path.normcase(working_directory))
+                    # Add the directory containing the script.
+                    paths_to_use.add(os.path.normcase(
+                        os.path.dirname(self.script)))
+                    # Dropping a mu.pth file containing the paths_to_use
+                    # into USER_SITE will add such paths to sys.path in the
+                    # child process.
+                    with open(path_file, 'w') as mu_pth:
+                        for p in paths_to_use:
+                            mu_pth.write(p + '\n')
+                else:
+                    logger.info("Unable to set Python paths."
+                                " Python's USER_SITE not enabled."
+                                " Check configuration with administrator.")
+            except Exception as ex:
+                # Log all possible errors and allow Mu to continue. This is a
+                # "best effort" attempt to add the correct paths to the child
+                # process, but sometimes configuration by sys-admins may cause
+                # this to fail.
+                logger.error('Could not set Python paths with mu.pth file.')
+                logger.error(ex)
         if envars:
             logger.info('Running with environment variables: '
                         '{}'.format(envars))

--- a/mu/logic.py
+++ b/mu/logic.py
@@ -31,6 +31,7 @@ import random
 import locale
 import shutil
 import appdirs
+import site
 from PyQt5.QtWidgets import QMessageBox
 from pyflakes.api import check
 from pycodestyle import StyleGuide, Checker
@@ -665,6 +666,7 @@ class Editor:
                                            'runtime instead.')
                 if 'zoom_level' in old_session:
                     self._view.zoom_position = old_session['zoom_level']
+                    self._view.set_zoom()
         # handle os passed file last,
         # so it will not be focused over by another tab
         if paths and len(paths) > 0:
@@ -1028,6 +1030,18 @@ class Editor:
             logger.debug('Session: {}'.format(session))
             logger.debug('Saving session to: {}'.format(session_path))
             json.dump(session, out, indent=2)
+        # Clean up temporary mu.pth file if needed (Windows only).
+        if sys.platform == 'win32' and 'pythonw.exe' in sys.executable:
+            if site.ENABLE_USER_SITE:
+                site_path = site.USER_SITE
+                path_file = os.path.join(site_path, 'mu.pth')
+                if os.path.exists(path_file):
+                    try:
+                        os.remove(path_file)
+                        logger.info('{} removed.'.format(path_file))
+                    except Exception as ex:
+                        logger.error('Unable to delete {}'.format(path_file))
+                        logger.error(ex)
         logger.info('Quitting.\n\n')
         sys.exit(0)
 

--- a/mu/mu-debug.py
+++ b/mu/mu-debug.py
@@ -1,5 +1,19 @@
 #!/usr/bin/env python3
+import os
+import sys
 from mu.app import debug
+
+
+if sys.platform == 'win32' and 'pythonw.exe' in sys.executable:
+    # Add the python**.zip path to sys.path if running from the version of Mu
+    # installed via the official Windows installer.
+    # See: #612 and #581 for context.
+    py_dir = os.path.dirname(sys.executable)
+    version = '{}{}'.format(*sys.version_info[:2])
+    zip_file = 'python{}.zip'.format(version)
+    path_to_add = os.path.normcase(os.path.join(py_dir, zip_file))
+    if os.path.exists(path_to_add):
+        sys.path.append(path_to_add)
 
 
 if __name__ == "__main__":

--- a/tests/interface/test_main.py
+++ b/tests/interface/test_main.py
@@ -308,6 +308,16 @@ def test_Window_change_mode():
     tab2.set_api.assert_called_once_with(api)
 
 
+def test_Window_set_zoom():
+    """
+    Ensure the correct signal is emitted.
+    """
+    w = mu.interface.main.Window()
+    w._zoom_in = mock.MagicMock()
+    w.set_zoom()
+    w._zoom_in.emit.assert_called_once_with('m')
+
+
 def test_Window_zoom_in():
     """
     Ensure the correct signal is emitted.

--- a/tests/interface/test_panes.py
+++ b/tests/interface/test_panes.py
@@ -1051,19 +1051,24 @@ def test_PythonProcessPane_start_process_windows_path():
     mock_sys.platform = 'win32'
     mock_sys.executable = 'C:\\Program Files\\Mu\\Python\\pythonw.exe'
     mock_os_p_e = mock.MagicMock(return_value=True)
+    mock_os_makedirs = mock.MagicMock()
     mock_site = mock.MagicMock()
     mock_site.ENABLE_USER_SITE = True
     mock_site.USER_SITE = ('C:\\Users\\foo\\AppData\\Roaming\\Python\\'
                            'Python36\\site-packages')
+    mock_site.getusersitepackages.return_value = mock_site.USER_SITE
     mock_open = mock.mock_open()
     with mock.patch('mu.interface.panes.QProcess', mock_process_class),\
             mock.patch('mu.interface.panes.sys', mock_sys),\
             mock.patch('mu.interface.panes.os.path.exists', mock_os_p_e),\
+            mock.patch('mu.interface.panes.os.makedirs', mock_os_makedirs),\
             mock.patch('mu.interface.panes.site', mock_site),\
             mock.patch('builtins.open', mock_open):
         ppp = mu.interface.panes.PythonProcessPane()
         ppp.start_process('script.py', 'workspace', interactive=False)
     expected_pth = os.path.join(mock_site.USER_SITE, 'mu.pth')
+    mock_os_makedirs.assert_called_once_with(mock_site.USER_SITE,
+                                             exist_ok=True)
     mock_open.assert_called_once_with(expected_pth, 'w')
     expected = [
         'workspace',

--- a/tests/interface/test_panes.py
+++ b/tests/interface/test_panes.py
@@ -1038,6 +1038,105 @@ def test_PythonProcessPane_start_process_not_interactive():
     ppp.process.start.assert_called_once_with(runner, expected_args)
 
 
+def test_PythonProcessPane_start_process_windows_path():
+    """
+    If running on Windows via the installer ensure that the expected paths
+    find their way into a temporary mu.pth file.
+    """
+    mock_process = mock.MagicMock()
+    mock_process_class = mock.MagicMock(return_value=mock_process)
+    mock_merge_chans = mock.MagicMock()
+    mock_process_class.MergedChannels = mock_merge_chans
+    mock_sys = mock.MagicMock()
+    mock_sys.platform = 'win32'
+    mock_sys.executable = 'C:\\Program Files\\Mu\\Python\\pythonw.exe'
+    mock_os_p_e = mock.MagicMock(return_value=True)
+    mock_site = mock.MagicMock()
+    mock_site.ENABLE_USER_SITE = True
+    mock_site.USER_SITE = ('C:\\Users\\foo\\AppData\\Roaming\\Python\\'
+                           'Python36\\site-packages')
+    mock_open = mock.mock_open()
+    with mock.patch('mu.interface.panes.QProcess', mock_process_class),\
+            mock.patch('mu.interface.panes.sys', mock_sys),\
+            mock.patch('mu.interface.panes.os.path.exists', mock_os_p_e),\
+            mock.patch('mu.interface.panes.site', mock_site),\
+            mock.patch('builtins.open', mock_open):
+        ppp = mu.interface.panes.PythonProcessPane()
+        ppp.start_process('script.py', 'workspace', interactive=False)
+    expected_pth = os.path.join(mock_site.USER_SITE, 'mu.pth')
+    mock_open.assert_called_once_with(expected_pth, 'w')
+    expected = [
+        'workspace',
+        os.path.normcase(os.path.dirname(os.path.abspath('script.py'))),
+    ]
+    mock_file = mock_open()
+    added_paths = [call[0][0] for call in mock_file.write.call_args_list]
+    for e in expected:
+        assert e + '\n' in added_paths
+
+
+def test_PythonProcessPane_start_process_windows_path_no_user_site():
+    """
+    If running on Windows via the installer ensure that the Mu logs the
+    fact it's unable to use the temporary mu.pth file because there is no
+    USER_SITE enabled.
+    """
+    mock_process = mock.MagicMock()
+    mock_process_class = mock.MagicMock(return_value=mock_process)
+    mock_merge_chans = mock.MagicMock()
+    mock_process_class.MergedChannels = mock_merge_chans
+    mock_sys = mock.MagicMock()
+    mock_sys.platform = 'win32'
+    mock_sys.executable = 'C:\\Program Files\\Mu\\Python\\pythonw.exe'
+    mock_os_p_e = mock.MagicMock(return_value=True)
+    mock_site = mock.MagicMock()
+    mock_site.ENABLE_USER_SITE = False
+    mock_log = mock.MagicMock()
+    with mock.patch('mu.interface.panes.QProcess', mock_process_class),\
+            mock.patch('mu.interface.panes.sys', mock_sys),\
+            mock.patch('mu.interface.panes.os.path.exists', mock_os_p_e),\
+            mock.patch('mu.interface.panes.site', mock_site),\
+            mock.patch('mu.interface.panes.logger', mock_log):
+        ppp = mu.interface.panes.PythonProcessPane()
+        ppp.start_process('script.py', 'workspace', interactive=False)
+    logs = [call[0][0] for call in mock_log.info.call_args_list]
+    expected = ("Unable to set Python paths. Python's USER_SITE not enabled."
+                " Check configuration with administrator.")
+    assert expected in logs
+
+
+def test_PythonProcessPane_start_process_windows_path_with_exception():
+    """
+    If running on Windows via the installer ensure that the expected paths
+    find their way into a temporary mu.pth file.
+    """
+    mock_process = mock.MagicMock()
+    mock_process_class = mock.MagicMock(return_value=mock_process)
+    mock_merge_chans = mock.MagicMock()
+    mock_process_class.MergedChannels = mock_merge_chans
+    mock_sys = mock.MagicMock()
+    mock_sys.platform = 'win32'
+    mock_sys.executable = 'C:\\Program Files\\Mu\\Python\\pythonw.exe'
+    mock_os_p_e = mock.MagicMock(return_value=True)
+    mock_site = mock.MagicMock()
+    mock_site.ENABLE_USER_SITE = True
+    mock_site.USER_SITE = ('C:\\Users\\foo\\AppData\\Roaming\\Python\\'
+                           'Python36\\site-packages')
+    mock_open = mock.MagicMock(side_effect=Exception("Boom"))
+    mock_log = mock.MagicMock()
+    with mock.patch('mu.interface.panes.QProcess', mock_process_class),\
+            mock.patch('mu.interface.panes.sys', mock_sys),\
+            mock.patch('mu.interface.panes.os.path.exists', mock_os_p_e),\
+            mock.patch('mu.interface.panes.site', mock_site),\
+            mock.patch('builtins.open', mock_open),\
+            mock.patch('mu.interface.panes.logger', mock_log):
+        ppp = mu.interface.panes.PythonProcessPane()
+        ppp.start_process('script.py', 'workspace', interactive=False)
+    logs = [call[0][0] for call in mock_log.error.call_args_list]
+    expected = ("Could not set Python paths with mu.pth file.")
+    assert expected in logs
+
+
 def test_PythonProcessPane_start_process_user_enviroment_variables():
     """
     Ensure that if environment variables are set, they are set in the context


### PR DESCRIPTION
This PR introduces three changes.

* A fix for #697, #662 so the expected / correct paths are included when Python 3 mode launches / debugs a user's script. This works by attempting to drop a `mu.pth` file in the directory Python/Windows reports as the `USER_SITE` (a directory that's usually writeable by the user, but which Python checks for configuration files when it starts up). If this step fails, Mu logs the error and continues as it used to behave (but the user will thus encounter the import errors reported in the referenced issues). The problem was caused by the version of Python used by the Windows installer for Mu running in "isolated" mode (i.e. protected from other versions of Python that may be installed on the system).
* A fix for #612 and #581 so the path to `pythonXX.zip` (where XX is Major/Minor numbers of the Python version) is included in the `sys.path`. This is simply an injection of the location of `python36.zip` into `sys.path` before the debugger kicks off the script-to-be-debugged.
* A minor fix to ensure the zoom-level from the last session is restored on application start. This is a trivial update.

While a relatively small PR, the path related issues took a while to figure out since there were various (and ultimately unusable) potential approaches which needed to be checked before I could be sure I had a "good" solution. I believe the approach taken here meets both the "it's simple" and the "it works" heuristics. However, I'm painfully aware that I'm no Windows expert nor do I have a Windows machine available to me which would allow me to check some of the more "weird" configurations Mu is likely to encounter (especially in school based environments). 

As a result, I'd love some feedback from Windows-related folks before merging. :-)

cc/@tjguk and @tim-mccurrach