### PR TITLE
Add ESP32 Boards CH552

### DIFF
--- a/mu/modes/esp.py
+++ b/mu/modes/esp.py
@@ -44,6 +44,7 @@ class ESPMode(MicroPythonMode):
         # VID  , PID
         (0x1A86, 0x7523),  # HL-340
         (0x10C4, 0xEA60),  # CP210x
+        (0x0403, 0x6001),  # CH552
         (0x0403, 0x6015),  # Sparkfun ESP32 VID, PID
     ]
 


### PR DESCRIPTION
I hope CH552 will be added.
It is used in M5StickC etc.

https://docs.m5stack.com/#/en/core/m5stickc