### PR TITLE
Update deps and fix Black

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,9 +64,19 @@ tidy: clean
 	black -l 79 mu 
 	black -l 79 package 
 	black -l 79 tests
-	black -l 79 utils 
+	black -l 79 utils
 
-check: clean tidy flake8 coverage
+black: clean
+	@echo "\nChecking code with black..."
+	black --check -l 79 setup.py 
+	black --check -l 79 win_installer.py
+	black --check -l 79 make.py
+	black --check -l 79 mu 
+	black --check -l 79 package 
+	black --check -l 79 tests
+	black --check -l 79 utils
+
+check: clean black flake8 coverage
 
 dist: check
 	@echo "\nChecks pass, good to package..."

--- a/make.py
+++ b/make.py
@@ -167,11 +167,33 @@ def tidy():
 
 
 @export
+def black():
+    """Check code with the 'black' formatter.
+    """
+    print("\nTidy")
+    for target in [
+        "setup.py",
+        "win_installer.py",
+        "make.py",
+        "mu",
+        "package",
+        "tests",
+        "utils",
+    ]:
+        return_code = subprocess.run(
+            [TIDY, "--check", "-l", "79", target]
+        ).returncode
+        if return_code != 0:
+            return return_code
+    return 0
+
+
+@export
 def check():
     """Run all the checkers and tests
     """
     print("\nCheck")
-    funcs = [clean, tidy, flake8, coverage]
+    funcs = [clean, black, flake8, coverage]
     for func in funcs:
         return_code = func()
         if return_code != 0:

--- a/setup.py
+++ b/setup.py
@@ -21,9 +21,9 @@ with open(os.path.join(base_dir, "CHANGES.rst"), encoding="utf8") as f:
 
 
 install_requires = [
-    'PyQt5 = 5.13.1;"arm" not in platform_machine',
-    'QScintilla = 2.11.2;"arm" not in platform_machine',
-    'PyQtChart = 5.13.0;"arm" not in platform_machine',
+    'PyQt5 == 5.13.1;"arm" not in platform_machine',
+    'QScintilla == 2.11.2;"arm" not in platform_machine',
+    'PyQtChart == 5.13.0;"arm" not in platform_machine',
     # `flake8` is actually a testing/packaging dependency that, among other
     # packages, brings in `pycodestyle` and `pyflakes` which are runtime
     # dependencies. For the sake of "locality", it is being declared here,
@@ -38,7 +38,7 @@ install_requires = [
     "appdirs == 1.4.3",
     "semver == 2.8.1",
     "nudatus == 0.0.4",
-    'black>=18.9b0;python_version > "3.5"',
+    'black >= 19.3b0;python_version > "3.5"',
     "Flask == 1.1.1",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -29,15 +29,15 @@ install_requires = [
     # dependencies. For the sake of "locality", it is being declared here,
     # though. Regarding these packages' versions, please refer to:
     # http://flake8.pycqa.org/en/latest/faq.html#why-does-flake8-use-ranges-for-its-dependencies
-    "flake8 == 3.7.8",
+    "flake8 >= 3.7.8",
     "pycodestyle >= 2.5.0, < 2.6.0",
     "pyflakes >= 2.1.0, < 2.2.0",
     "pyserial == 3.4",
     "qtconsole == 4.5.5",
     "pgzero == 1.2",
-    "appdirs == 1.4.3",
-    "semver == 2.8.1",
-    "nudatus == 0.0.4",
+    "appdirs >= 1.4.3",
+    "semver >= 2.8.1",
+    "nudatus >= 0.0.4",
     'black >= 19.3b0;python_version > "3.5"',
     "Flask == 1.1.1",
 ]

--- a/setup.py
+++ b/setup.py
@@ -21,25 +21,25 @@ with open(os.path.join(base_dir, "CHANGES.rst"), encoding="utf8") as f:
 
 
 install_requires = [
-    'PyQt5==5.12.1;"arm" not in platform_machine',
-    'QScintilla==2.11.1;"arm" not in platform_machine',
-    'PyQtChart==5.12;"arm" not in platform_machine',
+    'PyQt5 = 5.13.1;"arm" not in platform_machine',
+    'QScintilla = 2.11.2;"arm" not in platform_machine',
+    'PyQtChart = 5.13.0;"arm" not in platform_machine',
     # `flake8` is actually a testing/packaging dependency that, among other
     # packages, brings in `pycodestyle` and `pyflakes` which are runtime
     # dependencies. For the sake of "locality", it is being declared here,
     # though. Regarding these packages' versions, please refer to:
     # http://flake8.pycqa.org/en/latest/faq.html#why-does-flake8-use-ranges-for-its-dependencies
-    "flake8 >= 3.7.8",
+    "flake8 == 3.7.8",
     "pycodestyle >= 2.5.0, < 2.6.0",
     "pyflakes >= 2.1.0, < 2.2.0",
-    "pyserial==3.4",
-    "qtconsole==4.4.3",
-    "pgzero==1.2",
-    "appdirs>=1.4.3",
-    "semver>=2.8.0",
-    "nudatus>=0.0.3",
+    "pyserial == 3.4",
+    "qtconsole == 4.5.5",
+    "pgzero == 1.2",
+    "appdirs == 1.4.3",
+    "semver == 2.8.1",
+    "nudatus == 0.0.4",
     'black>=18.9b0;python_version > "3.5"',
-    "Flask==1.0.2",
+    "Flask == 1.1.1",
 ]
 
 


### PR DESCRIPTION
This branch introduces two changes:

1) The package dependencies in `setup.py` have all been updated to the latest versions as of time of writing. Addresses #893.

2) As per suggestion by @carlosperate, `make check` now runs with `black --check` so will error if the code hasn't been tidied. Use `make tidy` to automatically tidy the code. See discussion in #929 for context.