### PR TITLE
Docs: remove mbed driver reference from setup.rst

### DIFF
--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -174,8 +174,7 @@ code coverage.)
 .. warning::
 
     In order to use the MicroPython REPL via USB serial you may need to add
-    yourself to the ``dialout`` group on Linux, or, if you're on some versions
-    of Windows, install the `Windows serial driver <https://os.mbed.com/handbook/Windows-serial-configuration>`_.
+    yourself to the ``dialout`` group on Linux.
 
 Before Submitting
 +++++++++++++++++


### PR DESCRIPTION
Windows 7 reaches EOL in Jan 2020 and Micro:bit Educational Foundation no longer want to recommend installing the mBED driver as it conflicts with later versions of Windows 