### PR TITLE
Fix issue #595 - race condition, where a tab sometimes was renamed to name of other tab

### DIFF
--- a/mu/interface/main.py
+++ b/mu/interface/main.py
@@ -444,7 +444,7 @@ class Window(QMainWindow):
 
         @new_tab.modificationChanged.connect
         def on_modified():
-            modified_tab_index = self.tabs.currentIndex()
+            modified_tab_index = self.tabs.indexOf(new_tab)
             # Update tab label & window title
             # Tab dirty indicator is managed in FileTabs.addTab
             self.tabs.setTabText(modified_tab_index, new_tab.label)

--- a/tests/interface/test_main.py
+++ b/tests/interface/test_main.py
@@ -628,7 +628,7 @@ def test_Window_add_tab():
     new_tab_index = 999
     w.tabs = mock.MagicMock()
     w.tabs.addTab = mock.MagicMock(return_value=new_tab_index)
-    w.tabs.currentIndex = mock.MagicMock(return_value=new_tab_index)
+    w.tabs.indexOf = mock.MagicMock(return_value=new_tab_index)
     w.tabs.setCurrentIndex = mock.MagicMock(return_value=None)
     w.tabs.setTabText = mock.MagicMock(return_value=None)
     w.connect_zoom = mock.MagicMock(return_value=None)


### PR DESCRIPTION
See description of the fix over in the bug report: https://github.com/mu-editor/mu/issues/595#issuecomment-642970812