### PR TITLE
Don't remove `mu_editor.egg-info` on make clean: breaks editable installs.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,6 @@ clean:
 	rm -rf macOS
 	rm -rf *.mp4
 	rm -rf .git/avatar/*
-	rm -rf mu_editor.egg-info
 	find . \( -name '*.py[co]' -o -name dropin.cache \) -delete
 	find . \( -name '*.bak' -o -name dropin.cache \) -delete
 	find . \( -name '*.tgz' -o -name dropin.cache \) -delete


### PR DESCRIPTION
Addresses #896.

Interestingly, the Windows `make.py` counterpart does not remove it. Go figure! :)