### PR TITLE
Windows packaging to work on Linux

### DIFF
--- a/package/mu_nsist.py
+++ b/package/mu_nsist.py
@@ -22,7 +22,6 @@ import ntpath
 import os
 import shutil
 import sys
-import winreg
 import zipfile
 
 from nsist import InstallerBuilder
@@ -32,20 +31,6 @@ from nsist.util import download, get_cache_dir
 pjoin = os.path.join
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
-
-
-def find_makensis_win():
-    """Locate makensis.exe on Windows by querying the registry"""
-    try:
-        nsis_install_dir = winreg.QueryValue(
-            winreg.HKEY_LOCAL_MACHINE, "SOFTWARE\\NSIS"
-        )
-    except OSError:
-        nsis_install_dir = winreg.QueryValue(
-            winreg.HKEY_LOCAL_MACHINE, "SOFTWARE\\Wow6432Node\\NSIS"
-        )
-
-    return pjoin(nsis_install_dir, "makensis.exe")
 
 
 class InputError(ValueError):

--- a/setup.py
+++ b/setup.py
@@ -21,9 +21,9 @@ with open(os.path.join(base_dir, "CHANGES.rst"), encoding="utf8") as f:
 
 
 install_requires = [
-    'PyQt5==5.12.1;"arm" not in platform_machine',
-    'QScintilla==2.11.1;"arm" not in platform_machine',
-    'PyQtChart==5.12;"arm" not in platform_machine',
+    'PyQt5==5.13.2;"arm" not in platform_machine',
+    'QScintilla==2.11.3;"arm" not in platform_machine',
+    'PyQtChart==5.13.1;"arm" not in platform_machine',
     # `flake8` is actually a testing/packaging dependency that, among other
     # packages, brings in `pycodestyle` and `pyflakes` which are runtime
     # dependencies. For the sake of "locality", it is being declared here,
@@ -33,13 +33,14 @@ install_requires = [
     "pycodestyle >= 2.5.0, < 2.6.0",
     "pyflakes >= 2.1.0, < 2.2.0",
     "pyserial==3.4",
-    "qtconsole==4.4.3",
+    "qtconsole==4.6.0",
     "pgzero==1.2",
     "appdirs>=1.4.3",
     "semver>=2.8.0",
     "nudatus>=0.0.3",
     'black>=18.9b0;python_version > "3.5"',
     "Flask==1.0.2",
+    'pywin32>=227;platform_system == "Windows"',
 ]
 
 


### PR DESCRIPTION
**DO NOT MERGE**

This is a first attempt to fix things up so pynsist works again on Linux and OSX based computers.

I've got it working on Linux and have managed to build the installer using `make`.

I've had to update the PyQt based packages (see the changes in `setup.py`) since the check for available wheels wasn't working for the older versions. There are a couple of hacks to deal with `pip` related strangeness and the fact that some packages are not installed on Linux, which would be installed on Windows.

In any case, the installer works *AND* Mu runs.

However, and here's where I could do with some help, when you try to run the REPL Mu crashes. Looking at the log I see an exception raised somewhere in Jupyter (i.e. not *our* code) because it can't `import win32api`. Check out the installer I made (http://ntoll.org/static/files/mu-editor_64bit.exe), and please don't hesitate to give me some pointers. :-)

I'm assuming this PR will result in an installer created by Appveyor (i.e. on Windows). It'd be good to see what the difference, if any, is.

My guess is we need to include something (pywin32) in the `pkgs` directory, but I've not yet figured out that aspect properly yet.