### PR TITLE
Fix dev docs quickstart: update venv pip + works on Windows.

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -29,17 +29,17 @@ Clone the repository::
 
     git clone https://github.com/mu-editor/mu.git
 
-(Recommended) Upgrade local pip::
+Create a virtualenv and activate it. Then, upgrade ``pip``::
 
-    pip install --upgrade pip
+    python -m pip install --upgrade pip
 
-Make a virtualenv, then install the requirements::
+Install Mu and its development dependencies::
 
     pip install -e ".[dev]"
 
 Start Mu::
 
-    python run.py
+    mu-editor
 
 Run the test suite::
 


### PR DESCRIPTION
While reviewing open issues, I found out that closing #857 depended on minor fixes to the dev docs. Here they are, based on my notes [in this comment, here](https://github.com/mu-editor/mu/issues/857#issuecomment-509196666).

PS: The actual fix for #857 was actually the #879, but the follow-up #884 doc update is pointless in that it proposes i) updating system `pip` (irrelevant when venvs are in use, and bound to fail due to permissions) and ii) doing it in a non-Windows friendly way.