### PR TITLE
Resources relative to code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,6 @@ target/
 
 # Movie
 *.mp4
+
+# Virtual Environment
+.venv/

--- a/mu/modes/pygamezero.py
+++ b/mu/modes/pygamezero.py
@@ -155,7 +155,8 @@ class PyGameZeroMode(BaseMode):
         This should open the host OS's file system explorer so users can drag
         new files into the opened folder.
         """
-        image_dir = os.path.join(os.path.dirname(self.view.current_tab.path), 'images')
+        image_dir = os.path.join(
+            os.path.dirname(self.view.current_tab.path), 'images')
         self.view.open_directory_from_os(image_dir)
 
     def show_fonts(self, event):
@@ -165,7 +166,8 @@ class PyGameZeroMode(BaseMode):
         This should open the host OS's file system explorer so users can drag
         new files into the opened folder.
         """
-        image_dir = os.path.join(os.path.dirname(self.view.current_tab.path), 'fonts')
+        image_dir = os.path.join(
+            os.path.dirname(self.view.current_tab.path), 'fonts')
         self.view.open_directory_from_os(image_dir)
 
     def show_sounds(self, event):
@@ -175,7 +177,8 @@ class PyGameZeroMode(BaseMode):
         This should open the host OS's file system explorer so users can drag
         new files into the opened folder.
         """
-        sound_dir = os.path.join(os.path.dirname(self.view.current_tab.path), 'sounds')
+        sound_dir = os.path.join(
+            os.path.dirname(self.view.current_tab.path), 'sounds')
         self.view.open_directory_from_os(sound_dir)
 
     def show_music(self, event):
@@ -185,5 +188,6 @@ class PyGameZeroMode(BaseMode):
         This should open the host OS's file system explorer so users can drag
         new files into the opened folder.
         """
-        sound_dir = os.path.join(os.path.dirname(self.view.current_tab.path), 'music')
+        sound_dir = os.path.join(
+            os.path.dirname(self.view.current_tab.path), 'music')
         self.view.open_directory_from_os(sound_dir)

--- a/mu/modes/pygamezero.py
+++ b/mu/modes/pygamezero.py
@@ -185,5 +185,5 @@ class PyGameZeroMode(BaseMode):
         This should open the host OS's file system explorer so users can drag
         new files into the opened folder.
         """
-        sound_dir = os.path.join(self.workspace_dir(), 'music')
+        sound_dir = os.path.join(os.path.dirname(self.view.current_tab.path), 'music')
         self.view.open_directory_from_os(sound_dir)

--- a/mu/modes/pygamezero.py
+++ b/mu/modes/pygamezero.py
@@ -155,7 +155,7 @@ class PyGameZeroMode(BaseMode):
         This should open the host OS's file system explorer so users can drag
         new files into the opened folder.
         """
-        image_dir = os.path.join(self.workspace_dir(), 'images')
+        image_dir = os.path.join(os.path.dirname(self.view.current_tab.path), 'images')
         self.view.open_directory_from_os(image_dir)
 
     def show_fonts(self, event):
@@ -175,7 +175,7 @@ class PyGameZeroMode(BaseMode):
         This should open the host OS's file system explorer so users can drag
         new files into the opened folder.
         """
-        sound_dir = os.path.join(self.workspace_dir(), 'sounds')
+        sound_dir = os.path.join(os.path.dirname(self.view.current_tab.path), 'sounds')
         self.view.open_directory_from_os(sound_dir)
 
     def show_music(self, event):

--- a/mu/modes/pygamezero.py
+++ b/mu/modes/pygamezero.py
@@ -165,7 +165,7 @@ class PyGameZeroMode(BaseMode):
         This should open the host OS's file system explorer so users can drag
         new files into the opened folder.
         """
-        image_dir = os.path.join(self.workspace_dir(), 'fonts')
+        image_dir = os.path.join(os.path.dirname(self.view.current_tab.path), 'fonts')
         self.view.open_directory_from_os(image_dir)
 
     def show_sounds(self, event):

--- a/tests/modes/test_pygamezero.py
+++ b/tests/modes/test_pygamezero.py
@@ -233,7 +233,8 @@ def test_pgzero_show_music():
     """
     editor = mock.MagicMock()
     view = mock.MagicMock()
+    view.current_tab.path = os.path.join(tempfile.gettempdir(), "abc.py")
     pm = PyGameZeroMode(editor, view)
     pm.show_music(None)
-    music_dir = os.path.join(pm.workspace_dir(), 'music')
+    music_dir = os.path.join(os.path.dirname(view.current_tab.path), 'music')
     view.open_directory_from_os.assert_called_once_with(music_dir)

--- a/tests/modes/test_pygamezero.py
+++ b/tests/modes/test_pygamezero.py
@@ -8,6 +8,7 @@ from mu.modes.api import PYTHON3_APIS, SHARED_APIS, PI_APIS, PYGAMEZERO_APIS
 from unittest import mock
 import tempfile
 
+
 def test_pgzero_mode():
     """
     Sanity check for setting up of the mode.

--- a/tests/modes/test_pygamezero.py
+++ b/tests/modes/test_pygamezero.py
@@ -6,7 +6,7 @@ import os.path
 from mu.modes.pygamezero import PyGameZeroMode
 from mu.modes.api import PYTHON3_APIS, SHARED_APIS, PI_APIS, PYGAMEZERO_APIS
 from unittest import mock
-
+import tempfile
 
 def test_pgzero_mode():
     """
@@ -206,9 +206,10 @@ def test_pgzero_show_fonts():
     """
     editor = mock.MagicMock()
     view = mock.MagicMock()
+    view.current_tab.path = os.path.join(tempfile.gettempdir(), "abc.py")
     pm = PyGameZeroMode(editor, view)
     pm.show_fonts(None)
-    fonts_dir = os.path.join(pm.workspace_dir(), 'fonts')
+    fonts_dir = os.path.join(os.path.dirname(view.current_tab.path), 'fonts')
     view.open_directory_from_os.assert_called_once_with(fonts_dir)
 
 

--- a/tests/modes/test_pygamezero.py
+++ b/tests/modes/test_pygamezero.py
@@ -194,9 +194,10 @@ def test_pgzero_show_images():
     """
     editor = mock.MagicMock()
     view = mock.MagicMock()
+    view.current_tab.path = os.path.join(tempfile.gettempdir(), "abc.py")
     pm = PyGameZeroMode(editor, view)
     pm.show_images(None)
-    image_dir = os.path.join(pm.workspace_dir(), 'images')
+    image_dir = os.path.join(os.path.dirname(view.current_tab.path), 'images')
     view.open_directory_from_os.assert_called_once_with(image_dir)
 
 
@@ -219,9 +220,10 @@ def test_pgzero_show_sounds():
     """
     editor = mock.MagicMock()
     view = mock.MagicMock()
+    view.current_tab.path = os.path.join(tempfile.gettempdir(), "abc.py")
     pm = PyGameZeroMode(editor, view)
     pm.show_sounds(None)
-    sounds_dir = os.path.join(pm.workspace_dir(), 'sounds')
+    sounds_dir = os.path.join(os.path.dirname(view.current_tab.path), 'sounds')
     view.open_directory_from_os.assert_called_once_with(sounds_dir)
 
 


### PR DESCRIPTION
This change addresses issue #821 which is a necessary follow-on from the fact that you can load code from arbitrary directories outside or below the `mu_code` workspace directory combined with the fact that pygamezero expects its `images/` etc. directories to be relative to the code being run. (Strictly: relative to the current working directory).

Originally mu_code was the only recognised location for code files, so the `images/` `sounds/` etc. directories were expected to be statically `<workspace>/images` etc. Now that code can be loaded from any directory, the images, sounds etc. will be in different places depending on which file is active.

Therefore the [Images] button etc. need to open a folder relative to the code file being viewed.