### PR TITLE
Allow device recognition based on manufacturer-string.

### DIFF
--- a/mu/logic.py
+++ b/mu/logic.py
@@ -930,13 +930,13 @@ class Editor:
             self._view.show_message(message, info)
         else:
             if file_mode and self.mode != file_mode:
-                device_name = self.modes[file_mode].name
-                message = _("Is this a {} file?").format(device_name)
+                mode_name = self.modes[file_mode].name
+                message = _("Is this a {} file?").format(mode_name)
                 info = _(
                     "It looks like this could be a {} file.\n\n"
                     "Would you like to change Mu to the {}"
                     "mode?"
-                ).format(device_name, device_name)
+                ).format(mode_name, mode_name)
                 if (
                     self._view.show_confirmation(
                         message, info, icon="Question"
@@ -1421,13 +1421,13 @@ class Editor:
         devices = []
         device_types = set()
         # Detect connected devices.
-        for name, mode in self.modes.items():
+        for mode_name, mode in self.modes.items():
             if hasattr(mode, "find_device"):
                 # The mode can detect an attached device.
-                port, serial = mode.find_device(with_logging=False)
+                port, serial, board_name = mode.find_device(with_logging=False)
                 if port:
-                    devices.append((name, port))
-                    device_types.add(name)
+                    devices.append((mode_name, board_name, port))
+                    device_types.add(mode_name)
         # Remove no-longer connected devices.
         to_remove = []
         for connected in self.connected_devices:
@@ -1440,8 +1440,14 @@ class Editor:
             if device not in self.connected_devices:
                 self.connected_devices.add(device)
                 mode_name = device[0]
-                device_name = self.modes[mode_name].name
-                msg = _("Detected new {} device.").format(device_name)
+                board_name = device[1]
+                long_mode_name = self.modes[mode_name].name
+                if board_name:
+                    msg = _("Detected new {} device: {}.").format(
+                        long_mode_name, board_name
+                    )
+                else:
+                    msg = _("Detected new {} device.").format(long_mode_name)
                 self.show_status_message(msg)
                 # Only ask to switch mode if a single device type is connected
                 # and we're not already trying to select a new mode via the
@@ -1456,7 +1462,7 @@ class Editor:
                 ) and not running:
                     msg_body = _(
                         "Would you like to change Mu to the {} " "mode?"
-                    ).format(device_name)
+                    ).format(long_mode_name)
                     change_confirmation = self._view.show_confirmation(
                         msg, msg_body, icon="Question"
                     )

--- a/mu/modes/circuitpython.py
+++ b/mu/modes/circuitpython.py
@@ -36,18 +36,18 @@ class CircuitPythonMode(MicroPythonMode):
     connected = True  #: is the board connected.
     force_interrupt = False  #: NO keyboard interrupt on serial connection.
     valid_boards = [
-        (0x2B04, 0xC00C),  # Particle Argon
-        (0x2B04, 0xC00D),  # Particle Boron
-        (0x2B04, 0xC00E),  # Particle Xenon
-        (0x239A, None),  # Any Adafruit Boards
+        (0x2B04, 0xC00C, None, "Particle Argon"),
+        (0x2B04, 0xC00D, None, "Particle Boron"),
+        (0x2B04, 0xC00E, None, "Particle Xenon"),
+        (0x239A, None, None, "Adafruit CircuitPlayground"),
         # Non-Adafruit boards
-        (0x1209, 0xBAB1),  # Electronic Cats Meow Meow
-        (0x1209, 0xBAB2),  # Electronic Cats CatWAN USBStick
-        (0x1209, 0xBAB3),  # Electronic Cats Bast Pro Mini M0
-        (0x1B4F, 0x8D22),  # SparkFun SAMD21 Mini Breakout
-        (0x1B4F, 0x8D23),  # SparkFun SAMD21 Dev Breakout
-        (0x1209, 0x2017),  # Mini SAM M4
-        (0x1209, 0x7102),  # Mini SAM M0
+        (0x1209, 0xBAB1, None, "Electronic Cats Meow Meow"),
+        (0x1209, 0xBAB2, None, "Electronic Cats CatWAN USBStick"),
+        (0x1209, 0xBAB3, None, "Electronic Cats Bast Pro Mini M0"),
+        (0x1B4F, 0x8D22, None, "SparkFun SAMD21 Mini Breakout"),
+        (0x1B4F, 0x8D23, None, "SparkFun SAMD21 Dev Breakout"),
+        (0x1209, 0x2017, None, "Mini SAM M4"),
+        (0x1209, 0x7102, None, "Mini SAM M0"),
     ]
     # Modules built into CircuitPython which mustn't be used as file names
     # for source code.

--- a/mu/modes/esp.py
+++ b/mu/modes/esp.py
@@ -41,10 +41,11 @@ class ESPMode(MicroPythonMode):
     # the same USB / serial chips (which actually define the Vendor ID and
     # Product ID for the connected devices.
     valid_boards = [
-        # VID  , PID
-        (0x1A86, 0x7523),  # HL-340
-        (0x10C4, 0xEA60),  # CP210x
-        (0x0403, 0x6015),  # Sparkfun ESP32 VID, PID
+        # VID  , PID,    Manufacturer string, Device name
+        (0x1A86, 0x7523, None, "HL-340"),
+        (0x10C4, 0xEA60, None, "CP210x"),
+        (0x0403, 0x6015, None, "Sparkfun ESP32 Thing"),
+        (0x0403, 0x6001, "M5STACK Inc.", "M5Stack ESP32 device"),
     ]
 
     def actions(self):
@@ -209,7 +210,7 @@ class ESPMode(MicroPythonMode):
         """
 
         # Find serial port the ESP8266/ESP32 is connected to
-        device_port, serial_number = self.find_device()
+        device_port, serial_number, board_name = self.find_device()
 
         # Check for MicroPython device
         if not device_port:

--- a/mu/modes/microbit.py
+++ b/mu/modes/microbit.py
@@ -92,7 +92,11 @@ class MicrobitMode(MicroPythonMode):
     flash_timer = None
     file_extensions = ["hex"]
 
-    valid_boards = [(0x0D28, 0x0204)]  # micro:bit USB VID, PID
+    # Device name should only be supplied for modes
+    # supporting more than one board, thus None is returned.
+    #
+    #               VID,     PID,   manufact., device name
+    valid_boards = [(0x0D28, 0x0204, None, None)]
 
     valid_serial_numbers = [9900, 9901]  # Serial numbers of supported boards.
 
@@ -225,7 +229,7 @@ class MicrobitMode(MicroPythonMode):
         port = None
         serial_number = None
         try:
-            port, serial_number = self.find_device()
+            port, serial_number, board_name = self.find_device()
             logger.info("Serial port: {}".format(port))
             logger.info("Device serial number: {}".format(serial_number))
         except Exception as ex:
@@ -554,7 +558,7 @@ class MicrobitMode(MicroPythonMode):
         Add the file system navigator to the UI.
         """
         # Check for micro:bit
-        port, serial_number = self.find_device()
+        port, serial_number, board_name = self.find_device()
         if not port:
             message = _("Could not find an attached BBC micro:bit.")
             information = _(

--- a/tests/modes/test_esp.py
+++ b/tests/modes/test_esp.py
@@ -57,7 +57,9 @@ def test_add_fs(fm, qthread, esp_mode):
     It's possible to add the file system pane if the REPL is inactive.
     """
     esp_mode.view.current_tab = None
-    esp_mode.find_device = mock.MagicMock(return_value=("COM0", "12345"))
+    esp_mode.find_device = mock.MagicMock(
+        return_value=("COM0", "12345", "ESP8266")
+    )
     esp_mode.add_fs()
     workspace = esp_mode.workspace_dir()
     esp_mode.view.add_filesystem.assert_called_once_with(
@@ -73,7 +75,9 @@ def test_add_fs_project_path(fm, qthread, esp_mode):
     It's possible to add the file system pane if the REPL is inactive.
     """
     esp_mode.view.current_tab.path = "foo"
-    esp_mode.find_device = mock.MagicMock(return_value=("COM0", "12345"))
+    esp_mode.find_device = mock.MagicMock(
+        return_value=("COM0", "12345", "ESP8266")
+    )
     esp_mode.add_fs()
     workspace = os.path.dirname(os.path.abspath("foo"))
     esp_mode.view.add_filesystem.assert_called_once_with(
@@ -86,7 +90,7 @@ def test_add_fs_no_device(esp_mode):
     """
     If there's no device attached then ensure a helpful message is displayed.
     """
-    esp_mode.find_device = mock.MagicMock(return_value=(None, None))
+    esp_mode.find_device = mock.MagicMock(return_value=(None, None, None))
     esp_mode.add_fs()
     assert esp_mode.view.show_message.call_count == 1
 
@@ -229,7 +233,7 @@ def test_run_no_device(esp_mode):
     Ensure an error message is displayed if attempting to run a script
     and no device is found.
     """
-    esp_mode.find_device = mock.MagicMock(return_value=(None, None))
+    esp_mode.find_device = mock.MagicMock(return_value=(None, None, None))
     esp_mode.run()
     assert esp_mode.view.show_message.call_count == 1
 
@@ -239,7 +243,9 @@ def test_run(esp_mode):
     Ensure run/repl/files buttons are disabled while flashing.
     """
     esp_mode.set_buttons = mock.MagicMock()
-    esp_mode.find_device = mock.MagicMock(return_value=("COM0", "12345"))
+    esp_mode.find_device = mock.MagicMock(
+        return_value=("COM0", "12345", "ESP8266")
+    )
     esp_mode.run()
     esp_mode.set_buttons.assert_called_once_with(files=False)
 

--- a/tests/modes/test_microbit.py
+++ b/tests/modes/test_microbit.py
@@ -143,7 +143,7 @@ def test_flash_with_attached_device_has_latest_firmware():
         editor.minify = False
         editor.microbit_runtime = ""
         mm = MicrobitMode(editor, view)
-        mm.find_device = mock.MagicMock(return_value=("bar", "12345"))
+        mm.find_device = mock.MagicMock(return_value=("bar", "12345", None))
         mm.copy_main = mock.MagicMock()
         mm.set_buttons = mock.MagicMock()
         mm.flash()
@@ -186,7 +186,7 @@ def test_flash_device_has_latest_firmware_encounters_serial_problem_windows():
         editor.minify = False
         editor.microbit_runtime = ""
         mm = MicrobitMode(editor, view)
-        mm.find_device = mock.MagicMock(return_value=("bar", "12345"))
+        mm.find_device = mock.MagicMock(return_value=("bar", "12345", None))
         mm.flash_failed = mock.MagicMock()
         error = IOError("bang")
         mm.copy_main = mock.MagicMock(side_effect=error)
@@ -242,7 +242,7 @@ def test_flash_device_has_latest_firmware_encounters_serial_problem_unix():
         editor.minify = False
         editor.microbit_runtime = ""
         mm = MicrobitMode(editor, view)
-        mm.find_device = mock.MagicMock(return_value=("bar", "12345"))
+        mm.find_device = mock.MagicMock(return_value=("bar", "12345", None))
         mm.flash_failed = mock.MagicMock()
         error = IOError("bang")
         mm.copy_main = mock.MagicMock(side_effect=error)
@@ -294,7 +294,7 @@ def test_flash_with_attached_device_has_latest_firmware_encounters_problem():
         editor.minify = False
         editor.microbit_runtime = ""
         mm = MicrobitMode(editor, view)
-        mm.find_device = mock.MagicMock(return_value=("bar", "12345"))
+        mm.find_device = mock.MagicMock(return_value=("bar", "12345", None))
         mm.flash_failed = mock.MagicMock()
         error = ValueError("bang")
         mm.copy_main = mock.MagicMock(side_effect=error)
@@ -336,7 +336,9 @@ def test_flash_with_attached_device_has_old_firmware():
         editor.minify = False
         editor.microbit_runtime = ""
         mm = MicrobitMode(editor, view)
-        mm.find_device = mock.MagicMock(return_value=("bar", "990112345"))
+        mm.find_device = mock.MagicMock(
+            return_value=("bar", "990112345", None)
+        )
         mm.copy_main = mock.MagicMock()
         mm.set_buttons = mock.MagicMock()
         mm.flash()
@@ -378,7 +380,7 @@ def test_flash_force_with_no_micropython():
         editor.minify = False
         editor.microbit_runtime = "/foo/bar"
         mm = MicrobitMode(editor, view)
-        mm.find_device = mock.MagicMock(return_value=("bar", "12345"))
+        mm.find_device = mock.MagicMock(return_value=("bar", "12345", None))
         mm.set_buttons = mock.MagicMock()
         mm.flash()
         assert mm.flash_thread == mock_flasher
@@ -421,7 +423,9 @@ def test_flash_force_with_unsupported_microbit():
         editor.microbit_runtime = ""
         editor.minify = False
         mm = MicrobitMode(editor, view)
-        mm.find_device = mock.MagicMock(return_value=("bar", "1234567890"))
+        mm.find_device = mock.MagicMock(
+            return_value=("bar", "1234567890", None)
+        )
         mm.set_buttons = mock.MagicMock()
         mm.flash()
         assert view.show_message.call_count == 1
@@ -463,7 +467,7 @@ def test_flash_force_with_attached_device_as_windows():
         editor.microbit_runtime = "/foo/bar"
         mm = MicrobitMode(editor, view)
         mm.set_buttons = mock.MagicMock()
-        mm.find_device = mock.MagicMock(return_value=("bar", "12345"))
+        mm.find_device = mock.MagicMock(return_value=("bar", "12345", None))
         mm.flash()
         assert mm.flash_thread == mock_flasher
         assert editor.show_status_message.call_count == 1
@@ -517,7 +521,9 @@ def test_flash_forced_with_attached_device_as_not_windows():
         editor.minify = False
         editor.microbit_runtime = ""
         mm = MicrobitMode(editor, view)
-        mm.find_device = mock.MagicMock(return_value=("COM0", "990112345"))
+        mm.find_device = mock.MagicMock(
+            return_value=("COM0", "990112345", None)
+        )
         mm.set_buttons = mock.MagicMock()
         mm.copy_main = mock.MagicMock()
         mm.flash()
@@ -604,7 +610,9 @@ def test_flash_with_attached_known_device_and_forced():
         editor.minify = False
         editor.microbit_runtime = ""
         mm = MicrobitMode(editor, view)
-        mm.find_device = mock.MagicMock(return_value=("COM0", "990112345"))
+        mm.find_device = mock.MagicMock(
+            return_value=("COM0", "990112345", None)
+        )
         mm.flash()
         assert mock_flasher_class.call_count == 1
         mock_flasher_class.assert_called_once_with(["bar"], b"", None)
@@ -680,7 +688,9 @@ def test_force_flash_empty_script():
         editor.minify = False
         editor.microbit_runtime = ""
         mm = MicrobitMode(editor, view)
-        mm.find_device = mock.MagicMock(return_value=("COM0", "990112345"))
+        mm.find_device = mock.MagicMock(
+            return_value=("COM0", "990112345", None)
+        )
         mm.flash()
         mock_flasher_class.assert_called_once_with(["bar"], b"", None)
         mock_flasher.finished.connect.assert_called_once_with(
@@ -725,7 +735,7 @@ def test_force_flash_user_specified_device_path():
         editor.minify = False
         editor.microbit_runtime = ""
         mm = MicrobitMode(editor, view)
-        mm.find_device = mock.MagicMock(return_value=(None, None))
+        mm.find_device = mock.MagicMock(return_value=(None, None, None))
         mm.flash()
         home = HOME_DIRECTORY
         view.get_microbit_path.assert_called_once_with(home)
@@ -791,7 +801,7 @@ def test_flash_without_device():
         view.show_message = mock.MagicMock()
         editor = mock.MagicMock()
         mm = MicrobitMode(editor, view)
-        mm.find_device = mock.MagicMock(return_value=(None, None))
+        mm.find_device = mock.MagicMock(return_value=(None, None, None))
         mm.flash()
         message = "Could not find an attached BBC micro:bit."
         information = (
@@ -1040,7 +1050,7 @@ def test_add_fs():
     with mock.patch("mu.modes.microbit.FileManager") as mock_fm, mock.patch(
         "mu.modes.microbit.QThread"
     ):
-        mm.find_device = mock.MagicMock(return_value=("COM0", "12345"))
+        mm.find_device = mock.MagicMock(return_value=("COM0", "12345", None))
         mm.add_fs()
         workspace = mm.workspace_dir()
         view.add_filesystem.assert_called_once_with(
@@ -1057,7 +1067,7 @@ def test_add_fs_no_device():
     view.show_message = mock.MagicMock()
     editor = mock.MagicMock()
     mm = MicrobitMode(editor, view)
-    mm.find_device = mock.MagicMock(return_value=(None, None))
+    mm.find_device = mock.MagicMock(return_value=(None, None, None))
     mm.add_fs()
     assert view.show_message.call_count == 1
 

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -2622,10 +2622,10 @@ def test_check_usb():
     mode_py = mock.MagicMock()
     mode_py.name = "Python3"
     mode_py.runner = None
-    mode_py.find_device.return_value = (None, None)
+    mode_py.find_device.return_value = (None, None, None)
     mode_mb = mock.MagicMock()
     mode_mb.name = "BBC micro:bit"
-    mode_mb.find_device.return_value = ("/dev/ttyUSB0", "12345")
+    mode_mb.find_device.return_value = ("/dev/ttyUSB0", "12345", None)
     ed.modes = {"microbit": mode_mb, "python": mode_py}
     ed.show_status_message = mock.MagicMock()
     ed.check_usb()
@@ -2646,14 +2646,18 @@ def test_check_usb_change_mode_cancel():
     mode_py = mock.MagicMock()
     mode_py.name = "Python3"
     mode_py.runner = None
-    mode_py.find_device.return_value = (None, None)
+    mode_py.find_device.return_value = (None, None, None)
     mode_cp = mock.MagicMock()
     mode_cp.name = "CircuitPlayground"
-    mode_cp.find_device.return_value = ("/dev/ttyUSB1", "12345")
+    mode_cp.find_device.return_value = (
+        "/dev/ttyUSB1",
+        "12345",
+        "Adafruit Feather",
+    )
     ed.modes = {"circuitplayground": mode_cp, "python": mode_py}
     ed.show_status_message = mock.MagicMock()
     ed.check_usb()
-    expected = "Detected new CircuitPlayground device."
+    expected = "Detected new CircuitPlayground device: Adafruit Feather."
     ed.show_status_message.assert_called_with(expected)
     assert view.show_confirmation.called
     ed.change_mode.assert_not_called()
@@ -2669,9 +2673,9 @@ def test_check_usb_already_in_mode():
     ed.change_mode = mock.MagicMock()
     mode_mb = mock.MagicMock()
     mode_mb.name = "BBC micro:bit"
-    mode_mb.find_device.return_value = ("/dev/ttyUSB0", "12345")
+    mode_mb.find_device.return_value = ("/dev/ttyUSB0", "12345", None)
     mode_cp = mock.MagicMock()
-    mode_cp.find_device.return_value = (None, None)
+    mode_cp.find_device.return_value = (None, None, None)
     ed.modes = {"microbit": mode_mb, "circuitplayground": mode_cp}
     ed.mode = "microbit"
     ed.show_status_message = mock.MagicMock()
@@ -2692,10 +2696,10 @@ def test_check_usb_currently_running_code():
     mode_py = mock.MagicMock()
     mode_py.name = "Python3"
     mode_py.runner = True
-    mode_py.find_device.return_value = (None, None)
+    mode_py.find_device.return_value = (None, None, None)
     mode_mb = mock.MagicMock()
     mode_mb.name = "BBC micro:bit"
-    mode_mb.find_device.return_value = ("/dev/ttyUSB0", "12345")
+    mode_mb.find_device.return_value = ("/dev/ttyUSB0", "12345", None)
     ed.modes = {"microbit": mode_mb, "python": mode_py}
     ed.show_status_message = mock.MagicMock()
     ed.check_usb()
@@ -2714,13 +2718,17 @@ def test_check_usb_multiple_devices():
     mode_py = mock.MagicMock()
     mode_py.name = "Python3"
     mode_py.runner = None
-    mode_py.find_device.return_value = (None, None)
+    mode_py.find_device.return_value = (None, None, None)
     mode_mb = mock.MagicMock()
     mode_mb.name = "BBC micro:bit"
-    mode_mb.find_device.return_value = ("/dev/ttyUSB0", "12345")
+    mode_mb.find_device.return_value = ("/dev/ttyUSB0", "12345", None)
     mode_cp = mock.MagicMock()
     mode_cp.name = "CircuitPlayground"
-    mode_cp.find_device.return_value = ("/dev/ttyUSB1", "54321")
+    mode_cp.find_device.return_value = (
+        "/dev/ttyUSB1",
+        "54321",
+        "Adafruit Feather",
+    )
     ed.modes = {
         "microbit": mode_mb,
         "circuitplayground": mode_cp,
@@ -2729,7 +2737,9 @@ def test_check_usb_multiple_devices():
     ed.show_status_message = mock.MagicMock()
     ed.check_usb()
     expected_mb = mock.call("Detected new BBC micro:bit device.")
-    expected_cp = mock.call("Detected new CircuitPlayground device.")
+    expected_cp = mock.call(
+        "Detected new CircuitPlayground device: Adafruit Feather."
+    )
     ed.show_status_message.assert_has_calls(
         (expected_mb, expected_cp), any_order=True
     )
@@ -2749,15 +2759,19 @@ def test_check_usb_when_selecting_mode_is_silent():
     mode_py = mock.MagicMock()
     mode_py.name = "Python3"
     mode_py.runner = None
-    mode_py.find_device.return_value = (None, None)
+    mode_py.find_device.return_value = (None, None, None)
     mode_cp = mock.MagicMock()
     mode_cp.name = "CircuitPlayground"
-    mode_cp.find_device.return_value = ("/dev/ttyUSB1", "12345")
+    mode_cp.find_device.return_value = (
+        "/dev/ttyUSB1",
+        "12345",
+        "Adafruit Feather",
+    )
     ed.modes = {"circuitplayground": mode_cp, "python": mode_py}
     ed.show_status_message = mock.MagicMock()
     ed.selecting_mode = True
     ed.check_usb()
-    expected = "Detected new CircuitPlayground device."
+    expected = "Detected new CircuitPlayground device: Adafruit Feather."
     ed.show_status_message.assert_called_with(expected)
     assert view.show_confirmation.call_count == 0
     ed.change_mode.assert_not_called()


### PR DESCRIPTION
This allows detection of devices using generic VID/PID (such as the
currently popular M5Stack devices).

This change also makes device names independent of the mode
name. Making device name independent of the mode name, which make it
possible to show not only that a device of a specific mode has been
connected, but also the name of the device (e.g. Adafruit
Feather).

![Screenshot 2020-02-21 at 13 01 36](https://user-images.githubusercontent.com/55204/75033073-59716a80-54aa-11ea-90e8-79f5eb7eddd7.png)
