### PR TITLE
Fix intermittently failing macOS test.

### DIFF
--- a/tests/interface/test_editor.py
+++ b/tests/interface/test_editor.py
@@ -129,7 +129,7 @@ def test_Editor_connect_margin_ignores_margin_4():
     ep.connect_margin(mock_fn)
     margin = 4
     line = 0
-    modifiers = Qt.KeyboardModifiers()
+    modifiers = Qt.NoModifier
     ep.marginClicked.emit(margin, line, modifiers)
     assert mock_fn.call_count == 0
 
@@ -143,9 +143,16 @@ def test_Editor_connect_margin_1_works():
     ep.connect_margin(mock_fn)
     margin = 1
     line = 0
-    modifiers = Qt.KeyboardModifiers()
+    modifiers = Qt.NoModifier
     ep.marginClicked.emit(margin, line, modifiers)
-    mock_fn.assert_called_once_with(margin, line, modifiers)
+
+    mock_fn.assert_called_once()
+    args, _kwargs = mock_fn.call_args
+    call_margin, call_line, _call_modifiers = args
+    assert margin == call_margin
+    assert line == call_line
+    # Don't assert _call_modifiers value: not used in implementation and seems
+    # to fail intermittently on macOS.
 
 
 def test_EditorPane_set_theme():


### PR DESCRIPTION
PR #787 brought in a test that is failing intermittently on macOS with regards to editor margin click events and possibly associated keyboard modifier keys -- if fails "consistently intermittently" on my dev system, running macOS 10.12. Given that I myself issued that PR, I wonder how I missed it back then... Or maybe something changed? Not sure. :/

This PR changes that test slightly in that the keyboard modifier related information is discarded. Motives:
* Keyboard modifier information is not used by the handler code, in `mu/logic.py`, `Editor.debug_toggle_breakpoint`.
* Allows for a smoother CI ride, helping the evaluation and progress of #779.

Feedback welcome.