### PR TITLE
#880 Toggle comments fixes

### DIFF
--- a/mu/interface/editor.py
+++ b/mu/interface/editor.py
@@ -553,7 +553,7 @@ class EditorPane(QsciScintilla):
             self.replaceSelectedText(new_text)
             # Ensure the new text is also selected.
             last_newline = toggled_lines[-1]
-            last_oldline = lines[-1].strip()
+            last_oldline = lines[-1]
 
             # Adjust the selection based on whether the last line got
             # longer, shorter, or stayed the same

--- a/mu/interface/editor.py
+++ b/mu/interface/editor.py
@@ -521,18 +521,19 @@ class EditorPane(QsciScintilla):
         Given a raw_line, will return the toggled version of it.
         """
         clean_line = raw_line.strip()
+        if not clean_line or clean_line.startswith('##'):
+            # Ignore whitespace-only lines and compact multi-commented lines
+            return raw_line
+
         if clean_line.startswith('#'):
-            # It's a comment line, so handle "# " & "#..." as fallback:
+            # It's a comment line, so replace only the first "# " or "#":
             if clean_line.startswith('# '):
-                return raw_line.replace('# ', '')
+                return raw_line.replace('# ', '', 1)
             else:
-                return raw_line.replace('#', '')
-        elif clean_line:
+                return raw_line.replace('#', '', 1)
+        else:
             # It's a normal line of code.
             return '# ' + raw_line
-        else:
-            # It's a whitespace line, so just return it.
-            return raw_line
 
     def toggle_comments(self):
         """
@@ -553,14 +554,11 @@ class EditorPane(QsciScintilla):
             # Ensure the new text is also selected.
             last_newline = toggled_lines[-1]
             last_oldline = lines[-1].strip()
-            if last_newline.startswith('#'):
-                index_to += 2  # A newly commented line starts... "# "
-            elif last_oldline.startswith('#'):
-                # Check the original line to see what has been uncommented.
-                if last_oldline.startswith('# '):
-                    index_to -= 2  # It was "# ".
-                else:
-                    index_to -= 1  # It was "#".
+
+            # Adjust the selection based on whether the last line got
+            # longer, shorter, or stayed the same
+            delta = len(last_newline) - len(last_oldline)
+            index_to += delta
             self.setSelection(line_from, index_from, line_to, index_to)
         else:
             # Toggle the line currently containing the cursor.

--- a/tests/interface/test_editor.py
+++ b/tests/interface/test_editor.py
@@ -803,6 +803,40 @@ def test_EditorPane_toggle_comments_selected_hash_space_comment_lines():
     ep.setSelection.assert_called_once_with(0, 0, 2, 2)
 
 
+def test_EditorPane_toggle_comments_selected_spaces_before_comment_mark():
+    """
+    Check commented lines starting with "# " are now uncommented and on the
+    last line selection ends at "baz" when there are spaces before the comment
+    mark.
+    """
+    ep = mu.interface.editor.EditorPane(None, '# foo\n# bar\n    # baz')
+    ep.hasSelectedText = mock.MagicMock(return_value=True)
+    ep.getSelection = mock.MagicMock(return_value=(0, 0, 2, 6))
+    ep.selectedText = mock.MagicMock(return_value='# foo\n# bar\n    # baz')
+    ep.replaceSelectedText = mock.MagicMock()
+    ep.setSelection = mock.MagicMock()
+    ep.toggle_comments()
+    ep.replaceSelectedText.assert_called_once_with('foo\nbar\n    baz')
+    ep.setSelection.assert_called_once_with(0, 0, 2, 4)
+
+
+def test_EditorPane_toggle_comments_selected_spaces_after_comment_mark():
+    """
+    Check commented lines starting with "# " are now uncommented and on the
+    last line selection ends at "baz" when there are spaces between the comment
+    mark and the text.
+    """
+    ep = mu.interface.editor.EditorPane(None, '# foo\n# bar\n#     baz')
+    ep.hasSelectedText = mock.MagicMock(return_value=True)
+    ep.getSelection = mock.MagicMock(return_value=(0, 0, 2, 6))
+    ep.selectedText = mock.MagicMock(return_value='# foo\n# bar\n#     baz')
+    ep.replaceSelectedText = mock.MagicMock()
+    ep.setSelection = mock.MagicMock()
+    ep.toggle_comments()
+    ep.replaceSelectedText.assert_called_once_with('foo\nbar\n    baz')
+    ep.setSelection.assert_called_once_with(0, 0, 2, 4)
+
+
 def test_EditorPane_toggle_comments_selection_follows_len_change():
     """
     Check commented lines starting with "# " are now uncommented one level and

--- a/tests/interface/test_editor.py
+++ b/tests/interface/test_editor.py
@@ -695,6 +695,15 @@ def test_EditorPane_toggle_line_starts_with_hash_space():
     assert ep.toggle_line('    # foo') == '    foo'
 
 
+def test_EditorPane_toggle_line_preserves_embedded_comment():
+    """
+    If the line being un-commented has a trailing comment, only the first
+    comment marker should be removed.
+    """
+    ep = mu.interface.editor.EditorPane(None, 'baz')
+    assert ep.toggle_line('    # foo # comment') == '    foo # comment'
+
+
 def test_EditorPane_toggle_line_normal_line():
     """
     If the line is an uncommented line of text, then comment it with hash-space
@@ -719,6 +728,16 @@ def test_EditorPane_toggle_line_whitespace_line():
     """
     ep = mu.interface.editor.EditorPane(None, 'baz')
     assert ep.toggle_line('    ') == '    '
+
+
+def test_EditorPane_toggle_line_preserves_multi_comment():
+    """
+    If the line starts with two or more "#" together, then return it as-is.
+    """
+    ep = mu.interface.editor.EditorPane(None, 'baz')
+    assert ep.toggle_line('## double') == '## double'
+    assert ep.toggle_line('    ## space-double') == '    ## space-double'
+    assert ep.toggle_line('    ### triplet') == '    ### triplet'
 
 
 def test_EditorPane_toggle_comments_no_selection():
@@ -782,6 +801,23 @@ def test_EditorPane_toggle_comments_selected_hash_space_comment_lines():
     ep.toggle_comments()
     ep.replaceSelectedText.assert_called_once_with('foo\nbar\nbaz')
     ep.setSelection.assert_called_once_with(0, 0, 2, 2)
+
+
+def test_EditorPane_toggle_comments_selection_follows_len_change():
+    """
+    Check commented lines starting with "# " are now uncommented one level and
+    selection adjustment doesn't assume lines starting with "# " had comment
+    markers added instead of removed.
+    """
+    ep = mu.interface.editor.EditorPane(None, '# foo\n# bar\n# # baz')
+    ep.hasSelectedText = mock.MagicMock(return_value=True)
+    ep.getSelection = mock.MagicMock(return_value=(0, 0, 2, 6))
+    ep.selectedText = mock.MagicMock(return_value='# foo\n# bar\n# # baz')
+    ep.replaceSelectedText = mock.MagicMock()
+    ep.setSelection = mock.MagicMock()
+    ep.toggle_comments()
+    ep.replaceSelectedText.assert_called_once_with('foo\nbar\n# baz')
+    ep.setSelection.assert_called_once_with(0, 0, 2, 4)
 
 
 def test_EditorPane_wheelEvent():


### PR DESCRIPTION
Toggling comments should preserve embedded comments, should not change compact multi-marked comments, and selection should track actual change; includes tests.  Fixes issue #880