### PR TITLE
Fix selection match highlights with non-ASCII editor contents.

### DIFF
--- a/mu/interface/editor.py
+++ b/mu/interface/editor.py
@@ -29,7 +29,7 @@ from mu.logic import NEWLINE
 
 
 # Regular Expression for valid individual code 'words'
-RE_VALID_WORD = re.compile('^[A-Za-z0-9_-]*$')
+RE_VALID_WORD = re.compile(r'^\w+$')
 
 
 logger = logging.getLogger(__name__)

--- a/mu/interface/editor.py
+++ b/mu/interface/editor.py
@@ -362,8 +362,7 @@ class EditorPane(QsciScintilla):
         return the corresponding Scintilla line-offset pairs which are
         used for searches, indicators etc.
 
-        FIXME: Not clear whether the Scintilla conversions are expecting
-        bytes or characters (ie codepoints)
+        NOTE: Arguments must be byte offsets into the underlying text bytes.
         """
         start_line, start_offset = self.lineIndexFromPosition(start_position)
         end_line, end_offset = self.lineIndexFromPosition(end_position)
@@ -429,8 +428,10 @@ class EditorPane(QsciScintilla):
         # to the current theme.
         #
         indicators = self.search_indicators['selection']
-        text = self.text()
-        for match in re.finditer(selected_text, text):
+        encoding = 'utf8' if self.isUtf8() else 'latin1'
+        text_bytes = self.text().encode(encoding)
+        selected_text_bytes = selected_text.encode(encoding)
+        for match in re.finditer(selected_text_bytes, text_bytes):
             range = self.range_from_positions(*match.span())
             #
             # Don't highlight the text we've selected

--- a/tests/interface/test_editor.py
+++ b/tests/interface/test_editor.py
@@ -452,6 +452,42 @@ def test_EditorPane_highlight_selected_matches_with_match():
     assert ep.search_indicators['selection']['positions'] == expected_ranges
 
 
+def test_EditorPane_highlight_selected_matches_with_match_in_nonASCII_text():
+    """
+    Ensure that if the current selection is a single word then it causes the
+    expected search/highlight call when the text is not ASCII only.
+
+    There appears to be no way to iterate over indicators within the editor.
+    So we're using the search_indicators structure as a proxy
+    """
+    text = "résumé foo bar foo baz foo"
+    search_for = "foo"
+
+    ep = mu.interface.editor.EditorPane(None, 'baz')
+    ep.setText(text)
+
+    #
+    # Determine what ranges would be found and highlighted and arbitrarily
+    # use the last one for the selection
+    #
+    expected_ranges = []
+    selected_range = None
+    for range in _ranges_in_text(text, search_for):
+        if selected_range is None:
+            selected_range = range
+        else:
+            (line_start, col_start, line_end, col_end) = range
+            expected_ranges.append(
+                dict(
+                    line_start=line_start, col_start=col_start,
+                    line_end=line_end, col_end=col_end
+                )
+            )
+
+    ep.setSelection(*selected_range)
+    assert ep.search_indicators['selection']['positions'] == expected_ranges
+
+
 def test_EditorPane_highlight_selected_matches_incomplete_word():
     """
     Ensure that if the current selection is not a complete word

--- a/tests/interface/test_editor.py
+++ b/tests/interface/test_editor.py
@@ -488,6 +488,42 @@ def test_EditorPane_highlight_selected_matches_with_match_in_nonASCII_text():
     assert ep.search_indicators['selection']['positions'] == expected_ranges
 
 
+def test_EditorPane_highlight_selected_matches_with_nonASCII_match():
+    """
+    Ensure that if the current selection is a single non-ASCII word then it
+    causes the expected search/highlight call when the text is not ASCII only.
+
+    There appears to be no way to iterate over indicators within the editor.
+    So we're using the search_indicators structure as a proxy
+    """
+    text = "résumé bar résumé baz résumé"
+    search_for = "résumé"
+
+    ep = mu.interface.editor.EditorPane(None, 'baz')
+    ep.setText(text)
+
+    #
+    # Determine what ranges would be found and highlighted and arbitrarily
+    # use the last one for the selection
+    #
+    expected_ranges = []
+    selected_range = None
+    for range in _ranges_in_text(text, search_for):
+        if selected_range is None:
+            selected_range = range
+        else:
+            (line_start, col_start, line_end, col_end) = range
+            expected_ranges.append(
+                dict(
+                    line_start=line_start, col_start=col_start,
+                    line_end=line_end, col_end=col_end
+                )
+            )
+
+    ep.setSelection(*selected_range)
+    assert ep.search_indicators['selection']['positions'] == expected_ranges
+
+
 def test_EditorPane_highlight_selected_matches_incomplete_word():
     """
     Ensure that if the current selection is not a complete word

--- a/tests/interface/test_editor.py
+++ b/tests/interface/test_editor.py
@@ -362,6 +362,27 @@ def _ranges_in_text(text, search_for):
             yield n_line, match.start(), n_line, match.end()
 
 
+def _matched_selection(text, search_for):
+    """
+    Determine what ranges would be found and highlighted and arbitrarily
+    use the last one for the selection
+    """
+    expected_ranges = []
+    selected_range = None
+    for range in _ranges_in_text(text, search_for):
+        if selected_range is None:
+            selected_range = range
+        else:
+            (line_start, col_start, line_end, col_end) = range
+            expected_ranges.append(
+                dict(
+                    line_start=line_start, col_start=col_start,
+                    line_end=line_end, col_end=col_end
+                )
+            )
+    return expected_ranges, selected_range
+
+
 def test_EditorPane_highlight_selected_matches_no_selection():
     """
     Ensure that if the current selection is empty then all highlights
@@ -430,23 +451,7 @@ def test_EditorPane_highlight_selected_matches_with_match():
     ep = mu.interface.editor.EditorPane(None, 'baz')
     ep.setText(text)
 
-    #
-    # Determine what ranges would be found and highlighted and arbitrarily
-    # use the last one for the selection
-    #
-    expected_ranges = []
-    selected_range = None
-    for range in _ranges_in_text(text, search_for):
-        if selected_range is None:
-            selected_range = range
-        else:
-            (line_start, col_start, line_end, col_end) = range
-            expected_ranges.append(
-                dict(
-                    line_start=line_start, col_start=col_start,
-                    line_end=line_end, col_end=col_end
-                )
-            )
+    expected_ranges, selected_range = _matched_selection(text, search_for)
 
     ep.setSelection(*selected_range)
     assert ep.search_indicators['selection']['positions'] == expected_ranges
@@ -466,23 +471,7 @@ def test_EditorPane_highlight_selected_matches_with_match_in_nonASCII_text():
     ep = mu.interface.editor.EditorPane(None, 'baz')
     ep.setText(text)
 
-    #
-    # Determine what ranges would be found and highlighted and arbitrarily
-    # use the last one for the selection
-    #
-    expected_ranges = []
-    selected_range = None
-    for range in _ranges_in_text(text, search_for):
-        if selected_range is None:
-            selected_range = range
-        else:
-            (line_start, col_start, line_end, col_end) = range
-            expected_ranges.append(
-                dict(
-                    line_start=line_start, col_start=col_start,
-                    line_end=line_end, col_end=col_end
-                )
-            )
+    expected_ranges, selected_range = _matched_selection(text, search_for)
 
     ep.setSelection(*selected_range)
     assert ep.search_indicators['selection']['positions'] == expected_ranges
@@ -502,23 +491,7 @@ def test_EditorPane_highlight_selected_matches_with_nonASCII_match():
     ep = mu.interface.editor.EditorPane(None, 'baz')
     ep.setText(text)
 
-    #
-    # Determine what ranges would be found and highlighted and arbitrarily
-    # use the last one for the selection
-    #
-    expected_ranges = []
-    selected_range = None
-    for range in _ranges_in_text(text, search_for):
-        if selected_range is None:
-            selected_range = range
-        else:
-            (line_start, col_start, line_end, col_end) = range
-            expected_ranges.append(
-                dict(
-                    line_start=line_start, col_start=col_start,
-                    line_end=line_end, col_end=col_end
-                )
-            )
+    expected_ranges, selected_range = _matched_selection(text, search_for)
 
     ep.setSelection(*selected_range)
     assert ep.search_indicators['selection']['positions'] == expected_ranges


### PR DESCRIPTION
Addresses issue #725, please see my [notes there](
https://github.com/mu-editor/mu/issues/725#issuecomment-454389761).