### PR TITLE
Where available, provide HTTPS URLs in AppStream metadata

### DIFF
--- a/conf/mu.appdata.xml
+++ b/conf/mu.appdata.xml
@@ -20,8 +20,8 @@
         <p>Mu is written in Python and works on Windows, OSX, Linux and
         Raspberry Pi.</p>
 	</description>
-	<url type="homepage">http://codewith.mu/</url>
-	<url type="help">http://codewith.mu/tutorials/</url>
+	<url type="homepage">https://codewith.mu/</url>
+	<url type="help">https://codewith.mu/tutorials/</url>
 	<url type="bugtracker">https://github.com/mu-editor/mu/issues</url>
 	<project_group>mu-editor</project_group>
 	<developer_name>Nicholas H.Tollervey</developer_name>


### PR DESCRIPTION
Suggested by appstreamcli during CI testing on Debian:

$ appstreamcli validate --pedantic /usr/share/metainfo/mu.appdata.xml
I: mu.codewith.editor.desktop:24: url-not-secure http://codewith.mu/tutorials/
I: mu.codewith.editor.desktop:23: url-not-secure http://codewith.mu/