### PR TITLE
Update logger.warn() deprecated method to warning().

### DIFF
--- a/mu/interface/themes.py
+++ b/mu/interface/themes.py
@@ -47,7 +47,7 @@ def should_patch_osx_mojave_font():
 DEFAULT_FONT_SIZE = 14
 # All editor windows use the same font
 if should_patch_osx_mojave_font():  # pragma: no cover
-    logger.warn("Overriding built-in editor font due to Issue #552")
+    logger.warning("Overriding built-in editor font due to Issue #552")
     FONT_NAME = "Monaco"
 else:  # pragma: no cover
     FONT_NAME = "Source Code Pro"


### PR DESCRIPTION
I've been getting this deprecation warning every time I run the tests locally, so this tiny PR updates the method call.

https://docs.python.org/3/library/logging.html#logging.Logger.warning