### PR TITLE
Windows packaging: exit early on PyPI lookup failures + sub-process failures.

### DIFF
--- a/win_installer.py
+++ b/win_installer.py
@@ -166,17 +166,17 @@ def pypi_wheels_in(requirements):
         package = yarg.get(name)
         releases = package.release(version)
         if not releases:
-            feedback = (
-                "WARNING: Just installed but not found at PyPI."
-                " (bad meta-data?)"
+            raise RuntimeError(
+                "ABORTING: Did not find {!r} at PyPI. (bad meta-data?)".format(
+                    requirement
+                )
             )
-        elif any(r.package_type == "wheel" for r in releases):
+        if any(r.package_type == "wheel" for r in releases):
             wheels.append(requirement)
             feedback = "ok"
         else:
             feedback = "missing"
         print(feedback)
-
     return wheels
 
 

--- a/win_installer.py
+++ b/win_installer.py
@@ -106,13 +106,26 @@ TKINTER_ASSETS_URLS = {
 }
 
 
+def subprocess_run(args):
+    """
+    Wrapper around subprocess.run: when the sub-process exits with a non-zero
+    return code, prints out a message and exits with the same code.
+    """
+    cp = subprocess.run(args)
+    try:
+        cp.check_returncode()
+    except subprocess.CalledProcessError as exc:
+        print(exc)
+        sys.exit(cp.returncode)
+
+
 def create_packaging_venv(target_directory, name="mu-packaging-venv"):
     """
     Creates a Python virtual environment in the target_directry, returning
     the path to the newly created environment's Python executable.
     """
     fullpath = os.path.join(target_directory, name)
-    subprocess.run([sys.executable, "-m", "venv", fullpath])
+    subprocess_run([sys.executable, "-m", "venv", fullpath])
     return os.path.join(fullpath, "Scripts", "python.exe")
 
 
@@ -265,12 +278,12 @@ def run(bitness, repo_root):
         venv_python = create_packaging_venv(work_dir)
 
         print("Updating pip in the virtual environment", venv_python)
-        subprocess.run(
+        subprocess_run(
             [venv_python, "-m", "pip", "install", "--upgrade", "pip"]
         )
 
         print("Installing mu with", venv_python)
-        subprocess.run([venv_python, "-m", "pip", "install", repo_root])
+        subprocess_run([venv_python, "-m", "pip", "install", repo_root])
 
         pynsist_cfg = os.path.join(work_dir, "pynsist.cfg")
         print("Creating pynsist configuration file", pynsist_cfg)
@@ -284,11 +297,11 @@ def run(bitness, repo_root):
         unzip_file(filename, work_dir)
 
         print("Installing pynsist.")
-        subprocess.run([venv_python, "-m", "pip", "install", PYNSIST_REQ])
+        subprocess_run([venv_python, "-m", "pip", "install", PYNSIST_REQ])
 
         mu_pynsist_script = os.path.join(repo_root, "package", "mu_nsist.py")
         print("Running custom pynsist script at", mu_pynsist_script)
-        subprocess.run([venv_python, mu_pynsist_script, pynsist_cfg])
+        subprocess_run([venv_python, mu_pynsist_script, pynsist_cfg])
 
         destination_dir = os.path.join(repo_root, "dist")
         print("Copying installer file to", destination_dir)

--- a/win_installer.py
+++ b/win_installer.py
@@ -139,29 +139,6 @@ def about_dict(repo_root):
     return about
 
 
-def pypi_wheel_release(name, version):
-    """
-    Returns a `name==version` string if there's such a wheel at PyPI. When
-    version ends with ".0", a shorter version may be returned, matching what's
-    found at PyPI (name=`PyQtChart` version=`5.12.0` returns `PyQtChart==5.12`,
-    as of this writing). When no releases are found, a ValueError is raised.
-    """
-    package = yarg.get(name)
-    while True:
-        releases = package.release(version)
-        if releases or not version.endswith(".0"):
-            break
-        version = version[:-2]
-
-    if not releases:
-        raise ValueError("No {n!r} package found at PyPI.".format(n=name))
-
-    if any(r.package_type == "wheel" for r in releases):
-        return "{n}=={v}".format(n=name, v=version)
-
-    return None
-
-
 def pypi_wheels_in(requirements):
     """
     Returns a list of the entries in requirements which are distributed as
@@ -173,19 +150,18 @@ def pypi_wheels_in(requirements):
     for requirement in requirements:
         name, _, version = requirement.partition("==")
         print("-", requirement, end=" ")
-
-        try:
-            found_wheel = pypi_wheel_release(name, version)
-        except ValueError as exc:
-            feedback = "ERROR: {}".format(exc)
+        package = yarg.get(name)
+        releases = package.release(version)
+        if not releases:
+            feedback = (
+                "WARNING: Just installed but not found at PyPI."
+                " (bad meta-data?)"
+            )
+        elif any(r.package_type == "wheel" for r in releases):
+            wheels.append(requirement)
+            feedback = "ok"
         else:
-            if found_wheel:
-                wheels.append(found_wheel)
-                feedback = "ok"
-                if found_wheel != requirement:
-                    feedback += " ({})".format(found_wheel)
-            else:
-                feedback = "missing"
+            feedback = "missing"
         print(feedback)
 
     return wheels
@@ -202,12 +178,10 @@ def packages_from(requirements, wheels):
     """
     Returns a list of the entires in requirements that aren't found in
     wheels (both assumed to be lists/iterables of strings formatted like
-    "name==version", but only compared by name).
+    "name==version").
     """
-    req_names = map(package_name, requirements)
-    whl_names = map(package_name, wheels)
-    packages = set(req_names) - set(whl_names)
-    return list(packages)
+    packages = set(requirements) - set(wheels)
+    return [package_name(p) for p in packages]
 
 
 def create_pynsist_cfg(python, repo_root, filename, encoding="latin1"):

--- a/win_installer.py
+++ b/win_installer.py
@@ -182,6 +182,8 @@ def pypi_wheels_in(requirements):
             if found_wheel:
                 wheels.append(found_wheel)
                 feedback = "ok"
+                if found_wheel != requirement:
+                    feedback += " ({})".format(found_wheel)
             else:
                 feedback = "missing"
         print(feedback)

--- a/win_installer.py
+++ b/win_installer.py
@@ -152,7 +152,7 @@ def pypi_wheels_in(requirements):
         print("-", requirement, end=" ")
         package = yarg.get(name)
         releases = package.release(version)
-        if any(r.package_type == "wheel" for r in releases):
+        if releases and any(r.package_type == "wheel" for r in releases):
             wheels.append(requirement)
             feedback = "ok"
         else:


### PR DESCRIPTION
Attempting to address the windows packaging failure in #958, originally identified in #959. 

Even though the [docs state otherwise](https://yarg.readthedocs.io/api-search.html#yarg.package.Package.release), [`yarg`](https://pypi.org/project/yarg)'s `Package.release(...)` method does not always return return a `list`. When not found, it returns `None`, which is not iterable.
