### PR TITLE
allow user specify error and warning codes that pycodestyle should ig…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,10 +55,10 @@ pycodestyle:
 	find . \( -name _build -o -name var \) -type d -prune -o -name '*.py' -print0 | $(XARGS) -n 1 pycodestyle --repeat --exclude=package/*,build/*,docs/*,mu/contrib*,mu/modes/api/*,utils/*,venv/*,.vscode/* --ignore=E731,E402,W504
 
 test: clean
-	pytest --random-order
+	pytest -c tests/scripts/codestyle.ini  --random-order
 
 coverage: clean
-	pytest --random-order --cov-config .coveragerc --cov-report term-missing --cov=mu tests/
+	pytest -c tests/scripts/codestyle.ini  --random-order --cov-config .coveragerc --cov-report term-missing --cov=mu tests/
 
 check: clean pycodestyle pyflakes coverage
 

--- a/mu/logic.py
+++ b/mu/logic.py
@@ -447,7 +447,14 @@ def check_pycodestyle(code):
     ignore = ('E121', 'E123', 'E126', 'E226', 'E203', 'E302', 'E305', 'E24',
               'E704', 'W291', 'W292', 'W293', 'W391', 'W503', )
     style = StyleGuide(parse_argv=False, config_file=False)
-    style.options.ignore = ignore
+
+    # StyleGuide() returns pycodestyle module's own ignore list. That list may
+    # be a default list or a custom list provided by the user
+    # merge the above ignore list with StyleGuide() returned list, then
+    # remove duplicates with set(), convert back to tuple()
+    ignore = style.options.ignore + ignore
+    style.options.ignore = tuple(set(ignore))
+
     checker = Checker(code_filename, options=style.options)
     # Re-route stdout to a temporary buffer to be parsed below.
     temp_out = io.StringIO()

--- a/tests/scripts/codestyle.ini
+++ b/tests/scripts/codestyle.ini
@@ -1,0 +1,6 @@
+# this lets us define a custom environment variable for pytest
+# this one is used by the pycodestyle module to tell it where to look
+# for the code style error check override file, "pycodestyle"
+[pytest]
+env =
+	XDG_CONFIG_HOME=tests/scripts

--- a/tests/scripts/pycodestyle
+++ b/tests/scripts/pycodestyle
@@ -1,0 +1,2 @@
+[pycodestyle]
+ignore = E265

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -563,6 +563,29 @@ def test_check_flake_with_builtins():
         mock_check.assert_called_once_with('some code', 'foo.py', mock_r)
 
 
+def test_check_pycodestyle_E121():
+    """
+    Ensure the expected result is generated from the PEP8 style validator.
+    Should ensure we honor a mu internal override of E123 error
+    """
+    code = "mylist = [\n 1, 2,\n 3, 4,\n ]"   # would have Generated E123
+    result = mu.logic.check_pycodestyle(code)
+    assert len(result) == 0
+
+
+def test_check_pycodestyle_custom_override():
+    """
+    Ensure the expected result if generated from the PEP8 style validator.
+    For this test we have overridden the E265 error check via a custom
+    override "pycodestyle" file in a directory pointed to by the content of
+    scripts/codecheck.ini. We should "not" get and E265 error due to the
+    lack of space after the #
+    """
+    code = "# OK\n#this is ok if we override the E265 check\n"
+    result = mu.logic.check_pycodestyle(code)
+    assert len(result) == 0
+
+
 def test_check_pycodestyle():
     """
     Ensure the expected result if generated from the PEP8 style validator.


### PR DESCRIPTION
Changes to allow the user to specify a file to contain a list of error/warning codes which the pycodestyle module should ignore. This to shield new kids from having to deal with code style issues that do not impede functionality. We can re-enable to code style checks when they get more comfortable with the language.

The python module pycodestyle.py does currently support the user supplying an override file, unfortunately a previous code change to mu/logic.py resulted in that functionality being lost. This change pulls that support back in.
The user will need to set and environment variable  "XDG_CONFIG_HOME" which will point to a directory which must contain a file called pycodestyle. This file must contain the following format:
[pycodestyle]
ignore = E265, EXXX

The ignore list needs to contain the list of warnings/errors to be ignored.
We are currently looking at what is required to add an entry to the "Using Mu" section at codewith.mu to describe how  the user can take advantage of this.


Proposed changes to mu:

      modified:   mu/logic.py
                    update to re-enable allowing user to specify a file which contains warning/error numbers that
                    pycodestyle.py module should ignore

Proposed changes to the test framework. We add a test case that confirms the override file works.
A second test case confirms that we still honor a mu internally defined error code override
 
      modified:   Makefile
                    add option, -c, to pytest to provide the location of an environment variable definition file,
                    tests/scripts/codestyle.ini

      new file:   tests/scripts/codestyle.ini
                    contains the environment variable (XDG_CONFIG_HOME) that pytest will set prior to
                    executing test cases. The pycodestyle.py module uses that variable to locate the user
                    defined syntax check override file (pycodestyle)

      new file:   tests/scripts/pycodestyle
                    the user customized syntax check override configuration file used during out test
 
     modified:   tests/test_logic.py
                    updated to add two test cases
                    1. to verify the override file is read to ignore E265
                    2. to verify that mu internally defined overrides are still being honored by verifying
                        E123 is ignored
