### PR TITLE
Simple support for third party packages.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,9 @@ before_install:
   # OS and default Python info
   - uname -a
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then sw_vers; fi
+  # Linux packages needed for Qt to work.
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo pt-get update; fi
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo apt-get install libxkbcommon-x11-0; fi
   # Python 3 installation required
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then bash package/install_osx.sh; fi
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then pyenv install 3.6.5; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,9 @@ matrix:
       language: python
       python: 3.7
 
-    # To maximise compatibility pick earliest image, OS X 10.10 Yosemite
+    # To maximise compatibility pick earliest image, OS X 10.12
     - os: osx
-      osx_image: xcode8
+      osx_image: xcode8.3
       sudo: required
       language: generic
       python: 3.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ before_install:
   - uname -a
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then sw_vers; fi
   # Linux packages needed for Qt to work.
-  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo pt-get update; fi
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo apt-get update; fi
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo apt-get install libxkbcommon-x11-0; fi
   # Python 3 installation required
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then bash package/install_osx.sh; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,16 @@
 # Travis can building for Linux and macOS
 matrix:
   include:
-    # To maximise compatibility pick earliest image, Ubuntu 14.04.5 x64
     - os: linux
-      dist: trusty
+      dist: xenial 
       sudo: required
       language: python
       python: 3.5
     - os: linux
-      dist: trusty
+      dist: xenial 
       sudo: required
       language: python
       python: 3.6
-    # Py 3.7 needs xenial https://github.com/travis-ci/travis-ci/issues/9069
     - os: linux
       dist: xenial
       sudo: required

--- a/mu/debugger/runner.py
+++ b/mu/debugger/runner.py
@@ -139,9 +139,9 @@ class Debugger(bdb.Bdb):
         str_index = 0
         sl = len(self.stack)  # Bound check for stack length.
         if sl > 1 and self.stack[1][0].f_code.co_filename == '<string>':
-                str_index = 2
+            str_index = 2
         elif sl > 3 and self.stack[3][0].f_code.co_filename == '<string>':
-                str_index = 4
+            str_index = 4
         stack_data = []
         if str_index > 0:
             for frame, line_no in self.stack[str_index:]:

--- a/mu/interface/dialogs.py
+++ b/mu/interface/dialogs.py
@@ -21,6 +21,7 @@ import sys
 import logging
 import csv
 import shutil
+import platform
 from PyQt5.QtCore import QSize, QProcess, QTimer
 from PyQt5.QtWidgets import (QVBoxLayout, QListWidget, QLabel, QListWidgetItem,
                              QDialog, QDialogButtonBox, QPlainTextEdit,
@@ -224,7 +225,11 @@ class AdminDialog(QDialog):
         self.tabs.addTab(self.microbit_widget, _('BBC micro:bit Settings'))
         self.package_widget = PackagesWidget()
         self.package_widget.setup(packages)
-        self.tabs.addTab(self.package_widget, _('Third Party Packages'))
+        if 'armv' not in platform.platform():
+            # Only allow third party package management if NOT running on a
+            # Raspberry Pi. See:
+            # https://github.com/mu-editor/mu/pull/749#issuecomment-459051823
+            self.tabs.addTab(self.package_widget, _('Third Party Packages'))
 
     def settings(self):
         """

--- a/mu/interface/dialogs.py
+++ b/mu/interface/dialogs.py
@@ -314,6 +314,7 @@ class PackageDialog(QDialog):
         self.to_add = to_add
         self.module_dir = module_dir
         self.pkg_dirs = {}  # To hold locations of to-be-removed packages.
+        self.process = None
         # Basic layout.
         self.setMinimumSize(600, 400)
         self.setWindowTitle(_('Third Party Package Status'))

--- a/mu/interface/dialogs.py
+++ b/mu/interface/dialogs.py
@@ -176,18 +176,31 @@ class PackagesWidget(QWidget):
     def setup(self, packages):
         widget_layout = QVBoxLayout()
         self.setLayout(widget_layout)
-        label = QLabel(_('The packages shown below will be available to '
-                         'import in Python 3 mode. Delete a package from the '
-                         'list to remove its availability.\n\n'
-                         'Each separate package name should be on a new '
-                         'line. Packages are installed from PyPI '
-                         '(see: https://pypi.org/).'))
-        label.setWordWrap(True)
-        widget_layout.addWidget(label)
         self.text_area = QPlainTextEdit()
         self.text_area.setLineWrapMode(QPlainTextEdit.NoWrap)
-        self.text_area.setPlainText(packages)
-        widget_layout.addWidget(self.text_area)
+        if 'armv' in platform.platform():
+            # Only allow third party package management if NOT running on a
+            # Raspberry Pi. See:
+            # https://github.com/mu-editor/mu/pull/749#issuecomment-459051823
+            label = QLabel(_('Third party packages are not supported on the '
+                             'Raspberry Pi. Please use the operating '
+                             "system's package manager instead (refer to the "
+                             "operating system's documentation for how to do "
+                             "this)."))
+            label.setWordWrap(True)
+            widget_layout.addWidget(label)
+            self.text_area.setPlainText('')
+        else:
+            label = QLabel(_('The packages shown below will be available to '
+                             'import in Python 3 mode. Delete a package from '
+                             'the list to remove its availability.\n\n'
+                             'Each separate package name should be on a new '
+                             'line. Packages are installed from PyPI '
+                             '(see: https://pypi.org/).'))
+            label.setWordWrap(True)
+            widget_layout.addWidget(label)
+            self.text_area.setPlainText(packages)
+            widget_layout.addWidget(self.text_area)
 
 
 class AdminDialog(QDialog):
@@ -225,11 +238,7 @@ class AdminDialog(QDialog):
         self.tabs.addTab(self.microbit_widget, _('BBC micro:bit Settings'))
         self.package_widget = PackagesWidget()
         self.package_widget.setup(packages)
-        if 'armv' not in platform.platform():
-            # Only allow third party package management if NOT running on a
-            # Raspberry Pi. See:
-            # https://github.com/mu-editor/mu/pull/749#issuecomment-459051823
-            self.tabs.addTab(self.package_widget, _('Third Party Packages'))
+        self.tabs.addTab(self.package_widget, _('Third Party Packages'))
 
     def settings(self):
         """

--- a/mu/interface/dialogs.py
+++ b/mu/interface/dialogs.py
@@ -16,11 +16,16 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
+import os
+import sys
 import logging
-from PyQt5.QtCore import QSize
+import csv
+import shutil
+from PyQt5.QtCore import QSize, QProcess, QTimer
 from PyQt5.QtWidgets import (QVBoxLayout, QListWidget, QLabel, QListWidgetItem,
                              QDialog, QDialogButtonBox, QPlainTextEdit,
                              QTabWidget, QWidget, QCheckBox, QLineEdit)
+from PyQt5.QtGui import QTextCursor
 from mu.resources import load_icon
 
 
@@ -161,24 +166,48 @@ class MicrobitSettingsWidget(QWidget):
         widget_layout.addStretch()
 
 
+class PackagesWidget(QWidget):
+    """
+    Used for editing and displaying 3rd party packages installed via pip to be
+    used with Python 3 mode.
+    """
+
+    def setup(self, packages):
+        widget_layout = QVBoxLayout()
+        self.setLayout(widget_layout)
+        label = QLabel(_('The packages shown below will be available to '
+                         'import in Python 3 mode. Delete a package from the '
+                         'list to remove its availability.\n\n'
+                         'Each separate package name should be on a new '
+                         'line.'))
+        label.setWordWrap(True)
+        widget_layout.addWidget(label)
+        self.text_area = QPlainTextEdit()
+        self.text_area.setLineWrapMode(QPlainTextEdit.NoWrap)
+        self.text_area.setPlainText(packages)
+        widget_layout.addWidget(self.text_area)
+
+
 class AdminDialog(QDialog):
     """
     Displays administrative related information and settings (logs, environment
-    variables etc...).
+    variables, third party packages etc...).
     """
 
     def __init__(self, parent=None):
         super().__init__(parent)
 
-    def setup(self, log, settings):
+    def setup(self, log, settings, packages):
         self.setMinimumSize(600, 400)
         self.setWindowTitle(_('Mu Administration'))
         widget_layout = QVBoxLayout()
         self.setLayout(widget_layout)
         self.tabs = QTabWidget()
         widget_layout.addWidget(self.tabs)
-        button_box = QDialogButtonBox(QDialogButtonBox.Ok)
+        button_box = QDialogButtonBox(QDialogButtonBox.Ok |
+                                      QDialogButtonBox.Cancel)
         button_box.accepted.connect(self.accept)
+        button_box.rejected.connect(self.reject)
         widget_layout.addWidget(button_box)
         # Tabs
         self.log_widget = LogWidget()
@@ -192,6 +221,9 @@ class AdminDialog(QDialog):
         self.microbit_widget.setup(settings.get('minify', False),
                                    settings.get('microbit_runtime', ''))
         self.tabs.addTab(self.microbit_widget, _('BBC micro:bit Settings'))
+        self.package_widget = PackagesWidget()
+        self.package_widget.setup(packages)
+        self.tabs.addTab(self.package_widget, _('Third Party Packages'))
 
     def settings(self):
         """
@@ -203,6 +235,7 @@ class AdminDialog(QDialog):
             'envars': self.envar_widget.text_area.toPlainText(),
             'minify': self.microbit_widget.minify.isChecked(),
             'microbit_runtime': self.microbit_widget.runtime_path.text(),
+            'packages': self.package_widget.text_area.toPlainText(),
         }
 
 
@@ -262,3 +295,138 @@ class FindReplaceDialog(QDialog):
         Return the value of the global replace flag.
         """
         return self.replace_all_flag.isChecked()
+
+
+class PackageDialog(QDialog):
+    """
+    Display a dialog to indicate the status of the packaging related changes
+    currently run by pip.
+    """
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+
+    def setup(self, to_remove, to_add, module_dir):
+        """
+        Create the UI for the dialog.
+        """
+        self.to_remove = to_remove
+        self.to_add = to_add
+        self.module_dir = module_dir
+        self.pkg_dirs = {}  # To hold locations of to-be-removed packages.
+        # Basic layout.
+        self.setMinimumSize(600, 400)
+        self.setWindowTitle(_('Third Party Package Status'))
+        widget_layout = QVBoxLayout()
+        self.setLayout(widget_layout)
+        # Text area for pip output.
+        self.text_area = QPlainTextEdit()
+        self.text_area.setReadOnly(True)
+        self.text_area.setLineWrapMode(QPlainTextEdit.NoWrap)
+        widget_layout.addWidget(self.text_area)
+        # Buttons.
+        self.button_box = QDialogButtonBox(QDialogButtonBox.Ok)
+        self.button_box.button(QDialogButtonBox.Ok).setEnabled(False)
+        self.button_box.accepted.connect(self.accept)
+        widget_layout.addWidget(self.button_box)
+        # Kick off processing of packages.
+        if self.to_remove:
+            self.remove_packages()
+        if self.to_add:
+            self.run_pip()
+
+    def remove_packages(self):
+        """
+        Work out which packages need to be removed and then kick off their
+        removal.
+        """
+        dirs = [os.path.join(self.module_dir, d)
+                for d in os.listdir(self.module_dir)
+                if d.endswith("dist-info")]
+        self.pkg_dirs = {}
+        for pkg in self.to_remove:
+            for d in dirs:
+                if os.path.basename(d).lower().startswith(pkg + '-'):
+                    self.pkg_dirs[pkg] = d
+        if self.pkg_dirs:
+            # If there are packages to remove, schedule removal.
+            QTimer.singleShot(2, self.remove_package)
+
+    def remove_package(self):
+        """
+        Take a package from the pending packages to be removed, delete all its
+        assets and schedule the removal of the remaining packages. If there are
+        no packages to remove, move to the finished state.
+        """
+        if self.pkg_dirs:
+            package, dist = self.pkg_dirs.popitem()
+            record = os.path.join(dist, 'RECORD')
+            with open(record) as f:
+                files = csv.reader(f)
+                for row in files:
+                    to_delete = os.path.join(self.module_dir, row[0])
+                    try:
+                        os.remove(to_delete)
+                    except Exception as ex:
+                        logger.error('Unable to remove: {}'.format(to_delete))
+                        logger.error(ex)
+            shutil.rmtree(dist, ignore_errors=True)
+            shutil.rmtree(os.path.join(self.module_dir, package),
+                          ignore_errors=True)
+            self.append_data('Removed {}\n'.format(package))
+            QTimer.singleShot(2, self.remove_package)
+        else:
+            if not (self.to_add or self.process):
+                self.end_state()
+
+    def end_state(self):
+        """
+        Set the UI to a valid end state.
+        """
+        self.append_data('\nFINISHED')
+        self.button_box.button(QDialogButtonBox.Ok).setEnabled(True)
+
+    def run_pip(self):
+        """
+        Run a pip command in a subprocess and pipe the output to the dialog's
+        text area.
+        """
+        package = self.to_add.pop()
+        args = ['-m', 'pip', 'install', package, '--target',
+                self.module_dir]
+        self.process = QProcess(self)
+        self.process.readyRead.connect(self.read_process)
+        self.process.finished.connect(self.finished)
+        self.process.start(sys.executable, args)
+
+    def finished(self):
+        """
+        Called when the subprocess that uses pip to install a package is
+        finished.
+        """
+        if self.to_add:
+            self.process = None
+            self.run_pip()
+        else:
+            if not self.pkg_dirs:
+                self.end_state()
+
+    def read_process(self):
+        """
+        Read data from the child process and append it to the text area. Try
+        to keep reading until there's no more data from the process.
+        """
+        data = self.process.readAll()
+        if data:
+            self.append_data(data.data().decode('utf-8'))
+            QTimer.singleShot(2, self.read_process)
+
+    def append_data(self, msg):
+        """
+        Add data to the end of the text area.
+        """
+        cursor = self.text_area.textCursor()
+        cursor.movePosition(QTextCursor.End)
+        cursor.insertText(msg)
+        cursor.movePosition(QTextCursor.End)
+        self.text_area.setTextCursor(cursor)

--- a/mu/interface/dialogs.py
+++ b/mu/interface/dialogs.py
@@ -179,7 +179,8 @@ class PackagesWidget(QWidget):
                          'import in Python 3 mode. Delete a package from the '
                          'list to remove its availability.\n\n'
                          'Each separate package name should be on a new '
-                         'line.'))
+                         'line. Packages are installed from PyPI '
+                         '(see: https://pypi.org/).'))
         label.setWordWrap(True)
         widget_layout.addWidget(label)
         self.text_area = QPlainTextEdit()

--- a/mu/interface/dialogs.py
+++ b/mu/interface/dialogs.py
@@ -348,7 +348,9 @@ class PackageDialog(QDialog):
         self.pkg_dirs = {}
         for pkg in self.to_remove:
             for d in dirs:
-                if os.path.basename(d).lower().startswith(pkg.lower() + '-'):
+                # Assets on the filesystem use a normalised package name.
+                pkg_name = pkg.replace('-', '_').lower()
+                if os.path.basename(d).lower().startswith(pkg_name + '-'):
                     self.pkg_dirs[pkg] = d
         if self.pkg_dirs:
             # If there are packages to remove, schedule removal.
@@ -412,6 +414,7 @@ class PackageDialog(QDialog):
         args = ['-m', 'pip', 'install', package, '--target',
                 self.module_dir]
         self.process = QProcess(self)
+        self.process.setProcessChannelMode(QProcess.MergedChannels)
         self.process.readyRead.connect(self.read_process)
         self.process.finished.connect(self.finished)
         self.process.start(sys.executable, args)

--- a/mu/interface/main.py
+++ b/mu/interface/main.py
@@ -28,7 +28,8 @@ from PyQt5.QtWidgets import (QToolBar, QAction, QDesktopWidget, QWidget,
 from PyQt5.QtGui import QKeySequence, QStandardItemModel
 from PyQt5.QtSerialPort import QSerialPort
 from mu import __version__
-from mu.interface.dialogs import ModeSelector, AdminDialog, FindReplaceDialog
+from mu.interface.dialogs import (ModeSelector, AdminDialog, FindReplaceDialog,
+                                  PackageDialog)
 from mu.interface.themes import (DayTheme, NightTheme, ContrastTheme,
                                  DEFAULT_FONT_SIZE)
 from mu.interface.panes import (DebugInspector, DebugInspectorItem,
@@ -688,16 +689,28 @@ class Window(QMainWindow):
         if hasattr(self, 'plotter') and self.plotter:
             self.plotter_pane.set_theme(theme)
 
-    def show_admin(self, log, settings):
+    def show_admin(self, log, settings, packages):
         """
         Display the administrative dialog with referenced content of the log
         and settings. Return a dictionary of the settings that may have been
         changed by the admin dialog.
         """
         admin_box = AdminDialog(self)
-        admin_box.setup(log, settings)
-        admin_box.exec()
-        return admin_box.settings()
+        admin_box.setup(log, settings, packages)
+        result = admin_box.exec()
+        if result:
+            return admin_box.settings()
+        else:
+            return {}
+
+    def sync_packages(self, to_remove, to_add, module_dir):
+        """
+        Display a modal dialog that indicates the status of the add/remove
+        package management operation.
+        """
+        package_box = PackageDialog(self)
+        package_box.setup(to_remove, to_add, module_dir)
+        package_box.exec()
 
     def show_message(self, message, information=None, icon=None):
         """

--- a/mu/interface/panes.py
+++ b/mu/interface/panes.py
@@ -709,7 +709,7 @@ class PythonProcessPane(QTextEdit):
                 logger.error('Could not set Python paths with mu.pth file.')
                 logger.error(ex)
         if 'PYTHONPATH' not in envars:
-            envars.append(('PYTHONPATH', ':'.join(sys.path)))
+            envars.append(('PYTHONPATH', os.pathsep.join(sys.path)))
         if envars:
             logger.info('Running with environment variables: '
                         '{}'.format(envars))

--- a/mu/interface/panes.py
+++ b/mu/interface/panes.py
@@ -647,6 +647,8 @@ class PythonProcessPane(QTextEdit):
         If python_args is given, these are passed as arguments to the Python
         runtime used to launch the child process.
         """
+        if not envars:  # Envars must be a list if not passed a value.
+            envars = []
         self.script = os.path.abspath(os.path.normcase(script_name))
         logger.info('Running script: {}'.format(self.script))
         if interactive:
@@ -706,6 +708,8 @@ class PythonProcessPane(QTextEdit):
                 # this to fail.
                 logger.error('Could not set Python paths with mu.pth file.')
                 logger.error(ex)
+        if 'PYTHONPATH' not in envars:
+            envars.append(('PYTHONPATH', ':'.join(sys.path)))
         if envars:
             logger.info('Running with environment variables: '
                         '{}'.format(envars))

--- a/mu/interface/panes.py
+++ b/mu/interface/panes.py
@@ -662,12 +662,6 @@ class PythonProcessPane(QTextEdit):
         env = QProcessEnvironment.systemEnvironment()
         env.insert('PYTHONUNBUFFERED', '1')
         env.insert('PYTHONIOENCODING', 'utf-8')
-        if sys.platform == 'darwin':
-            parent_dir = os.path.dirname(__file__)
-            if '.app/Contents/Resources/app/mu' in parent_dir:
-                # Mu is running as a macOS app bundle. Ensure the expected
-                # paths are in PYTHONPATH of the subprocess.
-                env.insert('PYTHONPATH', ':'.join(sys.path))
         if sys.platform == 'win32' and 'pythonw.exe' in sys.executable:
             # On Windows, if installed via NSIS then Python is always run in
             # isolated mode via pythonw.exe so none of the expected directories

--- a/mu/logic.py
+++ b/mu/logic.py
@@ -156,10 +156,10 @@ def installed_packages():
                 if d.endswith("dist-info")]
     for pkg in pkg_dirs:
         metadata_file = os.path.join(pkg, 'METADATA')
-        with open(metadata_file) as f:
+        with open(metadata_file, 'rb') as f:
             lines = f.readlines()
-            name = lines[1].rsplit(':')[-1].strip()
-            result.append(name)
+            name = lines[1].rsplit(b':')[-1].strip()
+            result.append(name.decode('utf-8'))
     return sorted(result)
 
 
@@ -1108,25 +1108,25 @@ class Editor:
         with open(LOG_FILE, 'r', encoding='utf8') as logfile:
             new_settings = self._view.show_admin(logfile.read(), settings,
                                                  '\n'.join(packages))
-            if new_settings:
-                self.envars = extract_envars(new_settings['envars'])
-                self.minify = new_settings['minify']
-                runtime = new_settings['microbit_runtime'].strip()
-                if runtime and not os.path.isfile(runtime):
-                    self.microbit_runtime = ''
-                    message = _('Could not find MicroPython runtime.')
-                    information = _("The micro:bit runtime you specified "
-                                    "('{}') does not exist. "
-                                    "Please try again.").format(runtime)
-                    self._view.show_message(message, information)
-                else:
-                    self.microbit_runtime = runtime
-                new_packages = [p for p in
-                                new_settings['packages'].lower().split('\n')
-                                if p.strip()]
-                self.sync_package_state(packages, new_packages)
+        if new_settings:
+            self.envars = extract_envars(new_settings['envars'])
+            self.minify = new_settings['minify']
+            runtime = new_settings['microbit_runtime'].strip()
+            if runtime and not os.path.isfile(runtime):
+                self.microbit_runtime = ''
+                message = _('Could not find MicroPython runtime.')
+                information = _("The micro:bit runtime you specified "
+                                "('{}') does not exist. "
+                                "Please try again.").format(runtime)
+                self._view.show_message(message, information)
             else:
-                logger.info("No admin settings changed.")
+                self.microbit_runtime = runtime
+            new_packages = [p for p in
+                            new_settings['packages'].lower().split('\n')
+                            if p.strip()]
+            self.sync_package_state(packages, new_packages)
+        else:
+            logger.info("No admin settings changed.")
 
     def sync_package_state(self, old_packages, new_packages):
         """

--- a/mu/logic.py
+++ b/mu/logic.py
@@ -1124,7 +1124,8 @@ class Editor:
             new_packages = [p for p in
                             new_settings['packages'].lower().split('\n')
                             if p.strip()]
-            self.sync_package_state(packages, new_packages)
+            old_packages = [p.lower() for p in packages]
+            self.sync_package_state(old_packages, new_packages)
         else:
             logger.info("No admin settings changed.")
 
@@ -1137,9 +1138,15 @@ class Editor:
         """
         old = set(old_packages)
         new = set(new_packages)
+        logger.info('Synchronize package states...')
+        logger.info('Old: {}'.format(old))
+        logger.info('New: {}'.format(new))
         to_remove = old.difference(new)
         to_add = new.difference(old)
         if to_remove or to_add:
+            logger.info('To add: {}'.format(to_add))
+            logger.info('To remove: {}'.format(to_remove))
+            logger.info('Site packages: {}'.format(MODULE_DIR))
             self._view.sync_packages(to_remove, to_add, MODULE_DIR)
 
     def select_mode(self, event=None):

--- a/mu/logic.py
+++ b/mu/logic.py
@@ -47,6 +47,9 @@ HOME_DIRECTORY = os.path.expanduser('~')
 WORKSPACE_NAME = 'mu_code'
 # The default directory for application data (i.e., configuration).
 DATA_DIR = appdirs.user_data_dir(appname='mu', appauthor='python')
+# The directory containing user installed third party modules.
+MODULE_DIR = os.path.join(DATA_DIR, 'site-packages')
+sys.path.append(MODULE_DIR)
 # The default directory for application logs.
 LOG_DIR = appdirs.user_log_dir(appname='mu', appauthor='python')
 # The path to the log file for the application.
@@ -142,6 +145,22 @@ ENCODING_COOKIE_RE = re.compile(
     "^[ \t\v]*#.*?coding[:=][ \t]*([-_.a-zA-Z0-9]+)")
 
 logger = logging.getLogger(__name__)
+
+
+def installed_packages():
+    """
+    List all the third party modules installed by the user.
+    """
+    result = []
+    pkg_dirs = [os.path.join(MODULE_DIR, d) for d in os.listdir(MODULE_DIR)
+                if d.endswith("dist-info")]
+    for pkg in pkg_dirs:
+        metadata_file = os.path.join(pkg, 'METADATA')
+        with open(metadata_file) as f:
+            lines = f.readlines()
+            name = lines[1].rsplit(':')[-1].strip()
+            result.append(name)
+    return sorted(result)
 
 
 def write_and_flush(fileobj, content):
@@ -559,6 +578,9 @@ class Editor:
         if not os.path.exists(DATA_DIR):
             logger.debug('Creating directory: {}'.format(DATA_DIR))
             os.makedirs(DATA_DIR)
+        if not os.path.exists(MODULE_DIR):
+            logger.debug('Creating directory: {}'.format(MODULE_DIR))
+            os.makedirs(MODULE_DIR)
         logger.info('Settings path: {}'.format(get_settings_path()))
         logger.info('Session path: {}'.format(get_session_path()))
         logger.info('Log directory: {}'.format(LOG_DIR))
@@ -1074,7 +1096,7 @@ class Editor:
 
         Ensure any changes to the envars is updated.
         """
-        logger.info('Showing logs from {}'.format(LOG_FILE))
+        logger.info('Showing admin with logs from {}'.format(LOG_FILE))
         envars = '\n'.join(['{}={}'.format(name, value) for name, value in
                             self.envars])
         settings = {
@@ -1082,20 +1104,43 @@ class Editor:
             'minify': self.minify,
             'microbit_runtime': self.microbit_runtime,
         }
+        packages = installed_packages()
         with open(LOG_FILE, 'r', encoding='utf8') as logfile:
-            new_settings = self._view.show_admin(logfile.read(), settings)
-            self.envars = extract_envars(new_settings['envars'])
-            self.minify = new_settings['minify']
-            runtime = new_settings['microbit_runtime'].strip()
-            if runtime and not os.path.isfile(runtime):
-                self.microbit_runtime = ''
-                message = _('Could not find MicroPython runtime.')
-                information = _("The micro:bit runtime you specified ('{}') "
-                                "does not exist. "
-                                "Please try again.").format(runtime)
-                self._view.show_message(message, information)
+            new_settings = self._view.show_admin(logfile.read(), settings,
+                                                 '\n'.join(packages))
+            if new_settings:
+                self.envars = extract_envars(new_settings['envars'])
+                self.minify = new_settings['minify']
+                runtime = new_settings['microbit_runtime'].strip()
+                if runtime and not os.path.isfile(runtime):
+                    self.microbit_runtime = ''
+                    message = _('Could not find MicroPython runtime.')
+                    information = _("The micro:bit runtime you specified "
+                                    "('{}') does not exist. "
+                                    "Please try again.").format(runtime)
+                    self._view.show_message(message, information)
+                else:
+                    self.microbit_runtime = runtime
+                new_packages = [p for p in
+                                new_settings['packages'].lower().split('\n')
+                                if p.strip()]
+                self.sync_package_state(packages, new_packages)
             else:
-                self.microbit_runtime = runtime
+                logger.info("No admin settings changed.")
+
+    def sync_package_state(self, old_packages, new_packages):
+        """
+        Given the state of the old third party packages, compared to the new
+        third party packages, ensure that pip uninstalls and installs the
+        packages so the currently available third party packages reflects the
+        new state.
+        """
+        old = set(old_packages)
+        new = set(new_packages)
+        to_remove = old.difference(new)
+        to_add = new.difference(old)
+        if to_remove or to_add:
+            self._view.sync_packages(to_remove, to_add, MODULE_DIR)
 
     def select_mode(self, event=None):
         """

--- a/mu/modes/python3.py
+++ b/mu/modes/python3.py
@@ -62,13 +62,10 @@ class KernelRunner(QObject):
                     '{}'.format(self.envars))
         for k, v in self.envars.items():
             os.environ[k] = v
-        if sys.platform == 'darwin':
-            parent_dir = os.path.dirname(__file__)
-            if '.app/Contents/Resources/app/mu' in parent_dir:
-                # Mu is running as a macOS app bundle. Ensure the expected
-                # paths are in PYTHONPATH of the subprocess so the kernel can
-                # be found.
-                os.environ['PYTHONPATH'] = ':'.join(sys.path)
+        # Ensure the expected paths are in PYTHONPATH of the subprocess so the
+        # kernel and Mu-installed third party applications can be found.
+        if 'PYTHONPATH' not in os.environ:
+            os.environ['PYTHONPATH'] = ':'.join(sys.path)
         self.repl_kernel_manager = QtKernelManager()
         self.repl_kernel_manager.start_kernel()
         self.repl_kernel_client = self.repl_kernel_manager.client()

--- a/mu/modes/python3.py
+++ b/mu/modes/python3.py
@@ -65,7 +65,7 @@ class KernelRunner(QObject):
         # Ensure the expected paths are in PYTHONPATH of the subprocess so the
         # kernel and Mu-installed third party applications can be found.
         if 'PYTHONPATH' not in os.environ:
-            os.environ['PYTHONPATH'] = ':'.join(sys.path)
+            os.environ['PYTHONPATH'] = os.pathsep.join(sys.path)
         self.repl_kernel_manager = QtKernelManager()
         self.repl_kernel_manager.start_kernel()
         self.repl_kernel_client = self.repl_kernel_manager.client()

--- a/package/install_osx.sh
+++ b/package/install_osx.sh
@@ -4,6 +4,6 @@ brew update >/dev/null 2>&1  # This produces a lot of output that's not very int
 
 # Install Python 3.6
 #brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/f2a764ef944b1080be64bd88dca9a1d80130c558/Formula/python.rb
-brew install pyenv 
+brew upgrade pyenv 
 # The following are needed for Matplotlib
 brew install freetype

--- a/tests/debugger/test_client.py
+++ b/tests/debugger/test_client.py
@@ -576,7 +576,7 @@ def test_Debugger_on_breakpoint_ignore():
     db.view.reset_mock()
     db.on_breakpoint_ignore(1, 5)
     bp = db.bp_index[os.path.normcase(os.path.abspath('file.py'))][10]
-    assert bp.ignore is 5
+    assert bp.ignore == 5
     db.view.debug_on_breakpoint_ignore.assert_called_once_with(bp, 5)
 
 

--- a/tests/interface/test_dialogs.py
+++ b/tests/interface/test_dialogs.py
@@ -219,14 +219,17 @@ def test_PackageDialog_remove_packages():
     remove_package method is scheduled.
     """
     pd = mu.interface.dialogs.PackageDialog()
-    pd.to_remove = {'foo'}
-    pd.module_dir = 'bar'
-    with mock.patch('mu.interface.dialogs.os.listdir',
-                    return_value=['foo-1.0.0.dist-info', 'foo']), \
+    pd.to_remove = {'foo', 'bar-baz', 'Quux'}
+    pd.module_dir = 'wibble'
+    dirs = ['foo-1.0.0.dist-info', 'foo', 'bar_baz-1.0.0.dist-info', 'bar_baz',
+            'quux-1.0.0.dist-info', 'quux', ]
+    with mock.patch('mu.interface.dialogs.os.listdir', return_value=dirs), \
             mock.patch('mu.interface.dialogs.QTimer') as mock_qtimer:
         pd.remove_packages()
         assert pd.pkg_dirs == {
-            'foo': os.path.join('bar', 'foo-1.0.0.dist-info')
+            'foo': os.path.join('wibble', 'foo-1.0.0.dist-info'),
+            'bar-baz': os.path.join('wibble', 'bar_baz-1.0.0.dist-info'),
+            'Quux': os.path.join('wibble', 'quux-1.0.0.dist-info'),
         }
         mock_qtimer.singleShot.assert_called_once_with(2, pd.remove_package)
 

--- a/tests/interface/test_dialogs.py
+++ b/tests/interface/test_dialogs.py
@@ -6,7 +6,7 @@ import sys
 import os
 import pytest
 import mu.interface.dialogs
-from PyQt5.QtWidgets import QApplication, QDialog, QWidget, QDialogButtonBox
+from PyQt5.QtWidgets import QDialog, QWidget, QDialogButtonBox
 from unittest import mock
 from mu.modes import PythonMode, AdafruitMode, MicrobitMode, DebugMode
 
@@ -14,7 +14,6 @@ from mu.modes import PythonMode, AdafruitMode, MicrobitMode, DebugMode
 # Required so the QWidget tests don't abort with the message:
 # "QWidget: Must construct a QApplication before a QWidget"
 # The QApplication need only be instantiated once.
-app = QApplication([])
 
 
 def test_ModeItem_init():

--- a/tests/interface/test_dialogs.py
+++ b/tests/interface/test_dialogs.py
@@ -146,6 +146,23 @@ def test_PackagesWidget_setup():
     assert pw.text_area.toPlainText() == packages
 
 
+def test_PackagesWidget_setup_raspberry_pi():
+    """
+    The package related widget must be disabled in some way if Mu is running
+    on a Raspberry Pi. See:
+    https://github.com/mu-editor/mu/pull/749#issuecomment-459031400
+    for further context.
+    """
+    packages = 'foo\nbar\nbaz'
+    pw = mu.interface.dialogs.PackagesWidget()
+    mock_platform = mock.MagicMock()
+    platform = "Linux-4.14.79-v7+-armv7l-with-debian-9.6"
+    mock_platform.platform.return_value = platform
+    with mock.patch('mu.interface.dialogs.platform', mock_platform):
+        pw.setup(packages)
+    assert pw.text_area.toPlainText() == ''  # No packages
+
+
 def test_AdminDialog_setup():
     """
     Ensure the admin dialog is setup properly given the content of a log
@@ -166,31 +183,6 @@ def test_AdminDialog_setup():
     assert s['packages'] == packages
     del(s['packages'])
     assert s == settings
-
-
-def test_AdminDialog_setup_raspberry_pi():
-    """
-    The package related widget must NOT be visible if Mu is running on a
-    Raspberry Pi. See:
-    https://github.com/mu-editor/mu/pull/749#issuecomment-459031400
-    for further context.
-    """
-    log = 'this is the contents of a log file'
-    settings = {
-        'envars': 'name=value',
-        'minify': True,
-        'microbit_runtime': '/foo/bar',
-    }
-    packages = 'foo\nbar\nbaz\n'
-    mock_window = QWidget()
-    mock_platform = mock.MagicMock()
-    platform = "Linux-4.14.79-v7+-armv7l-with-debian-9.6"
-    mock_platform.platform.return_value = platform
-    ad = mu.interface.dialogs.AdminDialog(mock_window)
-    with mock.patch('mu.interface.dialogs.platform', mock_platform):
-        ad.setup(log, settings, packages)
-    # Package tab not added to tabs widget (position -1)
-    assert ad.tabs.indexOf(ad.package_widget) == -1
 
 
 def test_FindReplaceDialog_setup():

--- a/tests/interface/test_dialogs.py
+++ b/tests/interface/test_dialogs.py
@@ -2,11 +2,13 @@
 """
 Tests for the user interface elements of Mu.
 """
-from PyQt5.QtWidgets import QApplication, QDialog, QWidget
+import sys
+import os
+import pytest
+import mu.interface.dialogs
+from PyQt5.QtWidgets import QApplication, QDialog, QWidget, QDialogButtonBox
 from unittest import mock
 from mu.modes import PythonMode, AdafruitMode, MicrobitMode, DebugMode
-import mu.interface.dialogs
-import pytest
 
 
 # Required so the QWidget tests don't abort with the message:
@@ -133,6 +135,17 @@ def test_MicrobitSettingsWidget_setup():
     assert mbsw.runtime_path.text() == '/foo/bar'
 
 
+def test_PackagesWidget_setup():
+    """
+    Ensure the widget for editing settings related to third party packages
+    displays the referenced data in the expected way.
+    """
+    packages = 'foo\nbar\nbaz'
+    pw = mu.interface.dialogs.PackagesWidget()
+    pw.setup(packages)
+    assert pw.text_area.toPlainText() == packages
+
+
 def test_AdminDialog_setup():
     """
     Ensure the admin dialog is setup properly given the content of a log
@@ -144,11 +157,15 @@ def test_AdminDialog_setup():
         'minify': True,
         'microbit_runtime': '/foo/bar',
     }
+    packages = 'foo\nbar\nbaz\n'
     mock_window = QWidget()
     ad = mu.interface.dialogs.AdminDialog(mock_window)
-    ad.setup(log, settings)
+    ad.setup(log, settings, packages)
     assert ad.log_widget.log_text_area.toPlainText() == log
-    assert ad.settings() == settings
+    s = ad.settings()
+    assert s['packages'] == packages
+    del(s['packages'])
+    assert s == settings
 
 
 def test_FindReplaceDialog_setup():
@@ -176,3 +193,213 @@ def test_FindReplaceDialog_setup_with_args():
     assert frd.find() == find
     assert frd.replace() == replace
     assert frd.replace_flag()
+
+
+def test_PackageDialog_setup():
+    """
+    Ensure the PackageDialog is set up correctly and kicks off the process of
+    removing and adding packages.
+    """
+    pd = mu.interface.dialogs.PackageDialog()
+    pd.remove_packages = mock.MagicMock()
+    pd.run_pip = mock.MagicMock()
+    to_remove = {'foo'}
+    to_add = {'bar'}
+    module_dir = 'baz'
+    pd.setup(to_remove, to_add, module_dir)
+    pd.remove_packages.assert_called_once_with()
+    pd.run_pip.assert_called_once_with()
+    assert pd.button_box.button(QDialogButtonBox.Ok).isEnabled() is False
+    assert pd.pkg_dirs == {}
+
+
+def test_PackageDialog_remove_packages():
+    """
+    Ensure the pkg_dirs of to-be-removed packages is correctly filled and the
+    remove_package method is scheduled.
+    """
+    pd = mu.interface.dialogs.PackageDialog()
+    pd.to_remove = {'foo'}
+    pd.module_dir = 'bar'
+    with mock.patch('mu.interface.dialogs.os.listdir',
+                    return_value=['foo-1.0.0.dist-info', 'foo']), \
+            mock.patch('mu.interface.dialogs.QTimer') as mock_qtimer:
+        pd.remove_packages()
+        assert pd.pkg_dirs == {
+            'foo': os.path.join('bar', 'foo-1.0.0.dist-info')
+        }
+        mock_qtimer.singleShot.assert_called_once_with(2, pd.remove_package)
+
+
+def test_PackageDialog_remove_package():
+    """
+    Ensures that if there are packages remaining to be deleted, then the next
+    one is deleted as expected.
+    """
+    pd = mu.interface.dialogs.PackageDialog()
+    pd.append_data = mock.MagicMock()
+    pd.pkg_dirs = {'foo': os.path.join('bar', 'foo-1.0.0.dist-info')}
+    pd.module_dir = 'baz'
+    files = [
+        ['filename1', '', ],
+        ['filename2', '', ],
+        ['filename3', '', ],
+    ]
+    mock_remove = mock.MagicMock()
+    mock_shutil = mock.MagicMock()
+    mock_qtimer = mock.MagicMock()
+    with mock.patch('builtins.open'), \
+            mock.patch('mu.interface.dialogs.csv.reader',
+                       return_value=files), \
+            mock.patch('mu.interface.dialogs.os.remove', mock_remove), \
+            mock.patch('mu.interface.dialogs.shutil', mock_shutil), \
+            mock.patch('mu.interface.dialogs.QTimer', mock_qtimer):
+        pd.remove_package()
+        assert pd.pkg_dirs == {}
+        assert mock_remove.call_count == 3
+        assert mock_shutil.rmtree.call_count == 2
+        pd.append_data.assert_called_once_with('Removed foo\n')
+        mock_qtimer.singleShot.assert_called_once_with(2, pd.remove_package)
+
+
+def test_PackageDialog_remove_package_cannot_delete():
+    """
+    Ensures that if there are packages remaining to be deleted, then the next
+    one is deleted and any failures are logged.
+    """
+    pd = mu.interface.dialogs.PackageDialog()
+    pd.append_data = mock.MagicMock()
+    pd.pkg_dirs = {'foo': os.path.join('bar', 'foo-1.0.0.dist-info')}
+    pd.module_dir = 'baz'
+    files = [
+        ['filename1', '', ],
+        ['filename2', '', ],
+        ['filename3', '', ],
+    ]
+    mock_remove = mock.MagicMock(side_effect=Exception('Bang'))
+    mock_shutil = mock.MagicMock()
+    mock_qtimer = mock.MagicMock()
+    mock_log = mock.MagicMock()
+    with mock.patch('builtins.open'), \
+            mock.patch('mu.interface.dialogs.csv.reader',
+                       return_value=files), \
+            mock.patch('mu.interface.dialogs.os.remove', mock_remove), \
+            mock.patch('mu.interface.dialogs.logger.error', mock_log), \
+            mock.patch('mu.interface.dialogs.shutil', mock_shutil), \
+            mock.patch('mu.interface.dialogs.QTimer', mock_qtimer):
+        pd.remove_package()
+        assert pd.pkg_dirs == {}
+        assert mock_remove.call_count == 3
+        assert mock_log.call_count == 6
+        assert mock_shutil.rmtree.call_count == 2
+        pd.append_data.assert_called_once_with('Removed foo\n')
+        mock_qtimer.singleShot.assert_called_once_with(2, pd.remove_package)
+
+
+def test_PackageDialog_remove_package_end_state():
+    """
+    If there are no more packages to remove and there's nothing to be done for
+    adding packages, then ensure the expected end-state is called.
+    """
+    pd = mu.interface.dialogs.PackageDialog()
+    pd.pkg_dirs = {}
+    pd.to_add = {}
+    pd.process = None
+    pd.end_state = mock.MagicMock()
+    pd.remove_package()
+    pd.end_state.assert_called_once_with()
+
+
+def test_PackageDialog_end_state():
+    """
+    Ensure the expected end-state is correctly cofigured (for when all tasks
+    relating to third party packages have finished).
+    """
+    pd = mu.interface.dialogs.PackageDialog()
+    pd.append_data = mock.MagicMock()
+    pd.button_box = mock.MagicMock()
+    pd.end_state()
+    pd.append_data.assert_called_once_with('\nFINISHED')
+    pd.button_box.button().setEnabled.assert_called_once_with(True)
+
+
+def test_PackageDialog_run_pip():
+    """
+    Ensure the expected package to be installed is done so via the expected
+    correct call to "pip" in a new process (as per the recommended way to
+    us "pip").
+    """
+    pd = mu.interface.dialogs.PackageDialog()
+    pd.to_add = {'foo'}
+    pd.module_dir = 'bar'
+    mock_process = mock.MagicMock()
+    with mock.patch('mu.interface.dialogs.QProcess', mock_process):
+        pd.run_pip()
+        assert pd.to_add == set()
+        pd.process.readyRead.connect.assert_called_once_with(pd.read_process)
+        pd.process.finished.connect.assert_called_once_with(pd.finished)
+        args = [
+            '-m',  # run the module
+            'pip',  # called pip
+            'install',  # to install
+            'foo',  # a package called "foo"
+            '--target',  # and the target directory for package assets is...
+            'bar',  # ...this directory
+        ]
+        pd.process.start.assert_called_once_with(sys.executable, args)
+
+
+def test_PackageDialog_finished_with_more_to_remove():
+    """
+    When the pip process is finished, check if there are more packages to
+    install and run again.
+    """
+    pd = mu.interface.dialogs.PackageDialog()
+    pd.to_add = {'foo'}
+    pd.run_pip = mock.MagicMock()
+    pd.process = mock.MagicMock()
+    pd.finished()
+    assert pd.process is None
+    pd.run_pip.assert_called_once_with()
+
+
+def test_PackageDialog_finished_to_end_state():
+    """
+    When the pip process is finished, if there are no more packages to install
+    and there's no more activity for removing packages, move to the end state.
+    """
+    pd = mu.interface.dialogs.PackageDialog()
+    pd.to_add = set()
+    pd.pkg_dirs = {}
+    pd.end_state = mock.MagicMock()
+    pd.finished()
+    pd.end_state.assert_called_once_with()
+
+
+def test_PackageDialog_read_process():
+    """
+    Ensure any data from the subprocess running "pip" is read and appended to
+    the text area.
+    """
+    pd = mu.interface.dialogs.PackageDialog()
+    pd.process = mock.MagicMock()
+    pd.process.readAll().data.return_value = b'hello'
+    pd.append_data = mock.MagicMock()
+    mock_timer = mock.MagicMock()
+    with mock.patch('mu.interface.dialogs.QTimer', mock_timer):
+        pd.read_process()
+        pd.append_data.assert_called_once_with('hello')
+        mock_timer.singleShot.assert_called_once_with(2, pd.read_process)
+
+
+def test_PackageDialog_append_data():
+    """
+    Ensure that when data is appended, it's added to the end of the text area!
+    """
+    pd = mu.interface.dialogs.PackageDialog()
+    pd.text_area = mock.MagicMock()
+    pd.append_data('hello')
+    c = pd.text_area.textCursor()
+    assert c.movePosition.call_count == 2
+    c.insertText.assert_called_once_with('hello')
+    pd.text_area.setTextCursor.assert_called_once_with(c)

--- a/tests/interface/test_dialogs.py
+++ b/tests/interface/test_dialogs.py
@@ -6,7 +6,7 @@ import sys
 import os
 import pytest
 import mu.interface.dialogs
-from PyQt5.QtWidgets import QDialog, QWidget, QDialogButtonBox
+from PyQt5.QtWidgets import QApplication, QDialog, QWidget, QDialogButtonBox
 from unittest import mock
 from mu.modes import PythonMode, AdafruitMode, MicrobitMode, DebugMode
 
@@ -14,6 +14,7 @@ from mu.modes import PythonMode, AdafruitMode, MicrobitMode, DebugMode
 # Required so the QWidget tests don't abort with the message:
 # "QWidget: Must construct a QApplication before a QWidget"
 # The QApplication need only be instantiated once.
+app = QApplication([])
 
 
 def test_ModeItem_init():

--- a/tests/interface/test_dialogs.py
+++ b/tests/interface/test_dialogs.py
@@ -168,6 +168,31 @@ def test_AdminDialog_setup():
     assert s == settings
 
 
+def test_AdminDialog_setup_raspberry_pi():
+    """
+    The package related widget must NOT be visible if Mu is running on a
+    Raspberry Pi. See:
+    https://github.com/mu-editor/mu/pull/749#issuecomment-459031400
+    for further context.
+    """
+    log = 'this is the contents of a log file'
+    settings = {
+        'envars': 'name=value',
+        'minify': True,
+        'microbit_runtime': '/foo/bar',
+    }
+    packages = 'foo\nbar\nbaz\n'
+    mock_window = QWidget()
+    mock_platform = mock.MagicMock()
+    platform = "Linux-4.14.79-v7+-armv7l-with-debian-9.6"
+    mock_platform.platform.return_value = platform
+    ad = mu.interface.dialogs.AdminDialog(mock_window)
+    with mock.patch('mu.interface.dialogs.platform', mock_platform):
+        ad.setup(log, settings, packages)
+    # Package tab not added to tabs widget (position -1)
+    assert ad.tabs.indexOf(ad.package_widget) == -1
+
+
 def test_FindReplaceDialog_setup():
     """
     Ensure the find/replace dialog is setup properly given only the theme

--- a/tests/interface/test_main.py
+++ b/tests/interface/test_main.py
@@ -1152,11 +1152,48 @@ def test_Window_show_admin():
     mock_admin_display.return_value = mock_admin_box
     with mock.patch('mu.interface.main.AdminDialog', mock_admin_display):
         w = mu.interface.main.Window()
-        result = w.show_admin('log', 'envars')
+        result = w.show_admin('log', 'envars', 'packages')
         mock_admin_display.assert_called_once_with(w)
-        mock_admin_box.setup.assert_called_once_with('log', 'envars')
+        mock_admin_box.setup.assert_called_once_with('log', 'envars',
+                                                     'packages')
         mock_admin_box.exec.assert_called_once_with()
         assert result == 'this is the expected result'
+
+
+def test_Window_show_admin_cancelled():
+    """
+    If the modal dialog for the admin functions is cancelled, ensure an
+    empty dictionary (indicating a "falsey" no change) is returned.
+    """
+    mock_admin_display = mock.MagicMock()
+    mock_admin_box = mock.MagicMock()
+    mock_admin_box.exec.return_value = False
+    mock_admin_display.return_value = mock_admin_box
+    with mock.patch('mu.interface.main.AdminDialog', mock_admin_display):
+        w = mu.interface.main.Window()
+        result = w.show_admin('log', 'envars', 'packages')
+        mock_admin_display.assert_called_once_with(w)
+        mock_admin_box.setup.assert_called_once_with('log', 'envars',
+                                                     'packages')
+        mock_admin_box.exec.assert_called_once_with()
+        assert result == {}
+
+
+def test_Window_sync_packages():
+    """
+    Ensure the expected modal dialog indicating progress of third party package
+    add/removal is displayed with the expected settings.
+    """
+    mock_package_dialog = mock.MagicMock()
+    with mock.patch('mu.interface.main.PackageDialog', mock_package_dialog):
+        w = mu.interface.main.Window()
+        to_remove = {'foo'}
+        to_add = {'bar'}
+        module_dir = 'baz'
+        w.sync_packages(to_remove, to_add, module_dir)
+        dialog = mock_package_dialog()
+        dialog.setup.assert_called_once_with(to_remove, to_add, module_dir)
+        dialog.exec.assert_called_once_with()
 
 
 def test_Window_show_message():

--- a/tests/interface/test_panes.py
+++ b/tests/interface/test_panes.py
@@ -1161,12 +1161,14 @@ def test_PythonProcessPane_start_process_user_enviroment_variables():
         envars = [['name', 'value'], ]
         ppp.start_process('script.py', 'workspace', interactive=False,
                           envars=envars, runner='foo')
-    assert mock_environment.insert.call_count == 3
+    assert mock_environment.insert.call_count == 4
     assert mock_environment.insert.call_args_list[0][0] == ('PYTHONUNBUFFERED',
                                                             '1')
     assert mock_environment.insert.call_args_list[1][0] == ('PYTHONIOENCODING',
                                                             'utf-8')
     assert mock_environment.insert.call_args_list[2][0] == ('name', 'value')
+    assert mock_environment.insert.call_args_list[3][0] == ('PYTHONPATH',
+                                                            ':'.join(sys.path))
 
 
 def test_PythonProcessPane_start_process_darwin_app_pythonpath():
@@ -1194,7 +1196,7 @@ def test_PythonProcessPane_start_process_darwin_app_pythonpath():
         envars = [['name', 'value'], ]
         ppp.start_process('script.py', 'workspace', interactive=False,
                           envars=envars, runner='foo')
-    assert mock_environment.insert.call_count == 4
+    assert mock_environment.insert.call_count == 5
     assert mock_environment.insert.call_args_list[0][0] == ('PYTHONUNBUFFERED',
                                                             '1')
     assert mock_environment.insert.call_args_list[1][0] == ('PYTHONIOENCODING',
@@ -1202,6 +1204,8 @@ def test_PythonProcessPane_start_process_darwin_app_pythonpath():
     assert mock_environment.insert.call_args_list[2][0] == ('PYTHONPATH',
                                                             ':'.join(sys.path))
     assert mock_environment.insert.call_args_list[3][0] == ('name', 'value')
+    assert mock_environment.insert.call_args_list[4][0] == ('PYTHONPATH',
+                                                            ':'.join(sys.path))
 
 
 def test_PythonProcessPane_start_process_custom_runner():

--- a/tests/interface/test_panes.py
+++ b/tests/interface/test_panes.py
@@ -18,7 +18,10 @@ import mu.interface.panes
 # Required so the QWidget tests don't abort with the message:
 # "QWidget: Must construct a QApplication before a QWidget"
 # The QApplication need only be instantiated once.
-app = QApplication([])
+try:
+    app = QApplication([])
+except Exception:
+    pass
 
 
 def test_PANE_ZOOM_SIZES():

--- a/tests/interface/test_panes.py
+++ b/tests/interface/test_panes.py
@@ -18,10 +18,7 @@ import mu.interface.panes
 # Required so the QWidget tests don't abort with the message:
 # "QWidget: Must construct a QApplication before a QWidget"
 # The QApplication need only be instantiated once.
-try:
-    app = QApplication([])
-except Exception:
-    pass
+app = QApplication([])
 
 
 def test_PANE_ZOOM_SIZES():

--- a/tests/interface/test_panes.py
+++ b/tests/interface/test_panes.py
@@ -1167,8 +1167,9 @@ def test_PythonProcessPane_start_process_user_enviroment_variables():
     assert mock_environment.insert.call_args_list[1][0] == ('PYTHONIOENCODING',
                                                             'utf-8')
     assert mock_environment.insert.call_args_list[2][0] == ('name', 'value')
+    expected_path = os.pathsep.join(sys.path)
     assert mock_environment.insert.call_args_list[3][0] == ('PYTHONPATH',
-                                                            ':'.join(sys.path))
+                                                            expected_path)
 
 
 def test_PythonProcessPane_start_process_darwin_app_pythonpath():
@@ -1201,11 +1202,12 @@ def test_PythonProcessPane_start_process_darwin_app_pythonpath():
                                                             '1')
     assert mock_environment.insert.call_args_list[1][0] == ('PYTHONIOENCODING',
                                                             'utf-8')
+    expected_path = os.pathsep.join(sys.path)
     assert mock_environment.insert.call_args_list[2][0] == ('PYTHONPATH',
-                                                            ':'.join(sys.path))
+                                                            expected_path)
     assert mock_environment.insert.call_args_list[3][0] == ('name', 'value')
     assert mock_environment.insert.call_args_list[4][0] == ('PYTHONPATH',
-                                                            ':'.join(sys.path))
+                                                            expected_path)
 
 
 def test_PythonProcessPane_start_process_custom_runner():

--- a/tests/interface/test_panes.py
+++ b/tests/interface/test_panes.py
@@ -1172,44 +1172,6 @@ def test_PythonProcessPane_start_process_user_enviroment_variables():
                                                             expected_path)
 
 
-def test_PythonProcessPane_start_process_darwin_app_pythonpath():
-    """
-    When running on OSX as a packaged mu-editor.app, the PYTHONPATH needs to
-    be set so the child processes have access to the packaged libraries and
-    modules.
-    """
-    mock_process = mock.MagicMock()
-    mock_process_class = mock.MagicMock(return_value=mock_process)
-    mock_merge_chans = mock.MagicMock()
-    mock_process_class.MergedChannels = mock_merge_chans
-    mock_environment = mock.MagicMock()
-    mock_environment_class = mock.MagicMock()
-    mock_environment_class.systemEnvironment.return_value = mock_environment
-    mock_path = mock.MagicMock()
-    mock_path.return_value = ('/Applications/mu-editor.app/'
-                              'Contents/Resources/app/mu')
-    with mock.patch('mu.interface.panes.QProcess', mock_process_class), \
-            mock.patch('mu.interface.panes.QProcessEnvironment',
-                       mock_environment_class), \
-            mock.patch('os.path.dirname', mock_path), \
-            mock.patch('sys.platform', 'darwin'):
-        ppp = mu.interface.panes.PythonProcessPane()
-        envars = [['name', 'value'], ]
-        ppp.start_process('script.py', 'workspace', interactive=False,
-                          envars=envars, runner='foo')
-    assert mock_environment.insert.call_count == 5
-    assert mock_environment.insert.call_args_list[0][0] == ('PYTHONUNBUFFERED',
-                                                            '1')
-    assert mock_environment.insert.call_args_list[1][0] == ('PYTHONIOENCODING',
-                                                            'utf-8')
-    expected_path = os.pathsep.join(sys.path)
-    assert mock_environment.insert.call_args_list[2][0] == ('PYTHONPATH',
-                                                            expected_path)
-    assert mock_environment.insert.call_args_list[3][0] == ('name', 'value')
-    assert mock_environment.insert.call_args_list[4][0] == ('PYTHONPATH',
-                                                            expected_path)
-
-
 def test_PythonProcessPane_start_process_custom_runner():
     """
     Ensure that if the runner is set, it is used as the command to start the

--- a/tests/modes/test_python3.py
+++ b/tests/modes/test_python3.py
@@ -3,6 +3,7 @@
 Tests for the Python3 mode.
 """
 import sys
+import os
 from mu.modes.python3 import PythonMode, KernelRunner
 from mu.modes.api import PYTHON3_APIS, SHARED_APIS, PI_APIS
 from unittest import mock
@@ -22,6 +23,7 @@ def test_kernel_runner_start_kernel():
     kr.kernel_started = mock.MagicMock()
     mock_os = mock.MagicMock()
     mock_os.environ = {}
+    mock_os.pathsep = os.pathsep
     mock_os.path.dirname.return_value = ('/Applications/mu-editor.app'
                                          '/Contents/Resources/app/mu')
     mock_kernel_manager_class = mock.MagicMock()
@@ -33,7 +35,7 @@ def test_kernel_runner_start_kernel():
         kr.start_kernel()
     mock_os.chdir.assert_called_once_with('/a/path/to/mu_code')
     assert mock_os.environ['name'] == 'value'
-    assert mock_os.environ['PYTHONPATH'] == ':'.join(sys.path)
+    assert mock_os.environ['PYTHONPATH'] == os.pathsep.join(sys.path)
     assert kr.repl_kernel_manager == mock_kernel_manager
     mock_kernel_manager_class.assert_called_once_with()
     mock_kernel_manager.start_kernel.assert_called_once_with()

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -77,6 +77,7 @@ def test_run():
 
     class Win(mock.MagicMock):
         load_theme = DumSig()
+        icon = 'icon'
 
     window = Win()
 
@@ -102,7 +103,7 @@ def test_run():
         assert ed.call_count == 1
         assert len(ed.mock_calls) == 3
         assert win.call_count == 1
-        assert len(win.mock_calls) == 11
+        assert len(win.mock_calls) == 6
         assert ex.call_count == 1
         window.load_theme.emit('day')
         qa.assert_has_calls([mock.call().setStyleSheet(DAY_STYLE)])

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -2099,7 +2099,7 @@ def test_show_admin():
     }
     view.show_admin.return_value = new_settings
     mock_open = mock.mock_open()
-    mock_ip = mock.MagicMock(return_value=['foo', 'bar'])
+    mock_ip = mock.MagicMock(return_value=['Foo', 'bar'])
     with mock.patch('builtins.open', mock_open), \
             mock.patch('os.path.isfile', return_value=True), \
             mock.patch('mu.logic.installed_packages', mock_ip):
@@ -2111,6 +2111,7 @@ def test_show_admin():
         assert ed.envars == [['name', 'value']]
         assert ed.minify is True
         assert ed.microbit_runtime == '/foo/bar'
+        # Expect package names to be normalised to lowercase.
         ed.sync_package_state.assert_called_once_with(['foo', 'bar'], ['baz'])
 
 

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -201,8 +201,10 @@ def test_installed_packages():
     mock_open = mock.MagicMock()
     mock_file = mock.MagicMock()
     mock_open().__enter__ = mock.MagicMock(return_value=mock_file)
-    foo_metadata = ["Metadata-Version: 2.1", "Name: foo"]
-    bar_metadata = ["Metadata-Version: 2.1", "Name: bar"]
+    foo_metadata = [b"Metadata-Version: 2.1", b"Name: foo",
+                    b"test: \xe6\x88\x91"]
+    bar_metadata = [b"Metadata-Version: 2.1", b"Name: bar",
+                    b"test: \xe6\x88\x91"]
     mock_file.readlines = mock.MagicMock(side_effect=[foo_metadata,
                                                       bar_metadata])
     with mock.patch('builtins.open', mock_open), \

--- a/win_installer32.cfg
+++ b/win_installer32.cfg
@@ -32,6 +32,7 @@ pypi_wheels=
     parso==0.1.1
     pexpect==4.3.1
     pickleshare==0.7.4
+    pip==18.1
     prompt-toolkit==1.0.15
     ptyprocess==0.5.2
     pycodestyle==2.3.1

--- a/win_installer64.cfg
+++ b/win_installer64.cfg
@@ -32,6 +32,7 @@ pypi_wheels=
     parso==0.1.1
     pexpect==4.3.1
     pickleshare==0.7.4
+    pip==18.1
     prompt-toolkit==1.0.15
     ptyprocess==0.5.2
     pycodestyle==2.3.1


### PR DESCRIPTION
This PR fixes #675.

It has been tested on Linux (Ubuntu 18.04) but not Windows, OSX or Raspberry Pi. **Please give feedback from testing in these environments**.

# What does it do?

This is the simplest possible third party package manager for a beginners' editor. Until now we have bundled a bunch of "third party" modules with Mu in the official installers, thus bloating Mu's size. Furthermore, our bundled modules go out of date and/or miss some important packages for folks. This new functionality allows users to simply specify packages to be installed from PyPI. It also allows users to remove packages.

It is accessed via the "admin" dialog (accessed via the cog on the bottom right of the UI) and is one of the tabs found therein. The following GIF demonstrates it in action:

![mu_modules](https://user-images.githubusercontent.com/37602/51917850-5c4d7900-23d8-11e9-8ba6-16800c9308f0.gif)

The user simply ensures the list of module names (one per line) reflects their requirements. To remove a module from the list, just remove its line. Python's `pip` command (which does the heavy lifting under the hood) will, of course, install dependencies as required. To keep things simple (this is a beginners' editor!) the notion of version number is ignored, and the latest version will be installed by default. Ergo, if a user needs to update a package, they should remove and re-install it.

Currently, there is no attempt to handle conflicts between pre-packaged (in the installer) modules or the same module installed via this method. My hunch is to remove these pre-installed modules in favour of this mechanism. **I would love to hear thoughts on this from folks!**

Packages installed in this way are available in both scripts run or debugged in Python 3 mode, or from within the Python 3 REPL (iPython shell).

# How Does it Work?

There were several ways to skin this cat, and I've gone for the simplest I can think of.

* The new tab for third party packages is added to the admin dialog. If, when the dialog is closed via "OK", there is a change in package state, then a new modal dialog launches to provide visibility of the package syncing process.
* This new package related dialog simply contains a text area into which is piped information from `pip` and other functionality.
* The **recommended way to use pip is by launching it in a subprocess**. The `pip` developers will not guarantee the internal API of the `pip` module. This is why things work the way they do: new packages are added to a list. The first new package is popped from the list and installed via `pip` in a subprocess. When the subprocess completes, if there are any more candidate packages to install, the process is repeated.
* The `--target` flag is used to specify an OS specific writeable directory into which these packages will be installed. This directory is added to the Python path when running or debugging Python 3 scripts or using the Python 3 REPL.
* Sadly, the `pip` command doesn't allow for targetting a "package directory" from which to remove packages. Ergo, Mu uses the list of packages that have been removed in the admin dialog to discover the metadata for them in the directory Mu uses for such packages. Happily, the metadata contains a list of all files related to each package. Mu simply iterates over these, deletes them and deletes any parent directories related to the module to be removed.

That's it! All feedback most welcome!

cc/@asweigart