### PR TITLE
Add right-click menu option "Write to main.py on device" in local filepane

### DIFF
--- a/mu/interface/main.py
+++ b/mu/interface/main.py
@@ -522,6 +522,7 @@ class Window(QMainWindow):
         self.fs_pane.microbit_fs.delete.connect(file_manager.delete)
         self.fs_pane.microbit_fs.list_files.connect(file_manager.ls)
         self.fs_pane.local_fs.get.connect(file_manager.get)
+        self.fs_pane.local_fs.put.connect(file_manager.put)
         self.fs_pane.local_fs.list_files.connect(file_manager.ls)
         file_manager.on_put_file.connect(self.fs_pane.microbit_fs.on_put)
         file_manager.on_delete_file.connect(self.fs_pane.microbit_fs.on_delete)

--- a/mu/interface/panes.py
+++ b/mu/interface/panes.py
@@ -466,9 +466,8 @@ class LocalFileList(MuFileList):
         # Mu micro:bit mode only handles .py & .hex
         if ext == ".py" or ext == ".hex":
             open_internal_action = menu.addAction(_("Open in Mu"))
-            write_to_main_action = menu.addAction(
-                _("Write to main.py on device")
-            )
+        if ext == ".py":
+            write_to_main_action = menu.addAction( _("Write to main.py on device") )
         # Open outside Mu (things get meta if Mu is the default application)
         open_action = menu.addAction(_("Open"))
         action = menu.exec_(self.mapToGlobal(event.pos()))

--- a/mu/interface/panes.py
+++ b/mu/interface/panes.py
@@ -418,6 +418,7 @@ class LocalFileList(MuFileList):
     """
 
     get = pyqtSignal(str, str)
+    put = pyqtSignal(str, str)
     open_file = pyqtSignal(str)
 
     def __init__(self, home):
@@ -465,6 +466,9 @@ class LocalFileList(MuFileList):
         # Mu micro:bit mode only handles .py & .hex
         if ext == ".py" or ext == ".hex":
             open_internal_action = menu.addAction(_("Open in Mu"))
+            write_to_main_action = menu.addAction(
+                _("Write to main.py on device")
+            )
         # Open outside Mu (things get meta if Mu is the default application)
         open_action = menu.addAction(_("Open"))
         action = menu.exec_(self.mapToGlobal(event.pos()))
@@ -483,6 +487,9 @@ class LocalFileList(MuFileList):
             path = os.path.join(self.home, local_filename)
             # Send the signal bubbling up the tree
             self.open_file.emit(path)
+        elif action == write_to_main_action:
+            path = os.path.join(self.home, local_filename)
+            self.put.emit(path, "main.py")
 
 
 class FileSystemPane(QFrame):

--- a/mu/modes/base.py
+++ b/mu/modes/base.py
@@ -695,14 +695,14 @@ class FileManager(QObject):
             logger.error(ex)
             self.on_get_fail.emit(device_filename)
 
-    def put(self, local_filename):
+    def put(self, local_filename, target=None):
         """
         Put the referenced local file onto the filesystem on the micro:bit.
         Emit the name of the file on the micro:bit when complete, or emit
         a failure signal.
         """
         try:
-            microfs.put(local_filename, target=None, serial=self.serial)
+            microfs.put(local_filename, target=target, serial=self.serial)
             self.on_put_file.emit(os.path.basename(local_filename))
         except Exception as ex:
             logger.error(ex)


### PR DESCRIPTION
This is a possible and minimal fix for issue #806, where an extra menu item is introduced in the local file system view to make it easy to write files to "main.py" in MicroPython-modes (perhaps it should only be shown in ESP-mode?).