### PR TITLE
Ensure that, if we're developing inside a venv, the venv python is used

### DIFF
--- a/make.py
+++ b/make.py
@@ -60,7 +60,7 @@ def _process_code(executable, use_python, *args):
     in the codebase, skipping docs and build artefacts
     """
     if use_python:
-        execution = ["python", executable]
+        execution = [sys.executable, executable]
     else:
         execution = [executable]
     returncodes = set()
@@ -219,7 +219,7 @@ def translateall():
 
     result = subprocess.run(
         [
-            "python",
+            sys.executable,
             PYGETTEXT,
             "mu/*",
             "mu/debugger/*",
@@ -244,7 +244,7 @@ def run():
         raise RuntimeError(
             "Cannot run Mu;" "your Python virtualenv is not activated"
         )
-    return subprocess.run(["python", "-m", "mu"]).returncode
+    return subprocess.run([sys.executable, "-m", "mu"]).returncode
 
 
 @export
@@ -254,7 +254,7 @@ def dist():
     check()
     print("Checks pass; good to package")
     return subprocess.run(
-        ["python", "setup.py", "sdist", "bdist_wheel"]
+        [sys.executable, "setup.py", "sdist", "bdist_wheel"]
     ).returncode
 
 
@@ -285,7 +285,7 @@ def win32():
     check()
     print("Building 32-bit Windows installer")
     return subprocess.run(
-        ["python", "win_installer.py", "32", "setup.py"]
+        [sys.executable, "win_installer.py", "32", "setup.py"]
     ).returncode
 
 
@@ -296,7 +296,7 @@ def win64():
     check()
     print("Building 64-bit Windows installer")
     return subprocess.run(
-        ["python", "win_installer.py", "64", "setup.py"]
+        [sys.executable, "win_installer.py", "64", "setup.py"]
     ).returncode
 
 

--- a/setup.py
+++ b/setup.py
@@ -21,9 +21,9 @@ with open(os.path.join(base_dir, "CHANGES.rst"), encoding="utf8") as f:
 
 
 install_requires = [
-    'PyQt5==5.12.1;"arm" not in platform_machine',
-    'QScintilla==2.11.1;"arm" not in platform_machine',
-    'PyQtChart==5.12;"arm" not in platform_machine',
+    'PyQt5==5.15;"arm" not in platform_machine',
+    'QScintilla==2.11.4;"arm" not in platform_machine',
+    'PyQtChart==5.15;"arm" not in platform_machine',
     # `flake8` is actually a testing/packaging dependency that, among other
     # packages, brings in `pycodestyle` and `pyflakes` which are runtime
     # dependencies. For the sake of "locality", it is being declared here,
@@ -33,13 +33,13 @@ install_requires = [
     "pycodestyle >= 2.5.0, < 2.6.0",
     "pyflakes >= 2.1.0, < 2.2.0",
     "pyserial==3.4",
-    "qtconsole==4.4.3",
+    "qtconsole==4.7.4",
     "pgzero==1.2",
     "appdirs>=1.4.3",
     "semver>=2.8.0",
     "nudatus>=0.0.3",
     'black>=18.9b0;python_version > "3.5"',
-    "Flask==1.0.2",
+    "Flask==1.1.2",
 ]
 
 
@@ -57,7 +57,7 @@ extras_require = {
         "wheel",
         "twine",
         # Windows native packaging (see win_installer.py).
-        'requests==2.21.0;platform_system == "Windows"',
+        'requests==2.23.0;platform_system == "Windows"',
         'yarg==0.1.9;platform_system == "Windows"',
         # macOS native packaging (see Makefile)
         'briefcase==0.2.9;platform_system == "Darwin"',

--- a/win_installer.py
+++ b/win_installer.py
@@ -152,6 +152,8 @@ def pypi_wheels_in(requirements):
         print("-", requirement, end=" ")
         package = yarg.get(name)
         releases = package.release(version)
+        if not releases:
+            raise RuntimeError(f"No releases found for {package}")
         if any(r.package_type == "wheel" for r in releases):
             wheels.append(requirement)
             feedback = "ok"


### PR DESCRIPTION
This is hopefully a non-controversial PR to ensure that the Windows make.py uses Python from the running virtualenv, otherwise it won't pick up the installed packages