### PR TITLE
New versions of flake8 don't like variables named I, O, or l (E741)

### DIFF
--- a/mu/logic.py
+++ b/mu/logic.py
@@ -253,7 +253,8 @@ def save_and_encode(text, filepath, newline=os.linesep):
 
     with open(filepath, "w", encoding=encoding, newline="") as f:
         text_to_write = (
-            newline.join(l.rstrip(" ") for l in text.splitlines()) + newline
+            newline.join(line.rstrip(" ") for line in text.splitlines())
+            + newline
         )
         write_and_flush(f, text_to_write)
 


### PR DESCRIPTION
Really a minor thing, but `make check` started to fail, after an upgrade of flake8, which are now complaining if you use certain letters as variable names: https://www.flake8rules.com/rules/E741.html