### PR TITLE
added parameter to suppress auto-save error messages

### DIFF
--- a/mu/logic.py
+++ b/mu/logic.py
@@ -905,7 +905,7 @@ class Editor:
                 logger.error('Could not get path for {}: {}'.format(p, ex))
         return result
 
-    def save_tab_to_file(self, tab):
+    def save_tab_to_file(self, tab, show_error_messages=True):
         """
         Given a tab, will attempt to save the script in the tab to the path
         associated with the tab. If there's a problem this will be logged and
@@ -929,7 +929,7 @@ class Editor:
                             "remove it and try again.")
         else:
             error_message = information = None
-        if error_message:
+        if error_message and show_error_messages:
             self._view.show_message(error_message, information)
         else:
             tab.setModified(False)
@@ -1248,7 +1248,8 @@ class Editor:
             # Something has changed, so save it!
             for tab in self._view.widgets:
                 if tab.path and tab.isModified():
-                    self.save_tab_to_file(tab)
+                    # Suppress error message on autosave attempts
+                    self.save_tab_to_file(tab, show_error_messages=False)
                     logger.info('Autosave detected and saved '
                                 'changes in {}.'.format(tab.path))
 


### PR DESCRIPTION
My students keep encountering a strange loop where the editor attempts to auto-save open tabs to paths without permissions. E.g. Macintosh HD or /. They can't change the path, since the timeout is set to 5 seconds by default and the Save As.. dialog box is closed by the error message.

This change adds a show_error_messages parameter to the save_tab_to_file method. The value defaults to True and will preserve existing behavior. Setting this parameter to False causes the error message to be suppressed and keeps the tab marked as modified.