### PR TITLE
Added ESP32 support for XinaBox.

### DIFF
--- a/mu/modes/circuitpython.py
+++ b/mu/modes/circuitpython.py
@@ -48,6 +48,9 @@ class CircuitPythonMode(MicroPythonMode):
         (0x1B4F, 0x8D23),  # SparkFun SAMD21 Dev Breakout
         (0x1209, 0x2017),  # Mini SAM M4
         (0x1209, 0x7102),  # Mini SAM M0
+        (0x04D8, 0xEC72),  # XinaBox CC03
+        (0x04D8, 0xEC75),  # XinaBox CS11
+        (0x04D8, 0xED5E),  # XinaBox CW03
     ]
     # Modules built into CircuitPython which mustn't be used as file names
     # for source code.

--- a/mu/modes/esp.py
+++ b/mu/modes/esp.py
@@ -45,6 +45,8 @@ class ESPMode(MicroPythonMode):
         (0x1A86, 0x7523),  # HL-340
         (0x10C4, 0xEA60),  # CP210x
         (0x0403, 0x6015),  # Sparkfun ESP32 VID, PID
+        (0x0403, 0x6001),  # XinaBox CW01, CW02 (FTDI)
+
     ]
 
     def actions(self):


### PR DESCRIPTION
Append XinaBox CW02 (ESP32) VID and PID to valid boards.