### PR TITLE
Travis: Add Python 3.5 tests without checker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,11 @@ matrix:
       dist: xenial 
       sudo: required
       language: python
+      python: 3.5
+    - os: linux
+      dist: xenial 
+      sudo: required
+      language: python
       python: 3.6
     - os: linux
       dist: xenial
@@ -49,8 +54,9 @@ install:
   - pip freeze
 
 script:
-  # Run the tests on the Linux platform: needs "X Virtual Framebuffer".
-  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then xvfb-run make check; fi
+  # For Linux run only the tests on 3.5 and the full checker elsewhere, all need the "X Virtual Framebuffer"
+  - if [ "$TRAVIS_OS_NAME" = "linux" ] && [ "$TRAVIS_PYTHON_VERSION" = "3.5" ]; then xvfb-run make coverage; fi
+  - if [ "$TRAVIS_OS_NAME" = "linux" ] && [ "$TRAVIS_PYTHON_VERSION" != "3.5" ]; then xvfb-run make check; fi
   - make clean
 
   # Run the tests on macOS and package it: "make macos" runs checks+tests first.


### PR DESCRIPTION
Assuming Mu still supports Python 3.5, it'll be good to continue running the tests in Python 3.5, in case Python 3.6 features accidentally sneak into the codebase.

Since Black is 3.6+, the 3.5 environment runs `make coverage` only.