### PR TITLE
Remove repl and plotter panes when device disappears

### DIFF
--- a/mu/interface/main.py
+++ b/mu/interface/main.py
@@ -307,6 +307,7 @@ class Window(QMainWindow):
     timer = None
     usb_checker = None
     serial = None
+    serial_name = None
     repl = None
     plotter = None
     zooms = ("xs", "s", "m", "l", "xl", "xxl", "xxxl")  # levels of zoom.
@@ -519,6 +520,7 @@ class Window(QMainWindow):
         """
         self.input_buffer = []
         self.serial = QSerialPort()
+        self.serial_name = port
         self.serial.setPortName(port)
         if self.serial.open(QIODevice.ReadWrite):
             self.serial.setDataTerminalReady(True)
@@ -544,6 +546,15 @@ class Window(QMainWindow):
         if self.serial:
             self.serial.close()
             self.serial = None
+
+    def remove_serial_link(self, device):
+        """
+        Remove the repl and/or plotter associated with the current
+        serial link when it disappears. Called from check_usb.
+        """
+        if self.serial_name == device[1]:
+            self.remove_repl()
+            self.remove_plotter()
 
     def add_filesystem(self, home, file_manager, board_name="board"):
         """

--- a/mu/logic.py
+++ b/mu/logic.py
@@ -1435,6 +1435,7 @@ class Editor:
                 to_remove.append(connected)
         for device in to_remove:
             self.connected_devices.remove(device)
+            self._view.remove_serial_link(device)
         # Add newly connected devices.
         for device in devices:
             if device not in self.connected_devices:

--- a/tests/interface/test_main.py
+++ b/tests/interface/test_main.py
@@ -814,6 +814,22 @@ def test_Window_close_serial_link():
     assert w.serial is None
 
 
+def test_Window_remove_serial_link():
+    """
+    Ensure the repl and/or plotter panes are closed when
+    a serial link disappears.
+    """
+    w = mu.interface.main.Window()
+    w.serial_name = "/dev/ttyUSB0"
+    repl = mock.MagicMock()
+    plotter = mock.MagicMock()
+    w.repl = repl
+    w.plotter = plotter
+    w.remove_serial_link(("microbit", "/dev/ttyUSB0"))
+    repl.deleteLater.assert_called_once_with()
+    plotter.deleteLater.assert_called_once_with()
+
+
 def test_Window_add_filesystem():
     """
     Ensure the expected settings are updated when adding a file system pane.

--- a/tests/modes/test_base.py
+++ b/tests/modes/test_base.py
@@ -152,6 +152,11 @@ def test_base_mode_remove_plotter():
     """
     editor = mock.MagicMock()
     view = mock.MagicMock()
+
+    def view_rp(*args, **kwargs):
+        view.plotter = None
+
+    view.remove_plotter = mock.MagicMock(side_effect=view_rp)
     view.plotter_pane.raw_data = [1, 2, 3]
     bm = BaseMode(editor, view)
     bm.plotter = mock.MagicMock()
@@ -386,12 +391,16 @@ def test_micropython_mode_remove_repl():
     """
     editor = mock.MagicMock()
     view = mock.MagicMock()
-    view.remove_repl = mock.MagicMock()
+
+    def view_rr(*args, **kwargs):
+        view.repl = None
+
+    view.remove_repl = mock.MagicMock(side_effect=view_rr)
     mm = MicroPythonMode(editor, view)
     mm.repl = True
     mm.remove_repl()
     assert view.remove_repl.call_count == 1
-    assert mm.repl is False
+    assert mm.repl is None
 
 
 def test_micropython_mode_toggle_repl_on():

--- a/tests/modes/test_esp.py
+++ b/tests/modes/test_esp.py
@@ -10,6 +10,15 @@ from mu.modes.api import ESP_APIS, SHARED_APIS
 def esp_mode():
     editor = mock.MagicMock()
     view = mock.MagicMock()
+
+    def view_amr(*args, **kwargs):
+        view.repl = True
+
+    def view_rr(*args, **kwargs):
+        view.repl = None
+
+    view.add_micropython_repl = mock.MagicMock(side_effect=view_amr)
+    view.remove_repl = mock.MagicMock(side_effect=view_rr)
     esp_mode = ESPMode(editor, view)
     return esp_mode
 

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -2633,6 +2633,9 @@ def test_check_usb():
     ed.show_status_message.assert_called_with(expected)
     assert view.show_confirmation.called
     ed.change_mode.assert_called_once_with("microbit")
+    ed.modes = {}
+    ed.check_usb()
+    assert view.remove_serial_link.called_once_with("/dev/ttyUSB0")
 
 
 def test_check_usb_change_mode_cancel():


### PR DESCRIPTION
The first patch avoids having the view and mode state out-of-sync when the view closes the repl and plotter panes in response to the serial device disappearing. The alternative would be to have the mode in control of closing the repl/plotter panes when the device disappears, which would be more complicated to implement, but might be preferred.