### PR TITLE
Use rtds logo in README.rst and PyPI description.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 Mu - A Simple Python Code Editor 
 ================================
 
-.. image:: https://raw.githubusercontent.com/mu-editor/mu/master/docs/logo.png
+.. image:: https://mu.readthedocs.io/en/latest/_images/logo.png
 
 Mu is a simple code editor for beginner programmers based on extensive feedback
 from teachers and learners. Having said that, Mu is for anyone who wants to use

--- a/setup.py
+++ b/setup.py
@@ -15,9 +15,6 @@ with open(os.path.join(base_dir, 'mu', '__init__.py'), encoding='utf8') as f:
 
 with open(os.path.join(base_dir, 'README.rst'), encoding='utf8') as f:
     readme = f.read()
-    # Replace the logo URL in the README with something that works in PyPI
-    logo_url = 'https://mu.readthedocs.io/en/latest/_images/logo.png'
-    readme = readme.replace('docs/logo.png', logo_url)
 
 with open(os.path.join(base_dir, 'CHANGES.rst'), encoding='utf8') as f:
     changes = f.read()


### PR DESCRIPTION
The README file used to display the logo with a `docs/logo.png` relative URL. Then the setup.py would read the file, and replaced that string to a full URL for the PyPI description.

In commit 9997963eda1e4dc3c0a8a3d3be7cd93728aedb19 this was updated to a URL using raw.githubusercontent.com. The setup.py file was not updated, so the PyPI descriptions ends up with a malformed URL:
<img width="565" alt="image" src="https://user-images.githubusercontent.com/4189262/60615951-3fbece00-9dc8-11e9-9b38-5b167d5771ad.png">

Now that Read The Docs is configured to publish on each commit, the https://mu.readthedocs.io/en/latest/_images/logo.png URL used in setup.py should reflect the logo from master (as raw.githubusercontent.com did), so we can just use that URL in the README and remove that bit from the setup.py file.