### PR TITLE
Attempt at hot-fixing the issues with building Windows installers/Mac .app's

### DIFF
--- a/package/mu_nsist.py
+++ b/package/mu_nsist.py
@@ -22,7 +22,6 @@ import ntpath
 import os
 import shutil
 import sys
-import winreg
 import zipfile
 
 from nsist import InstallerBuilder
@@ -36,6 +35,8 @@ logger = logging.getLogger(__name__)
 
 def find_makensis_win():
     """Locate makensis.exe on Windows by querying the registry"""
+    import winreg
+
     try:
         nsis_install_dir = winreg.QueryValue(
             winreg.HKEY_LOCAL_MACHINE, "SOFTWARE\\NSIS"

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ extras_require = {
         "pytest-faulthandler",
         "coverage",
     ],
-    "docs": ["sphinx"],
+    "docs": ["docutils >= 0.10, < 0.16", "sphinx"],
     "package": [
         # Wheel building and PyPI uploading
         "wheel",


### PR DESCRIPTION
Hi all

My hope is that the small fixes here, can perhaps be a temporary fix to the issues that makes AppVeyor unable to generate Windows installers for pull requests. Also makes it possible to build installers on Mac/Linux.

This is just an attempt, and if I have misunderstood something about the somewhat involved build process for Mu, please excuse me and ignore this pull request.