### PR TITLE
Prepare standard buttons on dialogs for translation

### DIFF
--- a/mu/interface/dialogs.py
+++ b/mu/interface/dialogs.py
@@ -101,6 +101,8 @@ class ModeSelector(QDialog):
         button_box = QDialogButtonBox(
             QDialogButtonBox.Ok | QDialogButtonBox.Cancel
         )
+        button_box.button(QDialogButtonBox.Ok).setText(_("Ok"))
+        button_box.button(QDialogButtonBox.Cancel).setText(_("Cancel"))
         button_box.accepted.connect(self.accept)
         button_box.rejected.connect(self.reject)
         widget_layout.addWidget(button_box)
@@ -244,6 +246,8 @@ class AdminDialog(QDialog):
         button_box = QDialogButtonBox(
             QDialogButtonBox.Ok | QDialogButtonBox.Cancel
         )
+        button_box.button(QDialogButtonBox.Ok).setText(_("Ok"))
+        button_box.button(QDialogButtonBox.Cancel).setText(_("Cancel"))
         button_box.accepted.connect(self.accept)
         button_box.rejected.connect(self.reject)
         widget_layout.addWidget(button_box)
@@ -315,6 +319,8 @@ class FindReplaceDialog(QDialog):
         button_box = QDialogButtonBox(
             QDialogButtonBox.Ok | QDialogButtonBox.Cancel
         )
+        button_box.button(QDialogButtonBox.Ok).setText(_("Ok"))
+        button_box.button(QDialogButtonBox.Cancel).setText(_("Cancel"))
         button_box.accepted.connect(self.accept)
         button_box.rejected.connect(self.reject)
         widget_layout.addWidget(button_box)
@@ -368,6 +374,7 @@ class PackageDialog(QDialog):
         widget_layout.addWidget(self.text_area)
         # Buttons.
         self.button_box = QDialogButtonBox(QDialogButtonBox.Ok)
+        self.button_box.button(QDialogButtonBox.Ok).setText(_("Ok"))
         self.button_box.button(QDialogButtonBox.Ok).setEnabled(False)
         self.button_box.accepted.connect(self.accept)
         widget_layout.addWidget(self.button_box)


### PR DESCRIPTION
The Mu interface uses dialogs in a few places (Find/Replace; Mode-Changes). The `QDialogButtonBox` provides some standard buttons for `Ok`, `Cancel`. But the text on these buttons is not translated by Qt itself.
I run mu in a `de_DE.UTF8` locale but other languages are affected too (`fr_FR.UTF8` in this case): 
![mu-dialog](https://user-images.githubusercontent.com/418786/71721473-7a5ffc80-2e25-11ea-88f3-44fde10e51cd.jpg)

The changes in this pull request prepare the standard buttons on these dialogs for translation into all supported languages.