### PR TITLE
Add Particle Argon to CircuitPython

### DIFF
--- a/mu/modes/adafruit.py
+++ b/mu/modes/adafruit.py
@@ -54,6 +54,7 @@ class AdafruitMode(MicroPythonMode):
         (0x239A, 0xD1ED),  # Adafruit HalloWing M0
         (0x239A, 0x8030),  # Adafruit NeoTrellis M4
         (0x239A, 0x8032),  # Grand Central
+        (0x2b04, 0xC00C),  # Particle Argon
         (0x239A, 0x8034),  # future board
         (0x239A, 0x8036),  # future board
         (0x239A, 0x8038),  # future board

--- a/mu/modes/adafruit.py
+++ b/mu/modes/adafruit.py
@@ -54,7 +54,9 @@ class AdafruitMode(MicroPythonMode):
         (0x239A, 0xD1ED),  # Adafruit HalloWing M0
         (0x239A, 0x8030),  # Adafruit NeoTrellis M4
         (0x239A, 0x8032),  # Grand Central
-        (0x2b04, 0xC00C),  # Particle Argon
+        (0x2B04, 0xC00C),  # Particle Argon
+        (0x2B04, 0xC00D),  # Particle Boron
+        (0x2B04, 0xC00E),  # Particle Xenon
         (0x239A, 0x8034),  # future board
         (0x239A, 0x8036),  # future board
         (0x239A, 0x8038),  # future board


### PR DESCRIPTION
Adding Particle Argon to Mu's Adafruit Mode, since it's supported by CircuitPython 4 Alpha 5 (and onwards).

Addressing https://github.com/mu-editor/mu/issues/729