### PR TITLE
DO NOT MERGE - Feedback, comments and critique please..!

### DIFF
--- a/mu/interface/editor.py
+++ b/mu/interface/editor.py
@@ -82,6 +82,7 @@ class EditorPane(QsciScintilla):
 
     # Signal fired when a script or hex is droped on this editor
     open_file = pyqtSignal(str)
+    code_selected = pyqtSignal(int, int)
 
     def __init__(self, path, text, newline=NEWLINE):
         super().__init__()
@@ -515,6 +516,7 @@ class EditorPane(QsciScintilla):
             # Highlight matches
             self.reset_search_indicators()
             self.highlight_selected_matches()
+            self.code_selected.emit(line_from, line_to)
 
     def toggle_line(self, raw_line):
         """


### PR DESCRIPTION
I was in Boston at Tufts university earlier this week and was able to get feedback about how university level beginner developers find using Mu. One of the most interesting suggestions made was the ability to copy-and-paste code from the main editor window into the live REPL. This isn't the first time this feature has been requested (I seem to remember it being mentioned in a long distant micro:bit-only days), but there was a particularly compelling use case which made me go "aha!":

Chris Rogers (a professor in the engineering school) explained how being able to highlight a section of interesting code and have only that code evaluated, one line at a time, in the REPL was a really helpful way of debugging and watching things unfold, especially if the code is run on a MicroPython based board (where the graphical debugger won't work).

![repl_demo](https://user-images.githubusercontent.com/37602/61967727-00059380-afce-11e9-8332-11b6f8b1e15d.gif)

So, I've quickly bodged together a very simple proof of concept (see the diff) which gives you a sense of what I think Chris means. It is buggy, has no tests and is incomplete (see TODO in the code). However, I believe it shows promise and would love feedback, comments and constructive critique with a view to finding a consensus for what things should be named, how things should work and the scope of this potential feature. As always, I'm not precious about my code or suggestions, so please don't hesitate to knock holes in what I'm suggesting.

Open questions in my mind's eye:

* What should be written on the button in the REPL pane so it is both short and makes sense? ;-)
* What should happen if no code is selected in the main editor? Run it all, or simply run nothing?
* Un-indenting (or dedenting (or whatever the opposite of indenting is)) should happen automatically to code which may be copied from within an existing block of code... discuss...
* This may appear to be a sort of duplication of the Run button in the ESP mode... I wonder if / how we can consolidate such a potential overlap? (Would love to hear your thoughts on this @dybber)
* Since this is a feature of the REPL pane, it's featured across all modes that have a REPL. I wonder, since we're discussing this, what other universal REPL-ish interactions may be helpful / useful (the opposite sort of action -- copy all REPL based commands to editor pane -- immediately springs to mind).

In any case, this is a proof of concept with a view to encouraging debate to arrive at a consensus. Would love to hear your thoughts..!