### PR TITLE
Add support for Commander from 8086.net

### DIFF
--- a/mu/modes/circuitpython.py
+++ b/mu/modes/circuitpython.py
@@ -48,6 +48,7 @@ class CircuitPythonMode(MicroPythonMode):
         (0x1B4F, 0x8D23),  # SparkFun SAMD21 Dev Breakout
         (0x1209, 0x2017),  # Mini SAM M4
         (0x1209, 0x7102),  # Mini SAM M0
+        (0x3171, 0x0101),  # 8086.net Commander
     ]
     # Modules built into CircuitPython which mustn't be used as file names
     # for source code.


### PR DESCRIPTION
The new board https://www.8086.net/product/commander does not use the Adafruit VID but has another VID/PID.
I made the following addition to this same file of the Mu I use, and it works for me.
This was suggested by @danh from #circuitpython channel on Adafruit Discord.