### PR TITLE
Attempt at fixing #969: Calculate Plotter y min independent of y max

### DIFF
--- a/mu/interface/panes.py
+++ b/mu/interface/panes.py
@@ -1224,6 +1224,7 @@ class PlotterPane(QChartView):
         # Holds the raw actionable data detected while plotting.
         self.raw_data = []
         self.setObjectName("plotterpane")
+        self.num_datapoints = 0 # Number of datapoints to show (caps at self.max_x)
         self.lookback = 500
         self.max_x = 100  # Maximum value along x axis
         self.max_y = 1000  # Maximum value +/- along y axis
@@ -1343,6 +1344,7 @@ class PlotterPane(QChartView):
             min_ranges.append(min(self.data[i]))
             if len(self.data[i]) > self.lookback:
                 self.data[i].pop()
+            self.datapoints = min(self.num_datapoints + 1, self.max_x)
 
         # Re-scale y-axis.
         max_y_range = max(max_ranges)
@@ -1375,8 +1377,8 @@ class PlotterPane(QChartView):
         for i, line_series in enumerate(self.series):
             line_series.clear()
             xy_vals = []
-            for j in range(self.max_x):
-                val = self.data[i][self.max_x - 1 - j]
+            for j in range(self.num_datapoints):
+                val = self.data[i][self.num_datapoints - 1 - j]
                 xy_vals.append((j, val))
             for point in xy_vals:
                 line_series.append(*point)

--- a/mu/interface/panes.py
+++ b/mu/interface/panes.py
@@ -1224,7 +1224,8 @@ class PlotterPane(QChartView):
         # Holds the raw actionable data detected while plotting.
         self.raw_data = []
         self.setObjectName("plotterpane")
-        self.num_datapoints = 0 # Number of datapoints to show (caps at self.max_x)
+        # Number of datapoints to show (caps at self.max_x)
+        self.num_datapoints = 0
         self.lookback = 500
         self.max_x = 100  # Maximum value along x axis
         self.max_y = 1000  # Maximum value +/- along y axis
@@ -1344,7 +1345,7 @@ class PlotterPane(QChartView):
             min_ranges.append(min(self.data[i]))
             if len(self.data[i]) > self.lookback:
                 self.data[i].pop()
-            self.datapoints = min(self.num_datapoints + 1, self.max_x)
+            self.num_datapoints = min(self.num_datapoints + 1, self.max_x)
 
         # Re-scale y-axis.
         max_y_range = max(max_ranges)

--- a/mu/interface/panes.py
+++ b/mu/interface/panes.py
@@ -1224,13 +1224,14 @@ class PlotterPane(QChartView):
         # Holds the raw actionable data detected while plotting.
         self.raw_data = []
         self.setObjectName("plotterpane")
+        self.lookback = 500
         self.max_x = 100  # Maximum value along x axis
         self.max_y = 1000  # Maximum value +/- along y axis
         self.min_y = -1000
         self.flooded = False  # Flag to indicate if data flooding is happening.
 
         # Holds deques for each slot of incoming data (assumes 1 to start with)
-        self.data = [deque([0] * self.max_x)]
+        self.data = [deque([0] * self.lookback)]
         # Holds line series for each slot of incoming data (assumes 1 to start
         # with).
         self.series = [QLineSeries()]
@@ -1324,7 +1325,7 @@ class PlotterPane(QChartView):
                     self.chart.setAxisX(self.axis_x, new_series)
                     self.chart.setAxisY(self.axis_y, new_series)
                     self.series.append(new_series)
-                    self.data.append(deque([0] * self.max_x))
+                    self.data.append(deque([0] * self.lookback))
             else:
                 # Remove old line series.
                 for old_series in self.series[value_len:]:
@@ -1340,7 +1341,7 @@ class PlotterPane(QChartView):
             self.data[i].appendleft(value)
             max_ranges.append(max(self.data[i]))
             min_ranges.append(min(self.data[i]))
-            if len(self.data[i]) > self.max_x:
+            if len(self.data[i]) > self.lookback:
                 self.data[i].pop()
 
         # Re-scale y-axis.

--- a/mu/interface/panes.py
+++ b/mu/interface/panes.py
@@ -1226,6 +1226,7 @@ class PlotterPane(QChartView):
         self.setObjectName("plotterpane")
         self.max_x = 100  # Maximum value along x axis
         self.max_y = 1000  # Maximum value +/- along y axis
+        self.min_y = -1000
         self.flooded = False  # Flag to indicate if data flooding is happening.
 
         # Holds deques for each slot of incoming data (assumes 1 to start with)
@@ -1236,7 +1237,7 @@ class PlotterPane(QChartView):
 
         # Ranges used for the Y axis (up to 1000, after which we just double
         # the range).
-        self.y_ranges = [1, 5, 10, 25, 50, 100, 250, 500, 1000]
+        self.y_ranges = [0, 1, 5, 10, 25, 50, 100, 250, 500, 1000]
 
         # Set up the chart with sensible defaults.
         self.chart = QChart()
@@ -1245,7 +1246,7 @@ class PlotterPane(QChartView):
         self.axis_x = QValueAxis()
         self.axis_y = QValueAxis()
         self.axis_x.setRange(0, self.max_x)
-        self.axis_y.setRange(-self.max_y, self.max_y)
+        self.axis_y.setRange(self.min_y, self.max_y)
         self.axis_x.setLabelFormat("time")
         self.axis_y.setLabelFormat("%d")
         self.chart.setAxisX(self.axis_x, self.series[0])
@@ -1334,9 +1335,11 @@ class PlotterPane(QChartView):
         # Add the incoming values to the data to be displayed, and compute
         # max range.
         max_ranges = []
+        min_ranges = []
         for i, value in enumerate(values):
             self.data[i].appendleft(value)
-            max_ranges.append(max([max(self.data[i]), abs(min(self.data[i]))]))
+            max_ranges.append(max(self.data[i]))
+            min_ranges.append(min(self.data[i]))
             if len(self.data[i]) > self.max_x:
                 self.data[i].pop()
 
@@ -1349,10 +1352,20 @@ class PlotterPane(QChartView):
             self.max_y += self.max_y
         elif max_y_range < self.max_y / 2:
             self.max_y = self.max_y / 2
-        self.axis_y.setRange(-self.max_y, self.max_y)
+
+        min_y_range = min(min_ranges)
+        y_range = bisect.bisect_left(self.y_ranges, abs(min_y_range))
+        if y_range < len(self.y_ranges):
+            self.min_y = -self.y_ranges[y_range]
+        elif min_y_range < self.min_y:
+            self.min_y += self.min_y
+        elif min_y_range > self.min_y / 2:
+            self.min_y = self.min_y / 2
+
+        self.axis_y.setRange(self.min_y, self.max_y)
 
         # Ensure floats are used to label y axis if the range is small.
-        if self.max_y <= 5:
+        if self.max_y - self.min_y <= 10:
             self.axis_y.setLabelFormat("%2.2f")
         else:
             self.axis_y.setLabelFormat("%d")

--- a/tests/interface/test_panes.py
+++ b/tests/interface/test_panes.py
@@ -2320,9 +2320,7 @@ def test_PlotterPane_add_data():
     pp.add_data((1,))
     assert (1,) in pp.raw_data
     mock_line_series.clear.assert_called_once_with()
-    for i in range(99):
-        mock_line_series.append.call_args_list[i][0] == (i, 0)
-    mock_line_series.append.call_args_list[99][0] == (99, 1)
+    mock_line_series.append.call_args_list[0][0] == (0, 1)
 
 
 def test_PlotterPane_add_data_adjust_values_up():
@@ -2370,7 +2368,7 @@ def test_PlotterPane_add_data_re_scale_up():
     pp.series = [mock_line_series]
     pp.add_data((1001,))
     assert pp.max_y == 2000
-    pp.axis_y.setRange.assert_called_once_with(-2000, 2000)
+    pp.axis_y.setRange.assert_called_once_with(0, 2000)
 
 
 def test_PlotterPane_add_data_re_scale_down():
@@ -2385,7 +2383,37 @@ def test_PlotterPane_add_data_re_scale_down():
     pp.series = [mock_line_series]
     pp.add_data((1999,))
     assert pp.max_y == 2000
-    pp.axis_y.setRange.assert_called_once_with(-2000, 2000)
+    pp.axis_y.setRange.assert_called_once_with(0, 2000)
+
+
+def test_PlotterPane_add_data_re_scale_min_up():
+    """
+    If the y axis contains (negative) data smaller than the current
+    minimum, then ensure the negative range is doubled.
+    """
+    pp = mu.interface.panes.PlotterPane()
+    pp.axis_y = mock.MagicMock()
+    mock_line_series = mock.MagicMock()
+    pp.series = [mock_line_series]
+    pp.add_data((-1001,))
+    assert pp.min_y == -2000
+    pp.axis_y.setRange.assert_called_once_with(-2000, 0)
+
+
+def test_PlotterPane_add_data_re_scale_min_down():
+    """
+    If the y axis contains (negative) data less than half of the
+    current minimum, then ensure the negative range is halved.
+
+    """
+    pp = mu.interface.panes.PlotterPane()
+    pp.min_y = -4000
+    pp.axis_y = mock.MagicMock()
+    mock_line_series = mock.MagicMock()
+    pp.series = [mock_line_series]
+    pp.add_data((-1999,))
+    assert pp.min_y == -2000
+    pp.axis_y.setRange.assert_called_once_with(-2000, 0)
 
 
 def test_PlotterPane_set_label_format_to_float_when_range_small():
@@ -2400,7 +2428,7 @@ def test_PlotterPane_set_label_format_to_float_when_range_small():
     pp.series = [mock_line_series]
     pp.add_data((1,))
     assert pp.max_y == 1
-    pp.axis_y.setRange.assert_called_once_with(-1, 1)
+    pp.axis_y.setRange.assert_called_once_with(0, 1)
     pp.axis_y.setLabelFormat.assert_called_once_with("%2.2f")
 
 
@@ -2414,9 +2442,9 @@ def test_PlotterPane_set_label_format_to_int_when_range_large():
     pp.axis_y = mock.MagicMock()
     mock_line_series = mock.MagicMock()
     pp.series = [mock_line_series]
-    pp.add_data((10,))
-    assert pp.max_y == 10
-    pp.axis_y.setRange.assert_called_once_with(-10, 10)
+    pp.add_data((20,))
+    assert pp.max_y == 25
+    pp.axis_y.setRange.assert_called_once_with(0, 25)
     pp.axis_y.setLabelFormat.assert_called_once_with("%d")
 
 


### PR DESCRIPTION
This is an attempt at what can be done for issue #969 regarding the plotter. I'm not completely sure this is the way to go, but now we can see what issues it brings up if we try to follow the suggestion of making y min independent of y max calculation.

Basically if a signal oscillates, between lets say 0 and 1000, then previously it half of the plot would be empty as y min would be set to -1000, but the signal never decrease below 0. This fix makes that better, but on the other hand if the signal oscillates between say -100 and 100, this fix would then very often change the axis range (some times between 0-100, other times perhaps between 0 and -100)

I think this fix perhaps should be coupled with a fix that delays the change of range when signals decrease, so it doesn't do it immediately (as it might get back up again very shortly), but perhaps if there have been about 500 iterations, with no signal above a threshold then the range should decrease.