### PR TITLE
Fix issue #1055 - tab height difference on fresh start vs. reload of files

### DIFF
--- a/mu/logic.py
+++ b/mu/logic.py
@@ -733,6 +733,7 @@ class Editor:
         """
         settings_path = get_session_path()
         self.change_mode(self.mode)
+        self._view.set_theme(self.theme)
         with open(settings_path) as f:
             try:
                 old_session = json.load(f)
@@ -747,6 +748,7 @@ class Editor:
                 logger.debug(old_session)
                 if "theme" in old_session:
                     self.theme = old_session["theme"]
+                    self._view.set_theme(self.theme)
                 if "mode" in old_session:
                     old_mode = old_session["mode"]
                     if old_mode in self.modes:
@@ -802,7 +804,6 @@ class Editor:
         if paths and len(paths) > 0:
             self.load_cli(paths)
         self.change_mode(self.mode)
-        self._view.set_theme(self.theme)
         self.show_status_message(random.choice(MOTD), 10)
         if not self._view.tab_count:
             py = self.modes[self.mode].code_template + NEWLINE

--- a/mu/logic.py
+++ b/mu/logic.py
@@ -733,11 +733,11 @@ class Editor:
         """
         settings_path = get_session_path()
         self.change_mode(self.mode)
-        self._view.set_theme(self.theme)
         with open(settings_path) as f:
             try:
                 old_session = json.load(f)
             except ValueError:
+                old_session = None
                 logger.error(
                     "Settings file {} could not be parsed.".format(
                         settings_path
@@ -799,6 +799,8 @@ class Editor:
                     self._view.set_zoom()
                 old_window = old_session.get("window", {})
                 self._view.size_window(**old_window)
+        if old_session is None:
+            self._view.set_theme(self.theme)
         # handle os passed file last,
         # so it will not be focused over by another tab
         if paths and len(paths) > 0:


### PR DESCRIPTION
Fix issue #1055 by reordering when set_theme is called. Seems like Qt in this case needs things to happen in a specific order.

When the tabs are loaded without a theme set, it will use a Qt defined default height of the tabs, and not change back to what our stylesheets say, if the theme is set before this issue doesn't happen.