### PR TITLE
Adds stripped newline to end

### DIFF
--- a/mu/logic.py
+++ b/mu/logic.py
@@ -179,7 +179,7 @@ def save_and_encode(text, filepath, newline=os.linesep):
         encoding = ENCODING
 
     with open(filepath, "w", encoding=encoding, newline='') as f:
-        text_to_write = newline.join(l.rstrip(" ") for l in text.splitlines())
+        text_to_write = newline.join(l.rstrip(" ") for l in text.splitlines()) + newline
         write_and_flush(f, text_to_write)
 
 


### PR DESCRIPTION
I'm not sure if this is the best way to go about it, but it fixes #769. The other behavior (which I think is desirable) is that if the file does not have a newline at the end, this adds it. I edited the .py file in my Mu Editor App folder and tested that this change works.