### PR TITLE
#792 - Add help message when starting a debug session

### DIFF
--- a/mu/debugger/runner.py
+++ b/mu/debugger/runner.py
@@ -489,6 +489,9 @@ def run(hostname, port, filename, *args):
     debugger = Debugger(s, hostname, port)
     debugger.reset()
 
+    print("Running in debug mode. Use the Stop, Continue, and Step toolbar"
+          " buttons to debug the script", file=sys.stderr)
+
     while True:
         try:
             debugger._runscript(filename)

--- a/mu/interface/themes.py
+++ b/mu/interface/themes.py
@@ -47,7 +47,7 @@ def should_patch_osx_mojave_font():
 DEFAULT_FONT_SIZE = 14
 # All editor windows use the same font
 if should_patch_osx_mojave_font():  # pragma: no cover
-    logger.warn("Overriding built-in editor font due to Issue #552")
+    logger.debug("Overriding built-in editor font due to Issue #552")
     FONT_NAME = "Monaco"
 else:  # pragma: no cover
     FONT_NAME = "Source Code Pro"


### PR DESCRIPTION
Addresses #792:
* Make the OSX font override warning be a logging.debug message (it's never important) which hides it from the debug console output.
* Add a print to stderr during debugger startup that prints a message to the console
  pointing users to use the Stop/Continue/Step buttons to control execution flow.

Wording of help message is a bit janky, please update as appropriate

Example:
![2019-03-19 23 08 18](https://user-images.githubusercontent.com/704526/54647825-f908ca80-4a9b-11e9-9c8e-3def03596a32.gif)

