### PR TITLE
Adding two boards to valid_boards

### DIFF
--- a/mu/modes/circuitpython.py
+++ b/mu/modes/circuitpython.py
@@ -48,6 +48,8 @@ class CircuitPythonMode(MicroPythonMode):
         (0x1B4F, 0x8D23),  # SparkFun SAMD21 Dev Breakout
         (0x1209, 0x2017),  # Mini SAM M4
         (0x1209, 0x7102),  # Mini SAM M0
+        (0x04D8, 0xED94),  # PyCubed
+        (0x04D8, 0xEDBE),  # SAM32
     ]
     # Modules built into CircuitPython which mustn't be used as file names
     # for source code.


### PR DESCRIPTION
Adding two open source CircuitPython boards used in many educational settings. Not requiring students to modify Mu will make a HUGE improvement in workshops.