### PR TITLE
[INCOMPLETE] 881 crash opening assets

### DIFF
--- a/mu/modes/pygamezero.py
+++ b/mu/modes/pygamezero.py
@@ -155,7 +155,7 @@ class PyGameZeroMode(BaseMode):
         This should open the host OS's file system explorer so users can drag
         new files into the opened folder.
         """
-        if self.view.current_tab.path:
+        if self.view.current_tab and self.view.current_tab.path:
             base_dir = os.path.dirname(self.view.current_tab.path)
         else:
             base_dir = self.workspace_dir()
@@ -169,7 +169,7 @@ class PyGameZeroMode(BaseMode):
         This should open the host OS's file system explorer so users can drag
         new files into the opened folder.
         """
-        if self.view.current_tab.path:
+        if self.view.current_tab and self.view.current_tab.path:
             base_dir = os.path.dirname(self.view.current_tab.path)
         else:
             base_dir = self.workspace_dir()
@@ -183,7 +183,7 @@ class PyGameZeroMode(BaseMode):
         This should open the host OS's file system explorer so users can drag
         new files into the opened folder.
         """
-        if self.view.current_tab.path:
+        if self.view.current_tab and self.view.current_tab.path:
             base_dir = os.path.dirname(self.view.current_tab.path)
         else:
             base_dir = self.workspace_dir()
@@ -197,7 +197,7 @@ class PyGameZeroMode(BaseMode):
         This should open the host OS's file system explorer so users can drag
         new files into the opened folder.
         """
-        if self.view.current_tab.path:
+        if self.view.current_tab and self.view.current_tab.path:
             base_dir = os.path.dirname(self.view.current_tab.path)
         else:
             base_dir = self.workspace_dir()

--- a/mu/modes/pygamezero.py
+++ b/mu/modes/pygamezero.py
@@ -148,6 +148,26 @@ class PyGameZeroMode(BaseMode):
             self.runner = None
         self.view.remove_python_runner()
 
+    def assets_dir(self, asset_type):
+        """Determine (and create) the directory for a set of assets
+
+        This supports the [Images] and [Sounds] &c. buttons in pygamezero
+        mode and possibly other modes, too.
+
+        If a tab is current and has an active file, the assets directory
+        is looked for under that path; otherwise the workspace directory
+        is used.
+
+        If the assets directory does not exist it is created
+        """
+        if self.view.current_tab and self.view.current_tab.path:
+            base_dir = os.path.dirname(self.view.current_tab.path)
+        else:
+            base_dir = self.workspace_dir()
+        assets_dir = os.path.join(base_dir, asset_type)
+        os.makedirs(assets_dir, exist_ok=True)
+        return assets_dir
+
     def show_images(self, event):
         """
         Open the directory containing the image assets used by PyGame Zero.
@@ -155,12 +175,7 @@ class PyGameZeroMode(BaseMode):
         This should open the host OS's file system explorer so users can drag
         new files into the opened folder.
         """
-        if self.view.current_tab and self.view.current_tab.path:
-            base_dir = os.path.dirname(self.view.current_tab.path)
-        else:
-            base_dir = self.workspace_dir()
-        image_dir = os.path.join(base_dir, 'images')
-        self.view.open_directory_from_os(image_dir)
+        self.view.open_directory_from_os(self.assets_dir("images"))
 
     def show_fonts(self, event):
         """
@@ -169,12 +184,7 @@ class PyGameZeroMode(BaseMode):
         This should open the host OS's file system explorer so users can drag
         new files into the opened folder.
         """
-        if self.view.current_tab and self.view.current_tab.path:
-            base_dir = os.path.dirname(self.view.current_tab.path)
-        else:
-            base_dir = self.workspace_dir()
-        image_dir = os.path.join(base_dir, 'fonts')
-        self.view.open_directory_from_os(image_dir)
+        self.view.open_directory_from_os(self.assets_dir("fonts"))
 
     def show_sounds(self, event):
         """
@@ -183,12 +193,7 @@ class PyGameZeroMode(BaseMode):
         This should open the host OS's file system explorer so users can drag
         new files into the opened folder.
         """
-        if self.view.current_tab and self.view.current_tab.path:
-            base_dir = os.path.dirname(self.view.current_tab.path)
-        else:
-            base_dir = self.workspace_dir()
-        sound_dir = os.path.join(base_dir, 'sounds')
-        self.view.open_directory_from_os(sound_dir)
+        self.view.open_directory_from_os(self.assets_dir("sounds"))
 
     def show_music(self, event):
         """
@@ -197,9 +202,4 @@ class PyGameZeroMode(BaseMode):
         This should open the host OS's file system explorer so users can drag
         new files into the opened folder.
         """
-        if self.view.current_tab and self.view.current_tab.path:
-            base_dir = os.path.dirname(self.view.current_tab.path)
-        else:
-            base_dir = self.workspace_dir()
-        music_dir = os.path.join(base_dir, 'music')
-        self.view.open_directory_from_os(music_dir)
+        self.view.open_directory_from_os(self.assets_dir("music"))

--- a/mu/modes/pygamezero.py
+++ b/mu/modes/pygamezero.py
@@ -155,8 +155,11 @@ class PyGameZeroMode(BaseMode):
         This should open the host OS's file system explorer so users can drag
         new files into the opened folder.
         """
-        image_dir = os.path.join(
-            os.path.dirname(self.view.current_tab.path), 'images')
+        if self.view.current_tab.path:
+            base_dir = os.path.dirname(self.view.current_tab.path)
+        else:
+            base_dir = self.workspace_dir()
+        image_dir = os.path.join(base_dir, 'images')
         self.view.open_directory_from_os(image_dir)
 
     def show_fonts(self, event):
@@ -166,8 +169,11 @@ class PyGameZeroMode(BaseMode):
         This should open the host OS's file system explorer so users can drag
         new files into the opened folder.
         """
-        image_dir = os.path.join(
-            os.path.dirname(self.view.current_tab.path), 'fonts')
+        if self.view.current_tab.path:
+            base_dir = os.path.dirname(self.view.current_tab.path)
+        else:
+            base_dir = self.workspace_dir()
+        image_dir = os.path.join(base_dir, 'fonts')
         self.view.open_directory_from_os(image_dir)
 
     def show_sounds(self, event):
@@ -177,8 +183,11 @@ class PyGameZeroMode(BaseMode):
         This should open the host OS's file system explorer so users can drag
         new files into the opened folder.
         """
-        sound_dir = os.path.join(
-            os.path.dirname(self.view.current_tab.path), 'sounds')
+        if self.view.current_tab.path:
+            base_dir = os.path.dirname(self.view.current_tab.path)
+        else:
+            base_dir = self.workspace_dir()
+        sound_dir = os.path.join(base_dir, 'sounds')
         self.view.open_directory_from_os(sound_dir)
 
     def show_music(self, event):
@@ -188,6 +197,9 @@ class PyGameZeroMode(BaseMode):
         This should open the host OS's file system explorer so users can drag
         new files into the opened folder.
         """
-        sound_dir = os.path.join(
-            os.path.dirname(self.view.current_tab.path), 'music')
-        self.view.open_directory_from_os(sound_dir)
+        if self.view.current_tab.path:
+            base_dir = os.path.dirname(self.view.current_tab.path)
+        else:
+            base_dir = self.workspace_dir()
+        music_dir = os.path.join(base_dir, 'music')
+        self.view.open_directory_from_os(music_dir)

--- a/tests/modes/test_pygamezero.py
+++ b/tests/modes/test_pygamezero.py
@@ -208,7 +208,7 @@ def test_pgzero_show_images_no_file():
     """
     editor = mock.MagicMock()
     view = mock.MagicMock()
-    view.current_tab.path = None
+    view.current_tab = None
     pm = PyGameZeroMode(editor, view)
     pm.show_images(None)
     image_dir = os.path.join(pm.workspace_dir(), 'images')
@@ -234,7 +234,7 @@ def test_pgzero_show_fonts_no_file():
     """
     editor = mock.MagicMock()
     view = mock.MagicMock()
-    view.current_tab.path = None
+    view.current_tab = None
     pm = PyGameZeroMode(editor, view)
     pm.show_fonts(None)
     font_dir = os.path.join(pm.workspace_dir(), 'fonts')
@@ -260,7 +260,7 @@ def test_pgzero_show_sounds_no_file():
     """
     editor = mock.MagicMock()
     view = mock.MagicMock()
-    view.current_tab.path = None
+    view.current_tab = None
     pm = PyGameZeroMode(editor, view)
     pm.show_sounds(None)
     sound_dir = os.path.join(pm.workspace_dir(), 'sounds')
@@ -286,7 +286,7 @@ def test_pgzero_show_music_no_file():
     """
     editor = mock.MagicMock()
     view = mock.MagicMock()
-    view.current_tab.path = None
+    view.current_tab = None
     pm = PyGameZeroMode(editor, view)
     pm.show_music(None)
     music_dir = os.path.join(pm.workspace_dir(), 'music')

--- a/tests/modes/test_pygamezero.py
+++ b/tests/modes/test_pygamezero.py
@@ -202,6 +202,19 @@ def test_pgzero_show_images():
     view.open_directory_from_os.assert_called_once_with(image_dir)
 
 
+def test_pgzero_show_images_no_file():
+    """
+    Run the OS file explorer for the workspace if no file is current.
+    """
+    editor = mock.MagicMock()
+    view = mock.MagicMock()
+    view.current_tab.path = None
+    pm = PyGameZeroMode(editor, view)
+    pm.show_images(None)
+    image_dir = os.path.join(pm.workspace_dir(), 'images')
+    view.open_directory_from_os.assert_called_once_with(image_dir)
+
+
 def test_pgzero_show_fonts():
     """
     The view is called to run the OS's file explorer for the given fonts path.
@@ -213,6 +226,19 @@ def test_pgzero_show_fonts():
     pm.show_fonts(None)
     fonts_dir = os.path.join(os.path.dirname(view.current_tab.path), 'fonts')
     view.open_directory_from_os.assert_called_once_with(fonts_dir)
+
+
+def test_pgzero_show_fonts_no_file():
+    """
+    Run the OS file explorer for the workspace if no file is current.
+    """
+    editor = mock.MagicMock()
+    view = mock.MagicMock()
+    view.current_tab.path = None
+    pm = PyGameZeroMode(editor, view)
+    pm.show_fonts(None)
+    font_dir = os.path.join(pm.workspace_dir(), 'fonts')
+    view.open_directory_from_os.assert_called_once_with(font_dir)
 
 
 def test_pgzero_show_sounds():
@@ -228,6 +254,19 @@ def test_pgzero_show_sounds():
     view.open_directory_from_os.assert_called_once_with(sounds_dir)
 
 
+def test_pgzero_show_sounds_no_file():
+    """
+    Run the OS file explorer for the workspace if no file is current.
+    """
+    editor = mock.MagicMock()
+    view = mock.MagicMock()
+    view.current_tab.path = None
+    pm = PyGameZeroMode(editor, view)
+    pm.show_sounds(None)
+    sound_dir = os.path.join(pm.workspace_dir(), 'sounds')
+    view.open_directory_from_os.assert_called_once_with(sound_dir)
+
+
 def test_pgzero_show_music():
     """
     The view is called to run the OS's file explorer for the given music path.
@@ -238,4 +277,17 @@ def test_pgzero_show_music():
     pm = PyGameZeroMode(editor, view)
     pm.show_music(None)
     music_dir = os.path.join(os.path.dirname(view.current_tab.path), 'music')
+    view.open_directory_from_os.assert_called_once_with(music_dir)
+
+
+def test_pgzero_show_music_no_file():
+    """
+    Run the OS file explorer for the workspace if no file is current.
+    """
+    editor = mock.MagicMock()
+    view = mock.MagicMock()
+    view.current_tab.path = None
+    pm = PyGameZeroMode(editor, view)
+    pm.show_music(None)
+    music_dir = os.path.join(pm.workspace_dir(), 'music')
     view.open_directory_from_os.assert_called_once_with(music_dir)


### PR DESCRIPTION
I'm pushing what's there now, which fixes the immediate issue. 

But it raises another: we are now opening an images / sounds etc. folder under the directory which the source code is in, that folder might well not exist. Do we:

(a) Create it automatically and then open it

(b) Default to the workspace dir as we do when there's not file open

(c) Something else (eg raise a specific dialog-box error warning of the situation)

My preference is for (a) because: from a teacher's perspective, it's the easiest thing to do; and it doesn't seem as though it would introduce any problems even if it is slightly magical.

Thoughts?