### PR TITLE
Issue #780 allow user defined syntax check override

### DIFF
--- a/mu/logic.py
+++ b/mu/logic.py
@@ -431,7 +431,7 @@ def check_flake(filename, code, builtins=None):
     return feedback
 
 
-def check_pycodestyle(code):
+def check_pycodestyle(code, config_file=False):
     """
     Given some code, uses the PyCodeStyle module (was PEP8) to return a list
     of items describing issues of coding style. See:
@@ -446,8 +446,15 @@ def check_pycodestyle(code):
     # Configure which PEP8 rules to ignore.
     ignore = ('E121', 'E123', 'E126', 'E226', 'E203', 'E302', 'E305', 'E24',
               'E704', 'W291', 'W292', 'W293', 'W391', 'W503', )
-    style = StyleGuide(parse_argv=False, config_file=False)
-    style.options.ignore = ignore
+    style = StyleGuide(parse_argv=False, config_file=config_file)
+
+    # StyleGuide() returns pycodestyle module's own ignore list. That list may
+    # be a default list or a custom list provided by the user
+    # merge the above ignore list with StyleGuide() returned list, then
+    # remove duplicates with set(), convert back to tuple()
+    ignore = style.options.ignore + ignore
+    style.options.ignore = tuple(set(ignore))
+
     checker = Checker(code_filename, options=style.options)
     # Re-route stdout to a temporary buffer to be parsed below.
     temp_out = io.StringIO()

--- a/tests/scripts/pycodestyle
+++ b/tests/scripts/pycodestyle
@@ -1,0 +1,2 @@
+[pycodestyle]
+ignore = E265

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -563,6 +563,29 @@ def test_check_flake_with_builtins():
         mock_check.assert_called_once_with('some code', 'foo.py', mock_r)
 
 
+def test_check_pycodestyle_E121():
+    """
+    Ensure the expected result is generated from the PEP8 style validator.
+    Should ensure we honor a mu internal override of E123 error
+    """
+    code = "mylist = [\n 1, 2,\n 3, 4,\n ]"   # would have Generated E123
+    result = mu.logic.check_pycodestyle(code)
+    assert len(result) == 0
+
+
+def test_check_pycodestyle_custom_override():
+    """
+    Ensure the expected result if generated from the PEP8 style validator.
+    For this test we have overridden the E265 error check via a custom
+    override "pycodestyle" file in a directory pointed to by the content of
+    scripts/codecheck.ini. We should "not" get and E265 error due to the
+    lack of space after the #
+    """
+    code = "# OK\n#this is ok if we override the E265 check\n"
+    result = mu.logic.check_pycodestyle(code, "tests/scripts/pycodestyle")
+    assert len(result) == 0
+
+
 def test_check_pycodestyle():
     """
     Ensure the expected result if generated from the PEP8 style validator.


### PR DESCRIPTION
Changes to allow the user to specify a file to contain a list of error/warning codes which the pycodestyle module should ignore when mu's Check button is pressed. This to shield new kids from having to deal with code style issues that do not impede functionality. We can re-enable to code style checks when they get more comfortable with the language.

The python module pycodestyle.py does currently support the user supplying an override file, unfortunately a previous code change to mu/logic.py resulted in that functionality being lost. This change pulls that support back in.

Per the pycodestyle.py module functionality the override file is located via:
   On Linux/Mac there are a couple of methods used: one has the user setting an environment variable
   "XDG_CONFIG_HOME" which will point to a directory which must contain a file called pycodestyle.
   On Windows the file is expected to be in the users home directory "~\\.pycodestyle".

   This file must contain the following format, the ignore list contains the warnings/errors to be ignored:
   [pycodestyle]
   ignore = E265, EXXX

Further pycodestyle module details can be found at 
[]( http://pycodestyle.pycqa.org/en/latest/intro.html#configuration
)http://pycodestyle.pycqa.org/en/latest/intro.html#configuration

We are currently looking at what is required to add an entry to the "Using Mu" section at codewith.mu to describe how  the user can take advantage of this. Any changes there would need to specify what version of mu contains the override support.


Proposed changes to mu:

      modified:   mu/logic.py check_pycodestyle()
       - update to re-enable allowing user to specify a file which contains warning/error numbers
         that pycodestyle.py module should ignore
       - rather than overwrite the ignore list returned from StyleGuide() we merge that list with the 
         internal hard coded mu list

       - in order to execute a test case:
         the pycodestyle module needs to locate the override file per the above mentioned file location
         scheme. Within test case execution we can manage the Linux/Mac environment variable scheme
         with a bit more code but for Windows we cannot expect to add a file to the test process's home
         directory. Fortunately pycodestyle.StyleGuide() supports a parameter "config_file" that can be
         used to pass a path to the override file. Mu currently sets that param to False.
         - so as a workaround we add a second default parameter to logic.py's  check_pycodestyle()
           changing it 
            From:   check_pycodestyle(code)
            To:        check_pycodestyle(code,  config_files=False)
                            
         Thus when we call check_pycodestyle() from the test case, test_logic.py, we can pass
         StyleGuide() a path within the test directory structure where the file is located. During normal mu
         operation the default value of False is passed thus calling StyleGuide() as is done previously
         allowing pycodestyle's to use its normal config file location scheme.

Proposed changes to the test framework. We add a sample override file, one test case that confirms the override file works. Add a second test case to confirm that we still honor one of the mu internally defined error code overrides
 
      new file:   tests/scripts/pycodestyle
                    the user customized syntax check override configuration file used during our test
 
     modified:   tests/test_logic.py
                    updated to add two test cases
                    1. test_check_pycodestyle_custom_override(): verify the override file is read
                        and error E265 is ignored
                    2.  test_check_pycodestyle_E121(): verify that mu internally defined overrides are
                         still being honored by verifying E123 is ignored as expected
