### PR TITLE
ESP-mode: Show current directory in files pane to support multiple projects.

### DIFF
--- a/mu/modes/esp.py
+++ b/mu/modes/esp.py
@@ -21,6 +21,7 @@ from mu.modes.base import MicroPythonMode, FileManager
 from mu.modes.api import ESP_APIS, SHARED_APIS
 from mu.interface.panes import CHARTS
 from PyQt5.QtCore import QThread
+import os
 
 
 logger = logging.getLogger(__name__)
@@ -209,7 +210,14 @@ class ESPMode(MicroPythonMode):
         self.file_manager.moveToThread(self.file_manager_thread)
         self.file_manager_thread.started.\
             connect(self.file_manager.on_start)
-        self.fs = self.view.add_filesystem(self.workspace_dir(),
+
+        # Show directory of the current file in the left pane, if any,
+        # otherwise show the default workspace_dir
+        if self.view.current_tab and self.view.current_tab.path:
+            path = os.path.dirname(os.path.abspath(self.view.current_tab.path))
+        else:
+            path = self.workspace_dir()
+        self.fs = self.view.add_filesystem(path,
                                            self.file_manager,
                                            _("ESP board"))
         self.fs.set_message.connect(self.editor.show_status_message)


### PR DESCRIPTION
This is a fix that allows users to work on multiple projects in the ESP-mode. Currently, the files pane always show the content of the mu_code directory, however, every project must have main.py files and subdirectories are thus necessary to separate projects.

The simple fix in this patch is to show the directory of the file in the current tab, if the current tab is not associated with a file the workspace_dir (i.e. the mu_code directory by default) will be used.

The patch should be seen as a perhaps temporary fix to address the situation, a longer term fix would be to support directories directly in the file manager.