### PR TITLE
Extra margin: no breakpoint toggle if click slightly leftwards of 1st column.

### DIFF
--- a/tests/interface/test_editor.py
+++ b/tests/interface/test_editor.py
@@ -89,12 +89,12 @@ def test_EditorPane_configure():
     assert ep.setTabWidth.call_count == 1
     assert ep.setEdgeColumn.call_count == 1
     assert ep.setMarginLineNumbers.call_count == 1
-    assert ep.setMarginWidth.call_count == 1
+    assert ep.setMarginWidth.call_count == 2
     assert ep.setBraceMatching.call_count == 1
     assert ep.SendScintilla.call_count == 1
     assert ep.set_theme.call_count == 1
     assert ep.markerDefine.call_count == 1
-    assert ep.setMarginSensitivity.call_count == 2
+    assert ep.setMarginSensitivity.call_count == 3
     assert ep.setIndicatorDrawUnder.call_count == 1
     assert ep.setAnnotationDisplay.call_count == 1
     assert ep.selectionChanged.connect.call_count == 1
@@ -117,7 +117,35 @@ def test_Editor_connect_margin():
     ep = mu.interface.editor.EditorPane('/foo/bar.py', 'baz')
     ep.marginClicked = mock.MagicMock()
     ep.connect_margin(mock_fn)
-    ep.marginClicked.connect.assert_called_once_with(mock_fn)
+    ep.marginClicked.connect.assert_called_once()
+
+
+def test_Editor_connect_margin_ignores_margin_4():
+    """
+    Ensure that the margin click handler is not called if margin 4 is clicked.
+    """
+    mock_fn = mock.MagicMock()
+    ep = mu.interface.editor.EditorPane('/foo/bar.py', 'baz')
+    ep.connect_margin(mock_fn)
+    margin = 4
+    line = 0
+    modifiers = Qt.KeyboardModifiers()
+    ep.marginClicked.emit(margin, line, modifiers)
+    assert mock_fn.call_count == 0
+
+
+def test_Editor_connect_margin_1_works():
+    """
+    Ensure that the margin click handler is called if margin 1 is clicked.
+    """
+    mock_fn = mock.MagicMock()
+    ep = mu.interface.editor.EditorPane('/foo/bar.py', 'baz')
+    ep.connect_margin(mock_fn)
+    margin = 1
+    line = 0
+    modifiers = Qt.KeyboardModifiers()
+    ep.marginClicked.emit(margin, line, modifiers)
+    mock_fn.assert_called_once_with(margin, line, modifiers)
 
 
 def test_EditorPane_set_theme():

--- a/tests/interface/test_editor.py
+++ b/tests/interface/test_editor.py
@@ -117,7 +117,7 @@ def test_Editor_connect_margin():
     ep = mu.interface.editor.EditorPane('/foo/bar.py', 'baz')
     ep.marginClicked = mock.MagicMock()
     ep.connect_margin(mock_fn)
-    ep.marginClicked.connect.assert_called_once()
+    assert ep.marginClicked.connect.call_count == 1
 
 
 def test_Editor_connect_margin_ignores_margin_4():


### PR DESCRIPTION
Submitting this PR for evaluation, in the context of #786.

A few notes from my investigation and about this PR:
* What we see as the left gray area in the editor, with line numbers and the breakpoint marks, is what Scintilla calls margins.
* There can be up to 5 margins: each such margin is a vertical column in that gray area.
* Up until now, Mu is using two such margins: the first containing line numbers (margin number 0), the second containing breakpoint marks (margin number 1).
* This PR adds a third margin (but the last available, margin number 4) with no content and relatively narrow (currently hardcoded to 8 pixels wide).
* The "trick" in this PR is having clicks in that margin "do nothing":
  * By default clicks would highlight/select the whole text line in the editor.
  * This PR sets the margin as "sensitive" such that clicks are handled by the "margin click handler" which is common across all margins, and is itself is wrapped in a filtering handler that discards margin 4 clicks. Thus, margin 0 and 1 clicks still work as before, toggling breakpoints.
