### PR TITLE
Use fixture for QApplication initialization in tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,8 @@ matrix:
       sudo: required
       language: python
       python: 3.7
-    # To maximise compatibility pick earliest image, OS X 10.12
     - os: osx
-      osx_image: xcode8.3
+      osx_image: xcode9.3
       sudo: required
       language: generic
       python: 3.6

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ extras_require = {
         "pytest-faulthandler",
         "coverage",
     ],
-    "docs": ["docutils >= 0.10, < 0.16", "sphinx"],
+    "docs": ["sphinx"],
     "package": [
         # Wheel building and PyPI uploading
         "wheel",
@@ -60,7 +60,7 @@ extras_require = {
         'requests==2.23.0;platform_system == "Windows"',
         'yarg==0.1.9;platform_system == "Windows"',
         # macOS native packaging (see Makefile)
-        'briefcase==0.2.9;platform_system == "Darwin"',
+        'briefcase==0.3.0;platform_system == "Darwin"',
     ],
     "utils": ["scrapy", "beautifulsoup4", "requests"],
 }

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,9 @@ extras_require = {
         "pytest-faulthandler",
         "coverage",
     ],
-    "docs": ["sphinx"],
+    "docs": ["docutils >= 0.12, < 0.16", # adding docutils requirement to avoid
+                                         # conflict between sphinx and briefcase
+             "sphinx"],
     "package": [
         # Wheel building and PyPI uploading
         "wheel",
@@ -60,7 +62,7 @@ extras_require = {
         'requests==2.23.0;platform_system == "Windows"',
         'yarg==0.1.9;platform_system == "Windows"',
         # macOS native packaging (see Makefile)
-        'briefcase==0.3.0;platform_system == "Darwin"',
+        'briefcase==0.2.9;platform_system == "Darwin"',
     ],
     "utils": ["scrapy", "beautifulsoup4", "requests"],
 }

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ extras_require = {
         "pytest-faulthandler",
         "coverage",
     ],
-    "docs": ["sphinx"],
+    "docs": ["docutils >= 0.10, < 0.16", "sphinx"],
     "package": [
         # Wheel building and PyPI uploading
         "wheel",

--- a/setup.py
+++ b/setup.py
@@ -21,9 +21,9 @@ with open(os.path.join(base_dir, "CHANGES.rst"), encoding="utf8") as f:
 
 
 install_requires = [
-    'PyQt5==5.14.2;"arm" not in platform_machine',
-    'QScintilla==2.11.4;"arm" not in platform_machine',
-    'PyQtChart==5.14.0;"arm" not in platform_machine',
+    'PyQt5==5.13.2;"arm" not in platform_machine',
+    'QScintilla==2.11.3;"arm" not in platform_machine',
+    'PyQtChart==5.13.1;"arm" not in platform_machine',
     # `flake8` is actually a testing/packaging dependency that, among other
     # packages, brings in `pycodestyle` and `pyflakes` which are runtime
     # dependencies. For the sake of "locality", it is being declared here,

--- a/setup.py
+++ b/setup.py
@@ -21,9 +21,9 @@ with open(os.path.join(base_dir, "CHANGES.rst"), encoding="utf8") as f:
 
 
 install_requires = [
-    'PyQt5==5.15;"arm" not in platform_machine',
+    'PyQt5==5.14.2;"arm" not in platform_machine',
     'QScintilla==2.11.4;"arm" not in platform_machine',
-    'PyQtChart==5.15;"arm" not in platform_machine',
+    'PyQtChart==5.14.0;"arm" not in platform_machine',
     # `flake8` is actually a testing/packaging dependency that, among other
     # packages, brings in `pycodestyle` and `pyflakes` which are runtime
     # dependencies. For the sake of "locality", it is being declared here,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 import pytest
 from PyQt5.QtWidgets import QApplication
 
+
 @pytest.fixture(scope="session")
 def qtapp():
     app = QApplication.instance()

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,0 +1,12 @@
+import pytest
+from PyQt5.QtWidgets import QApplication
+
+@pytest.fixture(scope="session")
+def qtapp():
+    app = QApplication.instance()
+    if app is None:
+        global _qapp_instance
+        _qapp_instance = QApplication([])
+        return _qapp_instance
+    else:
+        return app

--- a/tests/interface/test_dialogs.py
+++ b/tests/interface/test_dialogs.py
@@ -6,15 +6,9 @@ import sys
 import os
 import pytest
 import mu.interface.dialogs
-from PyQt5.QtWidgets import QApplication, QDialog, QWidget, QDialogButtonBox
+from PyQt5.QtWidgets import QDialog, QWidget, QDialogButtonBox
 from unittest import mock
 from mu.modes import PythonMode, CircuitPythonMode, MicrobitMode, DebugMode
-
-
-# Required so the QWidget tests don't abort with the message:
-# "QWidget: Must construct a QApplication before a QWidget"
-# The QApplication need only be instantiated once.
-app = QApplication([])
 
 
 def test_ModeItem_init():

--- a/tests/interface/test_dialogs.py
+++ b/tests/interface/test_dialogs.py
@@ -37,7 +37,7 @@ def test_ModeItem_init():
     mock_icon.assert_called_once_with(icon)
 
 
-def test_ModeSelector_setup():
+def test_ModeSelector_setup(qtapp):
     """
     Ensure the ModeSelector dialog is setup properly given a list of modes.
 
@@ -64,7 +64,7 @@ def test_ModeSelector_setup():
     assert mock_item.call_count == 3
 
 
-def test_ModeSelector_select_and_accept():
+def test_ModeSelector_select_and_accept(qtapp):
     """
     Ensure the accept slot is fired when this event handler is called.
     """
@@ -75,7 +75,7 @@ def test_ModeSelector_select_and_accept():
     ms.accept.assert_called_once_with()
 
 
-def test_ModeSelector_get_mode():
+def test_ModeSelector_get_mode(qtapp):
     """
     Ensure that the ModeSelector will correctly return a selected mode (or
     raise the expected exception if cancelled).
@@ -94,7 +94,7 @@ def test_ModeSelector_get_mode():
         ms.get_mode()
 
 
-def test_LogWidget_setup():
+def test_LogWidget_setup(qtapp):
     """
     Ensure the log widget displays the referenced log file string in the
     expected way.
@@ -106,7 +106,7 @@ def test_LogWidget_setup():
     assert lw.log_text_area.isReadOnly()
 
 
-def test_EnvironmentVariablesWidget_setup():
+def test_EnvironmentVariablesWidget_setup(qtapp):
     """
     Ensure the widget for editing user defined environment variables displays
     the referenced string in the expected way.
@@ -118,7 +118,7 @@ def test_EnvironmentVariablesWidget_setup():
     assert not evw.text_area.isReadOnly()
 
 
-def test_MicrobitSettingsWidget_setup():
+def test_MicrobitSettingsWidget_setup(qtapp):
     """
     Ensure the widget for editing settings related to the BBC microbit
     displays the referenced settings data in the expected way.
@@ -131,7 +131,7 @@ def test_MicrobitSettingsWidget_setup():
     assert mbsw.runtime_path.text() == "/foo/bar"
 
 
-def test_PackagesWidget_setup():
+def test_PackagesWidget_setup(qtapp):
     """
     Ensure the widget for editing settings related to third party packages
     displays the referenced data in the expected way.
@@ -142,7 +142,7 @@ def test_PackagesWidget_setup():
     assert pw.text_area.toPlainText() == packages
 
 
-def test_AdminDialog_setup():
+def test_AdminDialog_setup(qtapp):
     """
     Ensure the admin dialog is setup properly given the content of a log
     file and envars.
@@ -164,7 +164,7 @@ def test_AdminDialog_setup():
     assert s == settings
 
 
-def test_FindReplaceDialog_setup():
+def test_FindReplaceDialog_setup(qtapp):
     """
     Ensure the find/replace dialog is setup properly given only the theme
     as an argument.
@@ -176,7 +176,7 @@ def test_FindReplaceDialog_setup():
     assert frd.replace_flag() is False
 
 
-def test_FindReplaceDialog_setup_with_args():
+def test_FindReplaceDialog_setup_with_args(qtapp):
     """
     Ensure the find/replace dialog is setup properly given only the theme
     as an argument.
@@ -191,7 +191,7 @@ def test_FindReplaceDialog_setup_with_args():
     assert frd.replace_flag()
 
 
-def test_PackageDialog_setup():
+def test_PackageDialog_setup(qtapp):
     """
     Ensure the PackageDialog is set up correctly and kicks off the process of
     removing and adding packages.
@@ -209,7 +209,7 @@ def test_PackageDialog_setup():
     assert pd.pkg_dirs == {}
 
 
-def test_PackageDialog_remove_packages():
+def test_PackageDialog_remove_packages(qtapp):
     """
     Ensure the pkg_dirs of to-be-removed packages is correctly filled and the
     remove_package method is scheduled.
@@ -237,7 +237,7 @@ def test_PackageDialog_remove_packages():
         mock_qtimer.singleShot.assert_called_once_with(2, pd.remove_package)
 
 
-def test_PackageDialog_remove_package_dist_info():
+def test_PackageDialog_remove_package_dist_info(qtapp):
     """
     Ensures that if there are packages remaining to be deleted, then the next
     one is deleted as expected.
@@ -265,7 +265,7 @@ def test_PackageDialog_remove_package_dist_info():
         mock_qtimer.singleShot.assert_called_once_with(2, pd.remove_package)
 
 
-def test_PackageDialog_remove_package_dist_info_cannot_delete():
+def test_PackageDialog_remove_package_dist_info_cannot_delete(qtapp):
     """
     Ensures that if there are packages remaining to be deleted, then the next
     one is deleted and any failures are logged.
@@ -297,7 +297,7 @@ def test_PackageDialog_remove_package_dist_info_cannot_delete():
         mock_qtimer.singleShot.assert_called_once_with(2, pd.remove_package)
 
 
-def test_PackageDialog_remove_package_egg_info():
+def test_PackageDialog_remove_package_egg_info(qtapp):
     """
     Ensures that if there are packages remaining to be deleted, then the next
     one is deleted as expected.
@@ -325,7 +325,7 @@ def test_PackageDialog_remove_package_egg_info():
         mock_qtimer.singleShot.assert_called_once_with(2, pd.remove_package)
 
 
-def test_PackageDialog_remove_package_egg_info_cannot_delete():
+def test_PackageDialog_remove_package_egg_info_cannot_delete(qtapp):
     """
     Ensures that if there are packages remaining to be deleted, then the next
     one is deleted and any failures are logged.
@@ -357,7 +357,7 @@ def test_PackageDialog_remove_package_egg_info_cannot_delete():
         mock_qtimer.singleShot.assert_called_once_with(2, pd.remove_package)
 
 
-def test_PackageDialog_remove_package_egg_info_cannot_open_record():
+def test_PackageDialog_remove_package_egg_info_cannot_open_record(qtapp):
     """
     If the installed-files.txt file is not available (sometimes the case), then
     simply raise an exception and communicate this to the user.
@@ -384,7 +384,7 @@ def test_PackageDialog_remove_package_egg_info_cannot_open_record():
         mock_qtimer.singleShot.assert_called_once_with(2, pd.remove_package)
 
 
-def test_PackageDialog_remove_package_end_state():
+def test_PackageDialog_remove_package_end_state(qtapp):
     """
     If there are no more packages to remove and there's nothing to be done for
     adding packages, then ensure all directories that do not contain files are
@@ -412,7 +412,7 @@ def test_PackageDialog_remove_package_end_state():
     pd.end_state.assert_called_once_with()
 
 
-def test_PackageDialog_end_state():
+def test_PackageDialog_end_state(qtapp):
     """
     Ensure the expected end-state is correctly cofigured (for when all tasks
     relating to third party packages have finished).
@@ -425,7 +425,7 @@ def test_PackageDialog_end_state():
     pd.button_box.button().setEnabled.assert_called_once_with(True)
 
 
-def test_PackageDialog_run_pip():
+def test_PackageDialog_run_pip(qtapp):
     """
     Ensure the expected package to be installed is done so via the expected
     correct call to "pip" in a new process (as per the recommended way to
@@ -451,7 +451,7 @@ def test_PackageDialog_run_pip():
         pd.process.start.assert_called_once_with(sys.executable, args)
 
 
-def test_PackageDialog_finished_with_more_to_remove():
+def test_PackageDialog_finished_with_more_to_remove(qtapp):
     """
     When the pip process is finished, check if there are more packages to
     install and run again.
@@ -465,7 +465,7 @@ def test_PackageDialog_finished_with_more_to_remove():
     pd.run_pip.assert_called_once_with()
 
 
-def test_PackageDialog_finished_to_end_state():
+def test_PackageDialog_finished_to_end_state(qtapp):
     """
     When the pip process is finished, if there are no more packages to install
     and there's no more activity for removing packages, move to the end state.
@@ -478,7 +478,7 @@ def test_PackageDialog_finished_to_end_state():
     pd.end_state.assert_called_once_with()
 
 
-def test_PackageDialog_read_process():
+def test_PackageDialog_read_process(qtapp):
     """
     Ensure any data from the subprocess running "pip" is read and appended to
     the text area.
@@ -494,7 +494,7 @@ def test_PackageDialog_read_process():
         mock_timer.singleShot.assert_called_once_with(2, pd.read_process)
 
 
-def test_PackageDialog_append_data():
+def test_PackageDialog_append_data(qtapp):
     """
     Ensure that when data is appended, it's added to the end of the text area!
     """

--- a/tests/interface/test_editor.py
+++ b/tests/interface/test_editor.py
@@ -12,7 +12,7 @@ from PyQt5.QtGui import QDropEvent
 import pytest
 
 
-def test_pythonlexer_keywords():
+def test_pythonlexer_keywords(qtapp):
     """
     Ensure both types of expected keywords are returned from the PythonLexer
     class.
@@ -26,7 +26,7 @@ def test_pythonlexer_keywords():
     assert lexer.keywords(3) is None
 
 
-def test_csslexer_description_comments():
+def test_csslexer_description_comments(qtapp):
     """
     Ensure that if a Comment enum is passed in, the string "Comment" is
     returned. This is due to a bug in the base QsciLexerCSS class.
@@ -35,7 +35,7 @@ def test_csslexer_description_comments():
     assert "Comment" == lexer.description(lexer.Comment)
 
 
-def test_csslexer_description_other():
+def test_csslexer_description_other(qtapp):
     """
     Ensure that if a Comment enum is passed in, the string "Comment" is
     returned. This is due to a bug in the base QsciLexerCSS class.
@@ -47,7 +47,7 @@ def test_csslexer_description_other():
         assert "foo" == lexer.description(lexer.Value)
 
 
-def test_EditorPane_init_python():
+def test_EditorPane_init_python(qtapp):
     """
     Ensure everything is set and configured given a path and text passed into
     a new instance of the EditorPane. Python file.
@@ -73,7 +73,7 @@ def test_EditorPane_init_python():
         assert isinstance(editor.lexer, mu.interface.editor.PythonLexer)
 
 
-def test_EditorPane_init_html():
+def test_EditorPane_init_html(qtapp):
     """
     Ensure everything is set and configured given a path and text passed into
     a new instance of the EditorPane. HTML file.
@@ -99,7 +99,7 @@ def test_EditorPane_init_html():
         assert isinstance(editor.lexer, mu.interface.editor.QsciLexerHTML)
 
 
-def test_EditorPane_init_css():
+def test_EditorPane_init_css(qtapp):
     """
     Ensure everything is set and configured given a path and text passed into
     a new instance of the EditorPane. CSS file.
@@ -125,7 +125,7 @@ def test_EditorPane_init_css():
         assert isinstance(editor.lexer, mu.interface.editor.QsciLexerCSS)
 
 
-def test_EditorPane_configure():
+def test_EditorPane_configure(qtapp):
     """
     Check the expected configuration takes place. NOTE - this is checking the
     expected attributes are configured, not what the actual configuration
@@ -192,7 +192,7 @@ def test_EditorPane_configure():
     assert ep.set_zoom.call_count == 1
 
 
-def test_Editor_connect_margin():
+def test_Editor_connect_margin(qtapp):
     """
     Ensure that the passed in function is connected to the marginClick event.
     """
@@ -203,7 +203,7 @@ def test_Editor_connect_margin():
     assert ep.marginClicked.connect.call_count == 1
 
 
-def test_Editor_connect_margin_ignores_margin_4():
+def test_Editor_connect_margin_ignores_margin_4(qtapp):
     """
     Ensure that the margin click handler is not called if margin 4 is clicked.
     """
@@ -217,7 +217,7 @@ def test_Editor_connect_margin_ignores_margin_4():
     assert mock_fn.call_count == 0
 
 
-def test_Editor_connect_margin_1_works():
+def test_Editor_connect_margin_1_works(qtapp):
     """
     Ensure that the margin click handler is called if margin 1 is clicked.
     """
@@ -238,7 +238,7 @@ def test_Editor_connect_margin_1_works():
     # to fail intermittently on macOS.
 
 
-def test_EditorPane_set_theme():
+def test_EditorPane_set_theme(qtapp):
     """
     Check all the expected configuration calls are made to ensure the widget's
     theme is updated.
@@ -256,7 +256,7 @@ def test_EditorPane_set_theme():
         mock_api.prepare.assert_called_once_with()
 
 
-def test_EditorPane_set_zoom():
+def test_EditorPane_set_zoom(qtapp):
     """
     Ensure the t-shirt size is turned into a call to parent's zoomTo.
     """
@@ -266,7 +266,7 @@ def test_EditorPane_set_zoom():
     ep.zoomTo.assert_called_once_with(8)
 
 
-def test_EditorPane_label():
+def test_EditorPane_label(qtapp):
     """
     Ensure the correct label is returned given a set of states:
 
@@ -285,7 +285,7 @@ def test_EditorPane_label():
     assert ep.title == "bar.py •"
 
 
-def test_EditorPane_reset_annotations():
+def test_EditorPane_reset_annotations(qtapp):
     """
     Ensure annotation state is reset.
     """
@@ -301,7 +301,7 @@ def test_EditorPane_reset_annotations():
     ep.reset_check_indicators.assert_called_once_with()
 
 
-def test_EditorPane_reset_check_indicators():
+def test_EditorPane_reset_check_indicators(qtapp):
     """
     Ensure code check indicators are reset.
     """
@@ -338,7 +338,7 @@ def test_EditorPane_reset_check_indicators():
         assert ep.check_indicators[indicator]["markers"] == {}
 
 
-def test_EditorPane_reset_search_indicators():
+def test_EditorPane_reset_search_indicators(qtapp):
     """
     Ensure search indicators are reset.
     """
@@ -362,7 +362,7 @@ def test_EditorPane_reset_search_indicators():
         assert ep.search_indicators[indicator]["positions"] == []
 
 
-def test_EditorPane_annotate_code():
+def test_EditorPane_annotate_code(qtapp):
     """
     Given a dict containing representations of feedback on the code contained
     within the EditorPane instance, ensure the correct indicators and markers
@@ -409,7 +409,7 @@ def test_EditorPane_annotate_code():
     ep.ensureLineVisible.assert_called_once_with(17)  # first problem visible
 
 
-def test_EditorPane_debugger_at_line():
+def test_EditorPane_debugger_at_line(qtapp):
     """
     Ensure the right calls are made to highlight the referenced line with the
     DEBUG_INDICATOR.
@@ -428,7 +428,7 @@ def test_EditorPane_debugger_at_line():
     ep.ensureLineVisible.assert_called_once_with(99)
 
 
-def test_EditorPane_debugger_at_line_windows_line_endings():
+def test_EditorPane_debugger_at_line_windows_line_endings(qtapp):
     """
     Ensure the right calls are made to highlight the referenced line with the
     DEBUG_INDICATOR.
@@ -447,7 +447,7 @@ def test_EditorPane_debugger_at_line_windows_line_endings():
     ep.ensureLineVisible.assert_called_once_with(99)
 
 
-def test_EditorPane_reset_debugger_highlight():
+def test_EditorPane_reset_debugger_highlight(qtapp):
     """
     Ensure all DEBUG_INDICATORs are removed from the editor.
     """
@@ -466,7 +466,7 @@ def test_EditorPane_reset_debugger_highlight():
     )
 
 
-def test_EditorPane_show_annotations():
+def test_EditorPane_show_annotations(qtapp):
     """
     Ensure the annotations are shown in "sentence" case and with an arrow to
     indicate the line to which they refer.
@@ -489,7 +489,7 @@ def test_EditorPane_show_annotations():
     )
 
 
-def test_EditorPane_find_next_match():
+def test_EditorPane_find_next_match(qtapp):
     """
     Ensures that the expected arg values are passed through to QsciScintilla
     for highlighting matched text.
@@ -527,7 +527,7 @@ def _ranges_in_text(text, search_for):
             yield n_line, match.start(), n_line, match.end()
 
 
-def test_EditorPane_highlight_selected_matches_no_selection():
+def test_EditorPane_highlight_selected_matches_no_selection(qtapp):
     """
     Ensure that if the current selection is empty then all highlights
     are cleared.
@@ -544,7 +544,7 @@ def test_EditorPane_highlight_selected_matches_no_selection():
     assert ep.search_indicators["selection"]["positions"] == []
 
 
-def test_EditorPane_highlight_selected_spans_two_or_more_lines():
+def test_EditorPane_highlight_selected_spans_two_or_more_lines(qtapp):
     """
     Ensure that if the current selection spans two or more lines then all
     highlights are cleared.
@@ -561,7 +561,7 @@ def test_EditorPane_highlight_selected_spans_two_or_more_lines():
     assert ep.search_indicators["selection"]["positions"] == []
 
 
-def test_EditorPane_highlight_selected_matches_multi_word():
+def test_EditorPane_highlight_selected_matches_multi_word(qtapp):
     """
     Ensure that if the current selection is not a single word then don't cause
     a search/highlight call.
@@ -589,7 +589,9 @@ def test_EditorPane_highlight_selected_matches_multi_word():
         ("résumé bar résumé baz résumé", "résumé"),
     ],
 )
-def test_EditorPane_highlight_selected_matches_with_match(text, search_for):
+def test_EditorPane_highlight_selected_matches_with_match(
+    qtapp, text, search_for
+):
     """
     Ensure that if the current selection is a single word then it causes the
     expected search/highlight call.
@@ -624,7 +626,7 @@ def test_EditorPane_highlight_selected_matches_with_match(text, search_for):
     assert ep.search_indicators["selection"]["positions"] == expected_ranges
 
 
-def test_EditorPane_highlight_selected_matches_incomplete_word():
+def test_EditorPane_highlight_selected_matches_incomplete_word(qtapp):
     """
     Ensure that if the current selection is not a complete word
     then no ranges are highlighted.
@@ -644,7 +646,7 @@ def test_EditorPane_highlight_selected_matches_incomplete_word():
     assert ep.search_indicators["selection"]["positions"] == []
 
 
-def test_EditorPane_highlight_selected_matches_cursor_remains():
+def test_EditorPane_highlight_selected_matches_cursor_remains(qtapp):
     """
     Ensure that if a selection is made, the text cursor remains in the
     same place after any matching terms have been highlighted.
@@ -674,7 +676,7 @@ def test_EditorPane_highlight_selected_matches_cursor_remains():
     assert ep.getCursorPosition() == (line1, index1 - select_n_chars)
 
 
-def test_EditorPane_selection_change_listener():
+def test_EditorPane_selection_change_listener(qtapp):
     """
     Enusure that is there is a change to the selected text then controll is
     passed to highlight_selected_matches.
@@ -690,7 +692,7 @@ def test_EditorPane_selection_change_listener():
     assert ep.highlight_selected_matches.call_count == 1
 
 
-def test_EditorPane_drop_event():
+def test_EditorPane_drop_event(qtapp):
     """
     If there's a drop event associated with files, cause them to be passed into
     Mu's existing file loading code.
@@ -715,7 +717,7 @@ def test_EditorPane_drop_event():
     assert m.call_count == 3
 
 
-def test_EditorPane_drop_event_not_file():
+def test_EditorPane_drop_event_not_file(qtapp):
     """
     If the drop event isn't for files (for example, it may be for dragging and
     dropping text into the editor), then pass the handling up to QScintilla.
@@ -729,7 +731,7 @@ def test_EditorPane_drop_event_not_file():
         mock_de.assert_called_once_with(event)
 
 
-def test_EditorPane_toggle_line_starts_with_hash():
+def test_EditorPane_toggle_line_starts_with_hash(qtapp):
     """
     If the line starts with a hash ("#") immediately followed by code, then
     uncomment it.
@@ -746,7 +748,7 @@ def test_EditorPane_toggle_line_starts_with_hash():
     assert ep.toggle_line("    #foo") == "    foo"
 
 
-def test_EditorPane_toggle_line_starts_with_hash_space():
+def test_EditorPane_toggle_line_starts_with_hash_space(qtapp):
     """
     If the line starts with a PEP-8 compliant hash followed by a space ("# ")
     then uncomment it.
@@ -765,7 +767,7 @@ def test_EditorPane_toggle_line_starts_with_hash_space():
     assert ep.toggle_line("    # foo") == "    foo"
 
 
-def test_EditorPane_toggle_line_preserves_embedded_comment():
+def test_EditorPane_toggle_line_preserves_embedded_comment(qtapp):
     """
     If the line being un-commented has a trailing comment, only the first
     comment marker should be removed.
@@ -774,7 +776,7 @@ def test_EditorPane_toggle_line_preserves_embedded_comment():
     assert ep.toggle_line("    # foo # comment") == "    foo # comment"
 
 
-def test_EditorPane_toggle_line_normal_line():
+def test_EditorPane_toggle_line_normal_line(qtapp):
     """
     If the line is an uncommented line of text, then comment it with hash-space
     ("# ").
@@ -791,7 +793,7 @@ def test_EditorPane_toggle_line_normal_line():
     assert ep.toggle_line("    foo") == "#     foo"
 
 
-def test_EditorPane_toggle_line_whitespace_line():
+def test_EditorPane_toggle_line_whitespace_line(qtapp):
     """
     If the line is simply empty or contains only whitespace, then ignore it and
     return as-is.
@@ -800,7 +802,7 @@ def test_EditorPane_toggle_line_whitespace_line():
     assert ep.toggle_line("    ") == "    "
 
 
-def test_EditorPane_toggle_line_preserves_multi_comment():
+def test_EditorPane_toggle_line_preserves_multi_comment(qtapp):
     """
     If the line starts with two or more "#" together, then return it as-is.
     """
@@ -810,7 +812,7 @@ def test_EditorPane_toggle_line_preserves_multi_comment():
     assert ep.toggle_line("    ### triplet") == "    ### triplet"
 
 
-def test_EditorPane_toggle_comments_no_selection():
+def test_EditorPane_toggle_comments_no_selection(qtapp):
     """
     If no text is selected, toggle the line currently containing the cursor.
     """
@@ -827,7 +829,7 @@ def test_EditorPane_toggle_comments_no_selection():
     ep.replaceSelectedText.assert_called_once_with("# foo")
 
 
-def test_EditorPane_toggle_comments_selected_normal_lines():
+def test_EditorPane_toggle_comments_selected_normal_lines(qtapp):
     """
     Check normal lines of code are properly commented and subsequently
     highlighted.
@@ -843,7 +845,7 @@ def test_EditorPane_toggle_comments_selected_normal_lines():
     ep.setSelection.assert_called_once_with(0, 0, 2, 4)
 
 
-def test_EditorPane_toggle_comments_selected_hash_comment_lines():
+def test_EditorPane_toggle_comments_selected_hash_comment_lines(qtapp):
     """
     Check commented lines starting with "#" are now uncommented.
     """
@@ -858,7 +860,7 @@ def test_EditorPane_toggle_comments_selected_hash_comment_lines():
     ep.setSelection.assert_called_once_with(0, 0, 2, 2)
 
 
-def test_EditorPane_toggle_comments_selected_hash_space_comment_lines():
+def test_EditorPane_toggle_comments_selected_hash_space_comment_lines(qtapp):
     """
     Check commented lines starting with "# " are now uncommented.
     """
@@ -873,7 +875,7 @@ def test_EditorPane_toggle_comments_selected_hash_space_comment_lines():
     ep.setSelection.assert_called_once_with(0, 0, 2, 2)
 
 
-def test_EditorPane_toggle_comments_selected_spaces_before_comment_mark():
+def test_EditorPane_toggle_comments_selected_spaces_before_comment_mark(qtapp):
     """
     Check commented lines starting with "# " are now uncommented and on the
     last line selection ends at "baz" when there are spaces before the comment
@@ -890,7 +892,7 @@ def test_EditorPane_toggle_comments_selected_spaces_before_comment_mark():
     ep.setSelection.assert_called_once_with(0, 0, 2, 4)
 
 
-def test_EditorPane_toggle_comments_selected_spaces_after_comment_mark():
+def test_EditorPane_toggle_comments_selected_spaces_after_comment_mark(qtapp):
     """
     Check commented lines starting with "# " are now uncommented and on the
     last line selection ends at "baz" when there are spaces between the comment
@@ -907,7 +909,7 @@ def test_EditorPane_toggle_comments_selected_spaces_after_comment_mark():
     ep.setSelection.assert_called_once_with(0, 0, 2, 4)
 
 
-def test_EditorPane_toggle_comments_selection_follows_len_change():
+def test_EditorPane_toggle_comments_selection_follows_len_change(qtapp):
     """
     Check commented lines starting with "# " are now uncommented one level and
     selection adjustment doesn't assume lines starting with "# " had comment
@@ -924,7 +926,7 @@ def test_EditorPane_toggle_comments_selection_follows_len_change():
     ep.setSelection.assert_called_once_with(0, 0, 2, 4)
 
 
-def test_EditorPane_wheelEvent():
+def test_EditorPane_wheelEvent(qtapp):
     """
     """
     ep = mu.interface.editor.EditorPane(None, "baz")
@@ -937,7 +939,7 @@ def test_EditorPane_wheelEvent():
         mw.assert_called_once_with(None)
 
 
-def test_EditorPane_wheelEvent_with_modifier_ignored():
+def test_EditorPane_wheelEvent_with_modifier_ignored(qtapp):
     """
     """
     ep = mu.interface.editor.EditorPane(None, "baz")

--- a/tests/interface/test_main.py
+++ b/tests/interface/test_main.py
@@ -15,7 +15,7 @@ import pytest
 import sys
 
 
-def test_ButtonBar_init():
+def test_ButtonBar_init(qtapp):
     """
     Ensure everything is set and configured given a new instance of the
     ButtonBar.
@@ -49,7 +49,7 @@ def test_ButtonBar_init():
         assert mock_reset.call_count == 1
 
 
-def test_ButtonBar_reset():
+def test_ButtonBar_reset(qtapp):
     """
     Ensure reset clears the slots and actions.
     """
@@ -63,7 +63,7 @@ def test_ButtonBar_reset():
         mock_clear.assert_called_once_with()
 
 
-def test_ButtonBar_change_mode():
+def test_ButtonBar_change_mode(qtapp):
     """
     Ensure the expected actions are added to the button bar when the mode is
     changed.
@@ -92,7 +92,7 @@ def test_ButtonBar_change_mode():
         assert mock_add_separator.call_count == 5
 
 
-def test_ButtonBar_set_responsive_mode():
+def test_ButtonBar_set_responsive_mode(qtapp):
     """
     Does the button bar shrink in compact mode and grow out of it?
     """
@@ -114,7 +114,7 @@ def test_ButtonBar_set_responsive_mode():
         bb.setStyleSheet.assert_called_with(style)
 
 
-def test_ButtonBar_add_action():
+def test_ButtonBar_add_action(qtapp):
     """
     Check the appropriately referenced QAction is created by a call to
     addAction.
@@ -127,7 +127,7 @@ def test_ButtonBar_add_action():
     assert isinstance(bb.slots["save"], QAction)
 
 
-def test_ButtonBar_connect():
+def test_ButtonBar_connect(qtapp):
     """
     Check the named slot is connected to the slot handler.
     """
@@ -143,7 +143,7 @@ def test_ButtonBar_connect():
     slot.setShortcut.assert_called_once_with(QKeySequence("Ctrl+S"))
 
 
-def test_FileTabs_init():
+def test_FileTabs_init(qtapp):
     """
     Ensure a FileTabs instance is initialised as expected.
     """
@@ -160,7 +160,7 @@ def test_FileTabs_init():
         mcc.connect.assert_called_once_with(qtw.change_tab)
 
 
-def test_FileTabs_removeTab_cancel():
+def test_FileTabs_removeTab_cancel(qtapp):
     """
     Ensure removeTab asks the user for confirmation if there is a modification
     to the tab. If "cancel" is selected, the parent removeTab is NOT called.
@@ -187,7 +187,7 @@ def test_FileTabs_removeTab_cancel():
         assert mock_tab.isModified.call_count == 1
 
 
-def test_FileTabs_removeTab_ok():
+def test_FileTabs_removeTab_ok(qtapp):
     """
     Ensure removeTab asks the user for confirmation if there is a modification
     to the tab. If user responds with "OK", the parent removeTab IS called.
@@ -214,7 +214,7 @@ def test_FileTabs_removeTab_ok():
         assert mock_tab.isModified.call_count == 1
 
 
-def test_FileTabs_change_tab():
+def test_FileTabs_change_tab(qtapp):
     """
     Ensure change_tab updates the title of the application window with the
     label from the currently selected file.
@@ -230,7 +230,7 @@ def test_FileTabs_change_tab():
     mock_window.update_title.assert_called_once_with(mock_tab.title)
 
 
-def test_FileTabs_change_tab_no_tabs():
+def test_FileTabs_change_tab_no_tabs(qtapp):
     """
     If there are no tabs left, ensure change_tab updates the title of the
     application window with the default value (None).
@@ -243,7 +243,7 @@ def test_FileTabs_change_tab_no_tabs():
     mock_window.update_title.assert_called_once_with(None)
 
 
-def test_FileTabs_addTab():
+def test_FileTabs_addTab(qtapp):
     """
     Expect tabs to be added with the right label and a button
     """
@@ -319,7 +319,7 @@ def test_FileTabs_addTab():
     assert mock_label.setPixmap.call_count == 3
 
 
-def test_Window_attributes():
+def test_Window_attributes(qtapp):
     """
     Expect the title and icon to be set correctly.
     """
@@ -330,7 +330,7 @@ def test_Window_attributes():
     assert w.zooms == ("xs", "s", "m", "l", "xl", "xxl", "xxxl")
 
 
-def test_Window_wheelEvent_zoom_in():
+def test_Window_wheelEvent_zoom_in(qtapp):
     """
     If the CTRL+scroll in a positive direction, zoom in.
     """
@@ -348,7 +348,7 @@ def test_Window_wheelEvent_zoom_in():
         mock_event.ignore.assert_called_once_with()
 
 
-def test_Window_wheelEvent_zoom_out():
+def test_Window_wheelEvent_zoom_out(qtapp):
     """
     If the CTRL+scroll in a negative direction, zoom out.
     """
@@ -366,7 +366,7 @@ def test_Window_wheelEvent_zoom_out():
         mock_event.ignore.assert_called_once_with()
 
 
-def test_Window_resizeEvent():
+def test_Window_resizeEvent(qtapp):
     """
     Ensure resize events are passed along to the button bar.
     """
@@ -381,7 +381,7 @@ def test_Window_resizeEvent():
     w.button_bar.set_responsive_mode.assert_called_with(1024, 768)
 
 
-def test_Window_select_mode_selected():
+def test_Window_select_mode_selected(qtapp):
     """
     Handle the selection of a new mode.
     """
@@ -399,7 +399,7 @@ def test_Window_select_mode_selected():
         mock_selector.exec.assert_called_once_with()
 
 
-def test_Window_select_mode_cancelled():
+def test_Window_select_mode_cancelled(qtapp):
     """
     Handle the selection of a new mode.
     """
@@ -415,7 +415,7 @@ def test_Window_select_mode_cancelled():
         assert result is None
 
 
-def test_Window_change_mode():
+def test_Window_change_mode(qtapp):
     """
     Ensure the change of mode is made by the button_bar.
     """
@@ -435,7 +435,7 @@ def test_Window_change_mode():
     tab2.set_api.assert_called_once_with(api)
 
 
-def test_Window_set_zoom():
+def test_Window_set_zoom(qtapp):
     """
     Ensure the correct signal is emitted.
     """
@@ -445,7 +445,7 @@ def test_Window_set_zoom():
     w._zoom_in.emit.assert_called_once_with("m")
 
 
-def test_Window_zoom_in():
+def test_Window_zoom_in(qtapp):
     """
     Ensure the correct signal is emitted.
     """
@@ -455,7 +455,7 @@ def test_Window_zoom_in():
     w._zoom_in.emit.assert_called_once_with("l")
 
 
-def test_Window_zoom_out():
+def test_Window_zoom_out(qtapp):
     """
     Ensure the correct signal is emitted.
     """
@@ -465,7 +465,7 @@ def test_Window_zoom_out():
     w._zoom_out.emit.assert_called_once_with("s")
 
 
-def test_Window_connect_zoom():
+def test_Window_connect_zoom(qtapp):
     """
     Ensure the zoom in/out signals are connected to the passed in widget's
     zoomIn and zoomOut handlers.
@@ -483,7 +483,7 @@ def test_Window_connect_zoom():
     assert w._zoom_out.connect.called_once_with(widget.zoomOut)
 
 
-def test_Window_current_tab():
+def test_Window_current_tab(qtapp):
     """
     Ensure the correct tab is extracted from Window.tabs.
     """
@@ -493,7 +493,7 @@ def test_Window_current_tab():
     assert w.current_tab == "foo"
 
 
-def test_Window_set_read_only():
+def test_Window_set_read_only(qtapp):
     """
     Ensure all the tabs have the setReadOnly method set to the boolean passed
     into set_read_only.
@@ -510,7 +510,7 @@ def test_Window_set_read_only():
     tab2.setReadOnly.assert_called_once_with(True)
 
 
-def test_Window_get_load_path_no_previous():
+def test_Window_get_load_path_no_previous(qtapp):
     """
     Ensure the QFileDialog is called with the expected arguments and the
     resulting path is returned.
@@ -531,7 +531,7 @@ def test_Window_get_load_path_no_previous():
     )
 
 
-def test_Window_get_load_path_with_previous():
+def test_Window_get_load_path_with_previous(qtapp):
     """
     Ensure the QFileDialog is called with the expected arguments and the
     resulting path is returned.
@@ -553,7 +553,7 @@ def test_Window_get_load_path_with_previous():
     )
 
 
-def test_Window_get_load_path_force_path():
+def test_Window_get_load_path_force_path(qtapp):
     """
     Ensure the QFileDialog is called with the expected arguments and the
     resulting path is returned.
@@ -575,7 +575,7 @@ def test_Window_get_load_path_force_path():
     )
 
 
-def test_Window_get_save_path():
+def test_Window_get_save_path(qtapp):
     """
     Ensure the QFileDialog is called with the expected arguments and the
     resulting path is returned.
@@ -598,7 +598,7 @@ def test_Window_get_save_path():
     assert returned_path == path
 
 
-def test_Window_get_microbit_path():
+def test_Window_get_microbit_path(qtapp):
     """
     Ensures the QFileDialog is called with the expected arguments and the
     resulting path is returned.
@@ -618,7 +618,7 @@ def test_Window_get_microbit_path():
     )
 
 
-def test_Window_add_tab():
+def test_Window_add_tab(qtapp):
     """
     Ensure adding a tab works as expected and the expected on_modified handler
     is created.
@@ -664,7 +664,7 @@ def test_Window_add_tab():
     w.tabs.setTabText.assert_called_once_with(new_tab_index, ep.label)
 
 
-def test_Window_focus_tab():
+def test_Window_focus_tab(qtapp):
     """
     Given a tab instance, ensure it has focus.
     """
@@ -677,7 +677,7 @@ def test_Window_focus_tab():
     tab.setFocus.assert_called_once_with()
 
 
-def test_Window_tab_count():
+def test_Window_tab_count(qtapp):
     """
     Ensure the number from Window.tabs.count() is returned.
     """
@@ -688,7 +688,7 @@ def test_Window_tab_count():
     w.tabs.count.assert_called_once_with()
 
 
-def test_Window_widgets():
+def test_Window_widgets(qtapp):
     """
     Ensure a list derived from calls to Window.tabs.widget(i) is returned.
     """
@@ -703,7 +703,7 @@ def test_Window_widgets():
     w.tabs.count.assert_called_once_with()
 
 
-def test_Window_modified():
+def test_Window_modified(qtapp):
     """
     Ensure the window's modified attribute is derived from the modified state
     of its tabs.
@@ -722,7 +722,7 @@ def test_Window_modified():
     assert w.modified
 
 
-def test_Window_on_serial_read():
+def test_Window_on_serial_read(qtapp):
     """
     When data is received the data_received signal should emit it.
     """
@@ -734,7 +734,7 @@ def test_Window_on_serial_read():
     w.data_received.emit.assert_called_once_with(b"Hello")
 
 
-def test_Window_on_stdout_write():
+def test_Window_on_stdout_write(qtapp):
     """
     Ensure the data_received signal is emitted with the data.
     """
@@ -744,7 +744,7 @@ def test_Window_on_stdout_write():
     w.data_received.emit.assert_called_once_with(b"hello")
 
 
-def test_Window_open_serial_link():
+def test_Window_open_serial_link(qtapp):
     """
     Ensure the serial port is opened in the expected manner.
     """
@@ -765,7 +765,7 @@ def test_Window_open_serial_link():
     mock_serial.readyRead.connect.assert_called_once_with(w.on_serial_read)
 
 
-def test_Window_open_serial_link_unable_to_connect():
+def test_Window_open_serial_link_unable_to_connect(qtapp):
     """
     If serial.open fails raise an IOError.
     """
@@ -780,7 +780,7 @@ def test_Window_open_serial_link_unable_to_connect():
             w.open_serial_link("COM0")
 
 
-def test_Window_open_serial_link_DTR_unset():
+def test_Window_open_serial_link_DTR_unset(qtapp):
     """
     If data terminal ready (DTR) is unset (as can be the case on some
     Windows / Qt combinations) then fall back to PySerial to correct. See
@@ -802,7 +802,7 @@ def test_Window_open_serial_link_DTR_unset():
     mock_pyser.close.assert_called_once_with()
 
 
-def test_Window_close_serial_link():
+def test_Window_close_serial_link(qtapp):
     """
     Ensure the serial link is closed / cleaned up as expected.
     """
@@ -814,7 +814,7 @@ def test_Window_close_serial_link():
     assert w.serial is None
 
 
-def test_Window_add_filesystem():
+def test_Window_add_filesystem(qtapp):
     """
     Ensure the expected settings are updated when adding a file system pane.
     """
@@ -879,7 +879,7 @@ def test_Window_add_filesystem():
     w.connect_zoom.assert_called_once_with(mock_fs)
 
 
-def test_Window_add_filesystem_open_signal():
+def test_Window_add_filesystem_open_signal(qtapp):
     w = mu.interface.main.Window()
     w.open_file = mock.MagicMock()
     mock_open_emit = mock.MagicMock()
@@ -889,7 +889,7 @@ def test_Window_add_filesystem_open_signal():
     mock_open_emit.assert_called_once_with("test")
 
 
-def test_Window_add_micropython_repl():
+def test_Window_add_micropython_repl(qtapp):
     """
     Ensure the expected object is instantiated and add_repl is called for a
     MicroPython based REPL.
@@ -916,7 +916,7 @@ def test_Window_add_micropython_repl():
     w.add_repl.assert_called_once_with(mock_repl, "Test REPL")
 
 
-def test_Window_add_micropython_repl_no_interrupt():
+def test_Window_add_micropython_repl_no_interrupt(qtapp):
     """
     Ensure the expected object is instantiated and add_repl is called for a
     MicroPython based REPL.
@@ -941,7 +941,7 @@ def test_Window_add_micropython_repl_no_interrupt():
     w.add_repl.assert_called_once_with(mock_repl, "Test REPL")
 
 
-def test_Window_add_micropython_plotter():
+def test_Window_add_micropython_plotter(qtapp):
     """
     Ensure the expected object is instantiated and add_plotter is called for
     a MicroPython based plotter.
@@ -969,7 +969,7 @@ def test_Window_add_micropython_plotter():
     w.add_plotter.assert_called_once_with(mock_plotter, "MicroPython Plotter")
 
 
-def test_Window_add_python3_plotter():
+def test_Window_add_python3_plotter(qtapp):
     """
     Ensure the plotter is created correctly when in Python 3 mode.
     """
@@ -989,7 +989,7 @@ def test_Window_add_python3_plotter():
     w.add_plotter.assert_called_once_with(mock_plotter, "Python3 data tuple")
 
 
-def test_Window_add_jupyter_repl():
+def test_Window_add_jupyter_repl(qtapp):
     """
     Ensure the expected object is instantiated and add_repl is called for a
     Jupyter based REPL.
@@ -1011,7 +1011,7 @@ def test_Window_add_jupyter_repl():
     w.add_repl.assert_called_once_with(mock_pane, "Python3 (Jupyter)")
 
 
-def test_Window_add_repl():
+def test_Window_add_repl(qtapp):
     """
     Ensure the expected settings are updated.
     """
@@ -1031,7 +1031,7 @@ def test_Window_add_repl():
     w.addDockWidget.assert_called_once_with(Qt.BottomDockWidgetArea, mock_dock)
 
 
-def test_Window_add_plotter():
+def test_Window_add_plotter(qtapp):
     """
     Ensure the expected settings are updated.
     """
@@ -1049,7 +1049,7 @@ def test_Window_add_plotter():
     w.addDockWidget.assert_called_once_with(Qt.BottomDockWidgetArea, mock_dock)
 
 
-def test_Window_add_python3_runner():
+def test_Window_add_python3_runner(qtapp):
     """
     Ensure a Python 3 runner (to capture stdin/out/err) is displayed correctly.
     """
@@ -1074,7 +1074,7 @@ def test_Window_add_python3_runner():
     w.addDockWidget.assert_called_once_with(Qt.BottomDockWidgetArea, mock_dock)
 
 
-def test_Window_add_debug_inspector():
+def test_Window_add_debug_inspector(qtapp):
     """
     Ensure a debug inspector (to display local variables) is displayed
     correctly.
@@ -1106,7 +1106,7 @@ def test_Window_add_debug_inspector():
     w.addDockWidget.assert_called_once_with(Qt.RightDockWidgetArea, mock_dock)
 
 
-def test_Window_update_debug_inspector():
+def test_Window_update_debug_inspector(qtapp):
     """
     Given a representation of the local objects in the debug runner's call
     stack. Ensure the debug inspector's model is populated in the correct way
@@ -1135,7 +1135,7 @@ def test_Window_update_debug_inspector():
     assert mock_standard_item.call_count == 22
 
 
-def test_Window_update_debug_inspector_with_exception():
+def test_Window_update_debug_inspector_with_exception(qtapp):
     """
     If an exception is encountered when working out the type of the value,
     make sure it just reverts to the repr of the object.
@@ -1153,7 +1153,7 @@ def test_Window_update_debug_inspector_with_exception():
     assert mock_standard_item.call_count == 2
 
 
-def test_Window_remove_filesystem():
+def test_Window_remove_filesystem(qtapp):
     """
     Check all the necessary calls to remove / reset the file system pane are
     made.
@@ -1169,7 +1169,7 @@ def test_Window_remove_filesystem():
     assert w.fs is None
 
 
-def test_Window_remove_repl():
+def test_Window_remove_repl(qtapp):
     """
     Check all the necessary calls to remove / reset the REPL are made.
     """
@@ -1186,7 +1186,7 @@ def test_Window_remove_repl():
     assert w.serial is None
 
 
-def test_Window_remove_repl_active_plotter():
+def test_Window_remove_repl_active_plotter(qtapp):
     """
     When removing the repl, if the plotter is active, retain the serial
     connection.
@@ -1200,7 +1200,7 @@ def test_Window_remove_repl_active_plotter():
     assert w.serial
 
 
-def test_Window_remove_plotter():
+def test_Window_remove_plotter(qtapp):
     """
     Check all the necessary calls to remove / reset the plotter are made.
     """
@@ -1217,7 +1217,7 @@ def test_Window_remove_plotter():
     assert w.serial is None
 
 
-def test_Window_remove_plotter_active_repl():
+def test_Window_remove_plotter_active_repl(qtapp):
     """
     When removing the plotter, if the repl is active, retain the serial
     connection.
@@ -1231,7 +1231,7 @@ def test_Window_remove_plotter_active_repl():
     assert w.serial
 
 
-def test_Window_remove_python_runner():
+def test_Window_remove_python_runner(qtapp):
     """
     Check all the necessary calls to remove / reset the Python3 runner are
     made.
@@ -1248,7 +1248,7 @@ def test_Window_remove_python_runner():
     assert w.runner is None
 
 
-def test_Window_remove_debug_inspector():
+def test_Window_remove_debug_inspector(qtapp):
     """
     Check all the necessary calls to remove / reset the debug inspector are
     made.
@@ -1268,7 +1268,7 @@ def test_Window_remove_debug_inspector():
     mock_inspector.deleteLater.assert_called_once_with()
 
 
-def test_Window_set_theme():
+def test_Window_set_theme(qtapp):
     """
     Check the theme is correctly applied to the window.
     """
@@ -1340,7 +1340,7 @@ def test_Window_set_theme():
     w.plotter_pane.set_theme.assert_called_once_with("day")
 
 
-def test_Window_set_checker_icon():
+def test_Window_set_checker_icon(qtapp):
     w = mu.interface.main.Window()
     w.button_bar = mock.MagicMock()
     w.button_bar.slots = {"check": mock.MagicMock()}
@@ -1366,7 +1366,7 @@ def test_Window_set_checker_icon():
     assert w.button_bar.slots["check"].setIcon.call_count == 2
 
 
-def test_Window_show_admin():
+def test_Window_show_admin(qtapp):
     """
     Ensure the modal widget for showing the admin features is correctly
     configured.
@@ -1386,7 +1386,7 @@ def test_Window_show_admin():
         assert result == "this is the expected result"
 
 
-def test_Window_show_admin_cancelled():
+def test_Window_show_admin_cancelled(qtapp):
     """
     If the modal dialog for the admin functions is cancelled, ensure an
     empty dictionary (indicating a "falsey" no change) is returned.
@@ -1406,7 +1406,7 @@ def test_Window_show_admin_cancelled():
         assert result == {}
 
 
-def test_Window_sync_packages():
+def test_Window_sync_packages(qtapp):
     """
     Ensure the expected modal dialog indicating progress of third party package
     add/removal is displayed with the expected settings.
@@ -1423,7 +1423,7 @@ def test_Window_sync_packages():
         dialog.exec.assert_called_once_with()
 
 
-def test_Window_show_message():
+def test_Window_show_message(qtapp):
     """
     Ensure the show_message method configures a QMessageBox in the expected
     manner.
@@ -1449,7 +1449,7 @@ def test_Window_show_message():
     mock_qmb.exec.assert_called_once_with()
 
 
-def test_Window_show_message_default():
+def test_Window_show_message_default(qtapp):
     """
     Ensure the show_message method configures a QMessageBox in the expected
     manner with default args.
@@ -1473,7 +1473,7 @@ def test_Window_show_message_default():
     mock_qmb.exec.assert_called_once_with()
 
 
-def test_Window_show_confirmation():
+def test_Window_show_confirmation(qtapp):
     """
     Ensure the show_confirmation method configures a QMessageBox in the
     expected manner.
@@ -1507,7 +1507,7 @@ def test_Window_show_confirmation():
     mock_qmb.exec.assert_called_once_with()
 
 
-def test_Window_show_confirmation_default():
+def test_Window_show_confirmation_default(qtapp):
     """
     Ensure the show_confirmation method configures a QMessageBox in the
     expected manner with default args.
@@ -1539,7 +1539,7 @@ def test_Window_show_confirmation_default():
     mock_qmb.exec.assert_called_once_with()
 
 
-def test_Window_update_title():
+def test_Window_update_title(qtapp):
     """
     Ensure a passed in title results in the correct call to setWindowTitle.
     """
@@ -1564,7 +1564,7 @@ def _qdesktopwidget_mock(width, height):
     return mock.MagicMock(return_value=mock_sg)
 
 
-def test_Window_autosize_window():
+def test_Window_autosize_window(qtapp):
     """
     Check the correct calculations take place and methods are called so the
     window is resized and positioned correctly.
@@ -1587,7 +1587,7 @@ def test_Window_autosize_window():
     w.move.assert_called_once_with(x, y)
 
 
-def test_Window_reset_annotations():
+def test_Window_reset_annotations(qtapp):
     """
     Ensure the current tab has its annotations reset.
     """
@@ -1599,7 +1599,7 @@ def test_Window_reset_annotations():
     tab.reset_annotations.assert_called_once_with()
 
 
-def test_Window_annotate_code():
+def test_Window_annotate_code(qtapp):
     """
     Ensure the current tab is annotated with the passed in feedback.
     """
@@ -1612,7 +1612,7 @@ def test_Window_annotate_code():
     tab.annotate_code.assert_called_once_with(feedback, "error")
 
 
-def test_Window_show_annotations():
+def test_Window_show_annotations(qtapp):
     """
     Ensure the current tab displays its annotations.
     """
@@ -1624,7 +1624,7 @@ def test_Window_show_annotations():
     tab.show_annotations.assert_called_once_with()
 
 
-def test_Window_setup():
+def test_Window_setup(qtapp):
     """
     Ensures the various default attributes of the window are set to the
     expected value.
@@ -1679,7 +1679,7 @@ def test_Window_setup():
     assert w.size_window.call_count == 0
 
 
-def test_Window_set_usb_checker():
+def test_Window_set_usb_checker(qtapp):
     """
     Ensure the callback for checking for connected devices is set as expected.
     """
@@ -1694,7 +1694,7 @@ def test_Window_set_usb_checker():
         w.usb_checker.start.assert_called_once_with(1000)
 
 
-def test_Window_set_timer():
+def test_Window_set_timer(qtapp):
     """
     Ensure a repeating timer with the referenced callback is created.
     """
@@ -1709,7 +1709,7 @@ def test_Window_set_timer():
         w.timer.start.assert_called_once_with(5 * 1000)
 
 
-def test_Window_stop_timer():
+def test_Window_stop_timer(qtapp):
     """
     Ensure the timer is stopped and destroyed.
     """
@@ -1721,7 +1721,7 @@ def test_Window_stop_timer():
     mock_timer.stop.assert_called_once_with()
 
 
-def test_Window_connect_tab_rename():
+def test_Window_connect_tab_rename(qtapp):
     """
     Ensure the referenced handler and shortcuts are set up to fire when
     the tab is double-clicked.
@@ -1740,7 +1740,7 @@ def test_Window_connect_tab_rename():
     mock_shortcut().activated.connect.assert_called_once_with(mock_handler)
 
 
-def test_Window_open_directory_from_os_windows():
+def test_Window_open_directory_from_os_windows(qtapp):
     """
     Ensure the file explorer for Windows is called for the expected path.
     """
@@ -1754,7 +1754,7 @@ def test_Window_open_directory_from_os_windows():
         mock_os.startfile.assert_called_once_with(path)
 
 
-def test_Window_open_directory_from_os_darwin():
+def test_Window_open_directory_from_os_darwin(qtapp):
     """
     Ensure the file explorer for OSX is called for the expected path.
     """
@@ -1768,7 +1768,7 @@ def test_Window_open_directory_from_os_darwin():
         mock_system.assert_called_once_with('open "{}"'.format(path))
 
 
-def test_Window_open_directory_from_os_freedesktop():
+def test_Window_open_directory_from_os_freedesktop(qtapp):
     """
     Ensure the file explorer for FreeDesktop (Linux) is called for the
     expected path.
@@ -1783,7 +1783,7 @@ def test_Window_open_directory_from_os_freedesktop():
         mock_system.assert_called_once_with('xdg-open "{}"'.format(path))
 
 
-def test_Window_open_file_event():
+def test_Window_open_file_event(qtapp):
     """
     Ensure the open_file event is emitted when a tab's open_file is
     triggered.
@@ -1812,7 +1812,7 @@ def test_Window_open_file_event():
     mock_emit.assert_called_once_with("/foo/bar.py")
 
 
-def test_Window_connect_find_replace():
+def test_Window_connect_find_replace(qtapp):
     """
     Ensure a shortcut is created with teh expected shortcut and handler
     function.
@@ -1832,7 +1832,7 @@ def test_Window_connect_find_replace():
     shortcut.activated.connect.assert_called_once_with(mock_handler)
 
 
-def test_Window_show_find_replace():
+def test_Window_show_find_replace(qtapp):
     """
     The find/replace dialog is setup with the right arguments and, if
     successfully closed, returns the expected result.
@@ -1850,7 +1850,7 @@ def test_Window_show_find_replace():
     assert result == ("foo", "bar", True)
 
 
-def test_Window_replace_text_not_current_tab():
+def test_Window_replace_text_not_current_tab(qtapp):
     """
     If there is currently no open tab in which to search, return 0 (to indicate
     no changes have been made).
@@ -1861,7 +1861,7 @@ def test_Window_replace_text_not_current_tab():
     assert w.replace_text("foo", "bar", False) == 0
 
 
-def test_Window_replace_text_not_global_found():
+def test_Window_replace_text_not_global_found(qtapp):
     """
     If the text to be replaced is found in the source, and the global_replace
     flag is false, return 1 (to indicate the number of changes made).
@@ -1875,7 +1875,7 @@ def test_Window_replace_text_not_global_found():
     mock_tab.replace.assert_called_once_with("bar")
 
 
-def test_Window_replace_text_not_global_missing():
+def test_Window_replace_text_not_global_missing(qtapp):
     """
     If the text to be replaced is missing in the source, and the global_replace
     flag is false, return 0 (to indicate no change made).
@@ -1888,7 +1888,7 @@ def test_Window_replace_text_not_global_missing():
     assert w.replace_text("foo", "bar", False) == 0
 
 
-def test_Window_replace_text_global_found():
+def test_Window_replace_text_global_found(qtapp):
     """
     If the text to be replaced is found several times in the source, and the
     global_replace flag is true, return X (to indicate X changes made) -- where
@@ -1904,7 +1904,7 @@ def test_Window_replace_text_global_found():
     assert mock_tab.replace.call_count == 2
 
 
-def test_Window_replace_text_global_missing():
+def test_Window_replace_text_global_missing(qtapp):
     """
     If the text to be replaced is missing in the source, and the global_replace
     flag is true, return 0 (to indicate no change made).
@@ -1917,7 +1917,7 @@ def test_Window_replace_text_global_missing():
     assert w.replace_text("foo", "bar", True) == 0
 
 
-def test_Window_highlight_text():
+def test_Window_highlight_text(qtapp):
     """
     Given target_text, highlights the first instance via Scintilla's findFirst
     method.
@@ -1931,7 +1931,7 @@ def test_Window_highlight_text():
     mock_tab.findFirst.assert_called_once_with("foo", True, True, False, True)
 
 
-def test_Window_highlight_text_no_tab():
+def test_Window_highlight_text_no_tab(qtapp):
     """
     If there's no current tab, just return False.
     """
@@ -1941,7 +1941,7 @@ def test_Window_highlight_text_no_tab():
     assert w.highlight_text("foo") is False
 
 
-def test_Window_connect_toggle_comments():
+def test_Window_connect_toggle_comments(qtapp):
     """
     Ensure the passed in handler is connected to a shortcut triggered by the
     shortcut.
@@ -1961,7 +1961,7 @@ def test_Window_connect_toggle_comments():
     shortcut.activated.connect.assert_called_once_with(mock_handler)
 
 
-def test_Window_toggle_comments():
+def test_Window_toggle_comments(qtapp):
     """
     If there's a current tab, call its toggle_comments method.
     """
@@ -1973,7 +1973,7 @@ def test_Window_toggle_comments():
     mock_tab.toggle_comments.assert_called_once_with()
 
 
-def test_StatusBar_init():
+def test_StatusBar_init(qtapp):
     """
     Ensure the status bar is set up as expected.
     """
@@ -1990,7 +1990,7 @@ def test_StatusBar_init():
     assert sb.logs_label
 
 
-def test_StatusBar_connect_logs():
+def test_StatusBar_connect_logs(qtapp):
     """
     Ensure the event handler / shortcut for viewing logs is correctly set.
     """
@@ -2010,7 +2010,7 @@ def test_StatusBar_connect_logs():
     mock_shortcut().activated.connect.assert_called_once_with(handler)
 
 
-def test_StatusBar_connect_mode():
+def test_StatusBar_connect_mode(qtapp):
     """
     Ensure the event handler / shortcut for selecting the new mode is
     correctly set.
@@ -2031,7 +2031,7 @@ def test_StatusBar_connect_mode():
     mock_shortcut().activated.connect.assert_called_once_with(handler)
 
 
-def test_StatusBar_set_message():
+def test_StatusBar_set_message(qtapp):
     """
     Ensure the default pause for displaying a message in the status bar is
     used.
@@ -2045,7 +2045,7 @@ def test_StatusBar_set_message():
     sb.showMessage.assert_called_once_with("Hello", 1000)
 
 
-def test_StatusBar_set_mode():
+def test_StatusBar_set_mode(qtapp):
     """
     Ensure the mode displayed in the status bar is correctly updated.
     """

--- a/tests/interface/test_panes.py
+++ b/tests/interface/test_panes.py
@@ -26,7 +26,7 @@ def test_PANE_ZOOM_SIZES():
     assert len(expected_sizes) == len(mu.interface.panes.PANE_ZOOM_SIZES)
 
 
-def test_MicroPythonREPLPane_init_default_args():
+def test_MicroPythonREPLPane_init_default_args(qtapp):
     """
     Ensure the MicroPython REPLPane object is instantiated as expected.
     """
@@ -35,7 +35,7 @@ def test_MicroPythonREPLPane_init_default_args():
     assert rp.serial == mock_serial
 
 
-def test_MicroPythonREPLPane_paste():
+def test_MicroPythonREPLPane_paste(qtapp):
     """
     Pasting into the REPL should send bytes via the serial connection.
     """
@@ -50,7 +50,7 @@ def test_MicroPythonREPLPane_paste():
     mock_serial.write.assert_called_once_with(bytes("paste me!", "utf8"))
 
 
-def test_MicroPythonREPLPane_paste_handle_unix_newlines():
+def test_MicroPythonREPLPane_paste_handle_unix_newlines(qtapp):
     """
     Pasting into the REPL should handle '\n' properly.
 
@@ -67,7 +67,7 @@ def test_MicroPythonREPLPane_paste_handle_unix_newlines():
     mock_serial.write.assert_called_once_with(bytes("paste\rme!", "utf8"))
 
 
-def test_MicroPythonREPLPane_paste_handle_windows_newlines():
+def test_MicroPythonREPLPane_paste_handle_windows_newlines(qtapp):
     """
     Pasting into the REPL should handle '\r\n' properly.
 
@@ -84,7 +84,9 @@ def test_MicroPythonREPLPane_paste_handle_windows_newlines():
     mock_serial.write.assert_called_once_with(bytes("paste\rme!", "utf8"))
 
 
-def test_MicroPythonREPLPane_paste_only_works_if_there_is_something_to_paste():
+def test_MicroPythonREPLPane_paste_only_works_if_there_is_something_to_paste(
+    qtapp,
+):
     """
     Pasting into the REPL should send bytes via the serial connection.
     """
@@ -99,7 +101,7 @@ def test_MicroPythonREPLPane_paste_only_works_if_there_is_something_to_paste():
     assert mock_serial.write.call_count == 0
 
 
-def test_MicroPythonREPLPane_context_menu():
+def test_MicroPythonREPLPane_context_menu(qtapp):
     """
     Ensure the context menu for the REPL is configured correctly for non-OSX
     platforms.
@@ -126,7 +128,7 @@ def test_MicroPythonREPLPane_context_menu():
     assert mock_qmenu.exec_.call_count == 1
 
 
-def test_MicroPythonREPLPane_context_menu_darwin():
+def test_MicroPythonREPLPane_context_menu_darwin(qtapp):
     """
     Ensure the context menu for the REPL is configured correctly for non-OSX
     platforms.
@@ -153,7 +155,7 @@ def test_MicroPythonREPLPane_context_menu_darwin():
     assert mock_qmenu.exec_.call_count == 1
 
 
-def test_MicroPythonREPLPane_keyPressEvent():
+def test_MicroPythonREPLPane_keyPressEvent(qtapp):
     """
     Ensure key presses in the REPL are handled correctly.
     """
@@ -167,7 +169,7 @@ def test_MicroPythonREPLPane_keyPressEvent():
     mock_serial.write.assert_called_once_with(bytes("a", "utf-8"))
 
 
-def test_MicroPythonREPLPane_keyPressEvent_backspace():
+def test_MicroPythonREPLPane_keyPressEvent_backspace(qtapp):
     """
     Ensure backspaces in the REPL are handled correctly.
     """
@@ -181,7 +183,7 @@ def test_MicroPythonREPLPane_keyPressEvent_backspace():
     mock_serial.write.assert_called_once_with(b"\b")
 
 
-def test_MicroPythonREPLPane_keyPressEvent_delete():
+def test_MicroPythonREPLPane_keyPressEvent_delete(qtapp):
     """
     Ensure delete in the REPL is handled correctly.
     """
@@ -195,7 +197,7 @@ def test_MicroPythonREPLPane_keyPressEvent_delete():
     mock_serial.write.assert_called_once_with(b"\x1B[\x33\x7E")
 
 
-def test_MicroPythonREPLPane_keyPressEvent_up():
+def test_MicroPythonREPLPane_keyPressEvent_up(qtapp):
     """
     Ensure up arrows in the REPL are handled correctly.
     """
@@ -209,7 +211,7 @@ def test_MicroPythonREPLPane_keyPressEvent_up():
     mock_serial.write.assert_called_once_with(b"\x1B[A")
 
 
-def test_MicroPythonREPLPane_keyPressEvent_down():
+def test_MicroPythonREPLPane_keyPressEvent_down(qtapp):
     """
     Ensure down arrows in the REPL are handled correctly.
     """
@@ -223,7 +225,7 @@ def test_MicroPythonREPLPane_keyPressEvent_down():
     mock_serial.write.assert_called_once_with(b"\x1B[B")
 
 
-def test_MicroPythonREPLPane_keyPressEvent_right():
+def test_MicroPythonREPLPane_keyPressEvent_right(qtapp):
     """
     Ensure right arrows in the REPL are handled correctly.
     """
@@ -237,7 +239,7 @@ def test_MicroPythonREPLPane_keyPressEvent_right():
     mock_serial.write.assert_called_once_with(b"\x1B[C")
 
 
-def test_MicroPythonREPLPane_keyPressEvent_left():
+def test_MicroPythonREPLPane_keyPressEvent_left(qtapp):
     """
     Ensure left arrows in the REPL are handled correctly.
     """
@@ -251,7 +253,7 @@ def test_MicroPythonREPLPane_keyPressEvent_left():
     mock_serial.write.assert_called_once_with(b"\x1B[D")
 
 
-def test_MicroPythonREPLPane_keyPressEvent_home():
+def test_MicroPythonREPLPane_keyPressEvent_home(qtapp):
     """
     Ensure home key in the REPL is handled correctly.
     """
@@ -265,7 +267,7 @@ def test_MicroPythonREPLPane_keyPressEvent_home():
     mock_serial.write.assert_called_once_with(b"\x1B[H")
 
 
-def test_MicroPythonREPLPane_keyPressEvent_end():
+def test_MicroPythonREPLPane_keyPressEvent_end(qtapp):
     """
     Ensure end key in the REPL is handled correctly.
     """
@@ -279,7 +281,7 @@ def test_MicroPythonREPLPane_keyPressEvent_end():
     mock_serial.write.assert_called_once_with(b"\x1B[F")
 
 
-def test_MicroPythonREPLPane_keyPressEvent_CTRL_C_Darwin():
+def test_MicroPythonREPLPane_keyPressEvent_CTRL_C_Darwin(qtapp):
     """
     Ensure end key in the REPL is handled correctly.
     """
@@ -294,7 +296,7 @@ def test_MicroPythonREPLPane_keyPressEvent_CTRL_C_Darwin():
     rp.copy.assert_called_once_with()
 
 
-def test_MicroPythonREPLPane_keyPressEvent_CTRL_V_Darwin():
+def test_MicroPythonREPLPane_keyPressEvent_CTRL_V_Darwin(qtapp):
     """
     Ensure end key in the REPL is handled correctly.
     """
@@ -309,7 +311,7 @@ def test_MicroPythonREPLPane_keyPressEvent_CTRL_V_Darwin():
     rp.paste.assert_called_once_with()
 
 
-def test_MicroPythonREPLPane_keyPressEvent_meta():
+def test_MicroPythonREPLPane_keyPressEvent_meta(qtapp):
     """
     Ensure backspaces in the REPL are handled correctly.
     """
@@ -327,7 +329,7 @@ def test_MicroPythonREPLPane_keyPressEvent_meta():
     mock_serial.write.assert_called_once_with(bytes([expected]))
 
 
-def test_MicroPythonREPLPane_process_bytes():
+def test_MicroPythonREPLPane_process_bytes(qtapp):
     """
     Ensure bytes coming from the device to the application are processed as
     expected. Backspace is enacted, carriage-return is ignored, newline moves
@@ -363,7 +365,7 @@ def test_MicroPythonREPLPane_process_bytes():
     rp.ensureCursorVisible.assert_called_once_with()
 
 
-def test_MicroPythonREPLPane_process_bytes_VT100():
+def test_MicroPythonREPLPane_process_bytes_VT100(qtapp):
     """
     Ensure bytes coming from the device to the application are processed as
     expected. In this case, make sure VT100 related codes are handled properly.
@@ -426,7 +428,7 @@ def test_MicroPythonREPLPane_process_bytes_VT100():
     rp.ensureCursorVisible.assert_called_once_with()
 
 
-def test_MicroPythonREPLPane_clear():
+def test_MicroPythonREPLPane_clear(qtapp):
     """
     Ensure setText is called with an empty string.
     """
@@ -437,7 +439,7 @@ def test_MicroPythonREPLPane_clear():
     rp.setText.assert_called_once_with("")
 
 
-def test_MicroPythonREPLPane_set_font_size():
+def test_MicroPythonREPLPane_set_font_size(qtapp):
     """
     Ensure the font is updated to the expected point size.
     """
@@ -451,7 +453,7 @@ def test_MicroPythonREPLPane_set_font_size():
     rp.setFont.assert_called_once_with(mock_font)
 
 
-def test_MicroPythonREPLPane_set_zoom():
+def test_MicroPythonREPLPane_set_zoom(qtapp):
     """
     Ensure the font size is correctly set from the t-shirt size.
     """
@@ -463,7 +465,7 @@ def test_MicroPythonREPLPane_set_zoom():
     rp.set_font_size.assert_called_once_with(expected)
 
 
-def test_MicroPythonREPLPane_send_commands():
+def test_MicroPythonREPLPane_send_commands(qtapp):
     """
     Ensure the list of commands is correctly encoded and bound by control
     commands to put the board into and out of raw mode.
@@ -489,7 +491,7 @@ def test_MicroPythonREPLPane_send_commands():
     rp.execute.assert_called_once_with(expected)
 
 
-def test_MicroPythonREPLPane_execute():
+def test_MicroPythonREPLPane_execute(qtapp):
     """
     Ensure the first command is sent via serial to the connected device, and
     further commands are scheduled for the future.
@@ -503,7 +505,7 @@ def test_MicroPythonREPLPane_execute():
         assert mock_timer.singleShot.call_count == 1
 
 
-def test_MuFileList_show_confirm_overwrite_dialog():
+def test_MuFileList_show_confirm_overwrite_dialog(qtapp):
     """
     Ensure the user is notified of an existing file.
     """
@@ -524,7 +526,7 @@ def test_MuFileList_show_confirm_overwrite_dialog():
     mock_qmb.setIcon.assert_called_once_with(QMessageBox.Information)
 
 
-def test_MicroPythonDeviceFileList_init():
+def test_MicroPythonDeviceFileList_init(qtapp):
     """
     Check the widget references the user's home and allows drag and drop.
     """
@@ -533,7 +535,7 @@ def test_MicroPythonDeviceFileList_init():
     assert mfs.dragDropMode() == mfs.DragDrop
 
 
-def test_MicroPythonDeviceFileList_dropEvent():
+def test_MicroPythonDeviceFileList_dropEvent(qtapp):
     """
     Ensure a valid drop event is handled as expected.
     """
@@ -554,7 +556,7 @@ def test_MicroPythonDeviceFileList_dropEvent():
     mfs.put.emit.assert_called_once_with(fn)
 
 
-def test_MicroPythonDeviceFileList_dropEvent_wrong_source():
+def test_MicroPythonDeviceFileList_dropEvent_wrong_source(qtapp):
     """
     Ensure that only drop events whose origins are LocalFileList objects are
     handled.
@@ -568,7 +570,7 @@ def test_MicroPythonDeviceFileList_dropEvent_wrong_source():
     assert mfs.findItems.call_count == 0
 
 
-def test_MicroPythonDeviceFileList_on_put():
+def test_MicroPythonDeviceFileList_on_put(qtapp):
     """
     A message and list_files signal should be emitted.
     """
@@ -581,7 +583,7 @@ def test_MicroPythonDeviceFileList_on_put():
     mfs.list_files.emit.assert_called_once_with()
 
 
-def test_MicroPythonDeviceFileList_contextMenuEvent():
+def test_MicroPythonDeviceFileList_contextMenuEvent(qtapp):
     """
     Ensure that the menu displayed when a file on the micro:bit is
     right-clicked works as expected when activated.
@@ -606,7 +608,7 @@ def test_MicroPythonDeviceFileList_contextMenuEvent():
     mfs.delete.emit.assert_called_once_with("foo.py")
 
 
-def test_MicroPythonFileList_on_delete():
+def test_MicroPythonFileList_on_delete(qtapp):
     """
     On delete should emit a message and list_files signal.
     """
@@ -619,7 +621,7 @@ def test_MicroPythonFileList_on_delete():
     mfs.list_files.emit.assert_called_once_with()
 
 
-def test_LocalFileList_init():
+def test_LocalFileList_init(qtapp):
     """
     Ensure the class instantiates with the expected state.
     """
@@ -628,7 +630,7 @@ def test_LocalFileList_init():
     assert lfl.dragDropMode() == lfl.DragDrop
 
 
-def test_LocalFileList_dropEvent():
+def test_LocalFileList_dropEvent(qtapp):
     """
     Ensure a valid drop event is handled as expected.
     """
@@ -650,7 +652,7 @@ def test_LocalFileList_dropEvent():
     lfs.get.emit.assert_called_once_with("foo.py", fn)
 
 
-def test_LocalFileList_dropEvent_wrong_source():
+def test_LocalFileList_dropEvent_wrong_source(qtapp):
     """
     Ensure that only drop events whose origins are LocalFileList objects are
     handled.
@@ -664,7 +666,7 @@ def test_LocalFileList_dropEvent_wrong_source():
     assert lfs.findItems.call_count == 0
 
 
-def test_LocalFileList_on_get():
+def test_LocalFileList_on_get(qtapp):
     """
     On get should emit two signals: a message and list_files.
     """
@@ -680,7 +682,7 @@ def test_LocalFileList_on_get():
     lfs.list_files.emit.assert_called_once_with()
 
 
-def test_LocalFileList_contextMenuEvent():
+def test_LocalFileList_contextMenuEvent(qtapp):
     """
     Ensure that the menu displayed when a local file is
     right-clicked works as expected when activated.
@@ -706,7 +708,7 @@ def test_LocalFileList_contextMenuEvent():
     mock_open.assert_called_once_with(os.path.join("homepath", "foo.py"))
 
 
-def test_LocalFileList_contextMenuEvent_external():
+def test_LocalFileList_contextMenuEvent_external(qtapp):
     """
     Ensure that the menu displayed when a local file is
     right-clicked works as expected when activated.
@@ -731,7 +733,7 @@ def test_LocalFileList_contextMenuEvent_external():
     assert mock_open.call_count == 0
 
 
-def test_FileSystemPane_init():
+def test_FileSystemPane_init(qtapp):
     """
     Check things are set up as expected.
     """
@@ -762,7 +764,7 @@ def test_FileSystemPane_init():
         )
 
 
-def test_FileSystemPane_disable():
+def test_FileSystemPane_disable(qtapp):
     """
     The child list widgets are disabled correctly.
     """
@@ -776,7 +778,7 @@ def test_FileSystemPane_disable():
     fsp.local_fs.setAcceptDrops.assert_called_once_with(False)
 
 
-def test_FileSystemPane_enable():
+def test_FileSystemPane_enable(qtapp):
     """
     The child list widgets are enabled correctly.
     """
@@ -790,7 +792,7 @@ def test_FileSystemPane_enable():
     fsp.local_fs.setAcceptDrops.assert_called_once_with(True)
 
 
-def test_FileSystemPane_set_theme():
+def test_FileSystemPane_set_theme(qtapp):
     """
     Setting theme doesn't error
     """
@@ -798,7 +800,7 @@ def test_FileSystemPane_set_theme():
     fsp.set_theme("test")
 
 
-def test_FileSystemPane_show_message():
+def test_FileSystemPane_show_message(qtapp):
     """
     Ensure the expected message signal is emitted.
     """
@@ -808,7 +810,7 @@ def test_FileSystemPane_show_message():
     fsp.set_message.emit.assert_called_once_with("Hello")
 
 
-def test_FileSystemPane_show_warning():
+def test_FileSystemPane_show_warning(qtapp):
     """
     Ensure the expected warning signal is emitted.
     """
@@ -818,7 +820,7 @@ def test_FileSystemPane_show_warning():
     fsp.set_warning.emit.assert_called_once_with("Hello")
 
 
-def test_FileSystemPane_on_ls():
+def test_FileSystemPane_on_ls(qtapp):
     """
     When lists of files have been obtained from the micro:bit and local
     filesystem, make sure they're properly processed by the on_ls event
@@ -843,7 +845,7 @@ def test_FileSystemPane_on_ls():
     fsp.enable.assert_called_once_with()
 
 
-def test_FileSystemPane_on_ls_fail():
+def test_FileSystemPane_on_ls_fail(qtapp):
     """
     A warning is emitted and the widget disabled if listing files fails.
     """
@@ -855,7 +857,7 @@ def test_FileSystemPane_on_ls_fail():
     fsp.disable.assert_called_once_with()
 
 
-def test_FileSystem_Pane_on_put_fail():
+def test_FileSystem_Pane_on_put_fail(qtapp):
     """
     A warning is emitted if putting files on the micro:bit fails.
     """
@@ -865,7 +867,7 @@ def test_FileSystem_Pane_on_put_fail():
     assert fsp.show_warning.call_count == 1
 
 
-def test_FileSystem_Pane_on_delete_fail():
+def test_FileSystem_Pane_on_delete_fail(qtapp):
     """
     A warning is emitted if deleting files on the micro:bit fails.
     """
@@ -875,7 +877,7 @@ def test_FileSystem_Pane_on_delete_fail():
     assert fsp.show_warning.call_count == 1
 
 
-def test_FileSystem_Pane_on_get_fail():
+def test_FileSystem_Pane_on_get_fail(qtapp):
     """
     A warning is emitted if getting files from the micro:bit fails.
     """
@@ -885,7 +887,7 @@ def test_FileSystem_Pane_on_get_fail():
     assert fsp.show_warning.call_count == 1
 
 
-def test_FileSystemPane_set_font_size():
+def test_FileSystemPane_set_font_size(qtapp):
     """
     Ensure the right size is set as the point size and the text based UI child
     widgets are updated.
@@ -904,7 +906,7 @@ def test_FileSystemPane_set_font_size():
     fsp.local_fs.setFont.assert_called_once_with(fsp.font)
 
 
-def test_FileSystemPane_open_file():
+def test_FileSystemPane_open_file(qtapp):
     """
     FileSystemPane should propogate the open_file signal
     """
@@ -916,7 +918,7 @@ def test_FileSystemPane_open_file():
     mock_open_emit.assert_called_once_with("test")
 
 
-def test_JupyterREPLPane_init():
+def test_JupyterREPLPane_init(qtapp):
     """
     Ensure the widget is setup with the correct defaults.
     """
@@ -924,7 +926,7 @@ def test_JupyterREPLPane_init():
     assert jw.console_height == 10
 
 
-def test_JupyterREPLPane_append_plain_text():
+def test_JupyterREPLPane_append_plain_text(qtapp):
     """
     Ensure signal and expected bytes are emitted when _append_plain_text is
     called.
@@ -935,7 +937,7 @@ def test_JupyterREPLPane_append_plain_text():
     jw.on_append_text.emit.assert_called_once_with("hello".encode("utf-8"))
 
 
-def test_JupyterREPLPane_set_font_size():
+def test_JupyterREPLPane_set_font_size(qtapp):
     """
     Check the new point size is succesfully applied.
     """
@@ -944,7 +946,7 @@ def test_JupyterREPLPane_set_font_size():
     assert jw.font.pointSize() == 16
 
 
-def test_JupyterREPLPane_set_zoom():
+def test_JupyterREPLPane_set_zoom(qtapp):
     """
     Ensure the expected font point size is set from the zoom size.
     """
@@ -956,7 +958,7 @@ def test_JupyterREPLPane_set_zoom():
     )
 
 
-def test_JupyterREPLPane_set_theme_day():
+def test_JupyterREPLPane_set_theme_day(qtapp):
     """
     Make sure the theme is correctly set for day.
     """
@@ -966,7 +968,7 @@ def test_JupyterREPLPane_set_theme_day():
     jw.set_default_style.assert_called_once_with()
 
 
-def test_JupyterREPLPane_set_theme_night():
+def test_JupyterREPLPane_set_theme_night(qtapp):
     """
     Make sure the theme is correctly set for night.
     """
@@ -976,7 +978,7 @@ def test_JupyterREPLPane_set_theme_night():
     jw.set_default_style.assert_called_once_with(colors="nocolor")
 
 
-def test_JupyterREPLPane_set_theme_contrast():
+def test_JupyterREPLPane_set_theme_contrast(qtapp):
     """
     Make sure the theme is correctly set for high contrast.
     """
@@ -986,7 +988,7 @@ def test_JupyterREPLPane_set_theme_contrast():
     jw.set_default_style.assert_called_once_with(colors="nocolor")
 
 
-def test_JupyterREPLPane_setFocus():
+def test_JupyterREPLPane_setFocus(qtapp):
     """
     Ensures setFocus actually occurs to the _control containing the REPL.
     """
@@ -996,7 +998,7 @@ def test_JupyterREPLPane_setFocus():
     jw._control.setFocus.assert_called_once_with()
 
 
-def test_PythonProcessPane_init():
+def test_PythonProcessPane_init(qtapp):
     """
     Check the font, input_buffer and other initial state is set as expected.
     """
@@ -1011,7 +1013,7 @@ def test_PythonProcessPane_init():
     assert ppp.reading_stdout is False
 
 
-def test_PythonProcessPane_start_process():
+def test_PythonProcessPane_start_process(qtapp):
     """
     Ensure the default arguments for starting a new process work as expected.
     Interactive mode is True, no debugger flag nor additional arguments.
@@ -1039,7 +1041,7 @@ def test_PythonProcessPane_start_process():
     assert ppp.running is True
 
 
-def test_PythonProcessPane_start_process_command_args():
+def test_PythonProcessPane_start_process_command_args(qtapp):
     """
     Ensure that the new process is passed the expected comand line args.
     """
@@ -1057,7 +1059,7 @@ def test_PythonProcessPane_start_process_command_args():
     ppp.process.start.assert_called_once_with(runner, expected_args)
 
 
-def test_PythonProcessPane_start_process_debugger():
+def test_PythonProcessPane_start_process_debugger(qtapp):
     """
     Ensure starting a new process with the debugger flag set to True uses the
     debug runner to execute the script.
@@ -1080,7 +1082,7 @@ def test_PythonProcessPane_start_process_debugger():
     ppp.process.start.assert_called_once_with(python_exec, expected_args)
 
 
-def test_PythonProcessPane_start_process_not_interactive():
+def test_PythonProcessPane_start_process_not_interactive(qtapp):
     """
     Ensure that if the interactive flag is unset, the "-i" flag passed into
     the Python process is missing.
@@ -1101,7 +1103,7 @@ def test_PythonProcessPane_start_process_not_interactive():
     ppp.process.start.assert_called_once_with(runner, expected_args)
 
 
-def test_PythonProcessPane_start_process_windows_path():
+def test_PythonProcessPane_start_process_windows_path(qtapp):
     """
     If running on Windows via the installer ensure that the expected paths
     find their way into a temporary mu.pth file.
@@ -1150,7 +1152,7 @@ def test_PythonProcessPane_start_process_windows_path():
         assert e + "\n" in added_paths
 
 
-def test_PythonProcessPane_start_process_windows_path_no_user_site():
+def test_PythonProcessPane_start_process_windows_path_no_user_site(qtapp):
     """
     If running on Windows via the installer ensure that the Mu logs the
     fact it's unable to use the temporary mu.pth file because there is no
@@ -1186,7 +1188,7 @@ def test_PythonProcessPane_start_process_windows_path_no_user_site():
     assert expected in logs
 
 
-def test_PythonProcessPane_start_process_windows_path_with_exception():
+def test_PythonProcessPane_start_process_windows_path_with_exception(qtapp):
     """
     If running on Windows via the installer ensure that the expected paths
     find their way into a temporary mu.pth file.
@@ -1224,7 +1226,7 @@ def test_PythonProcessPane_start_process_windows_path_with_exception():
     assert expected in logs
 
 
-def test_PythonProcessPane_start_process_user_enviroment_variables():
+def test_PythonProcessPane_start_process_user_enviroment_variables(qtapp):
     """
     Ensure that if environment variables are set, they are set in the context
     of the new child Python process.
@@ -1283,7 +1285,7 @@ def test_PythonProcessPane_start_process_user_enviroment_variables():
     )
 
 
-def test_PythonProcessPane_start_process_custom_runner():
+def test_PythonProcessPane_start_process_custom_runner(qtapp):
     """
     Ensure that if the runner is set, it is used as the command to start the
     new child Python process.
@@ -1307,7 +1309,7 @@ def test_PythonProcessPane_start_process_custom_runner():
     ppp.process.start.assert_called_once_with("foo", expected_args)
 
 
-def test_PythonProcessPane_start_process_custom_python_args():
+def test_PythonProcessPane_start_process_custom_python_args(qtapp):
     """
     Ensure that if there are arguments to be passed into the Python runtime
     starting the child process, these are passed on correctly.
@@ -1328,7 +1330,7 @@ def test_PythonProcessPane_start_process_custom_python_args():
     ppp.process.start.assert_called_once_with(runner, expected_args)
 
 
-def test_PythonProcessPane_finished():
+def test_PythonProcessPane_finished(qtapp):
     """
     Check the functionality to handle the process finishing is correct.
     """
@@ -1346,7 +1348,7 @@ def test_PythonProcessPane_finished():
     ppp.setTextCursor.assert_called_once_with(ppp.textCursor())
 
 
-def test_PythonProcessPane_context_menu():
+def test_PythonProcessPane_context_menu(qtapp):
     """
     Ensure the context menu for the REPL is configured correctly for non-OSX
     platforms.
@@ -1372,7 +1374,7 @@ def test_PythonProcessPane_context_menu():
     assert mock_qmenu.exec_.call_count == 1
 
 
-def test_PythonProcessPane_context_menu_darwin():
+def test_PythonProcessPane_context_menu_darwin(qtapp):
     """
     Ensure the context menu for the REPL is configured correctly for non-OSX
     platforms.
@@ -1398,7 +1400,7 @@ def test_PythonProcessPane_context_menu_darwin():
     assert mock_qmenu.exec_.call_count == 1
 
 
-def test_PythonProcessPane_paste():
+def test_PythonProcessPane_paste(qtapp):
     """
     Ensure pasted text is handed off to the parse_paste method.
     """
@@ -1414,7 +1416,7 @@ def test_PythonProcessPane_paste():
     ppp.parse_paste.assert_called_once_with("Hello")
 
 
-def test_PythonProcessPane_paste_normalize_windows_newlines():
+def test_PythonProcessPane_paste_normalize_windows_newlines(qtapp):
     """
     Ensure that pasted text containing Windows style line-ends is normalised
     to '\n'.
@@ -1431,7 +1433,7 @@ def test_PythonProcessPane_paste_normalize_windows_newlines():
     ppp.parse_paste.assert_called_once_with("h\ni")
 
 
-def test_PythonProcessPane_parse_paste():
+def test_PythonProcessPane_parse_paste(qtapp):
     """
     Given some text ensure that the first character is correctly handled and
     the remaining text to be processed is scheduled to be parsed in the future.
@@ -1450,7 +1452,7 @@ def test_PythonProcessPane_parse_paste():
     assert mock_timer.singleShot.call_count == 1
 
 
-def test_PythonProcessPane_parse_paste_non_ascii():
+def test_PythonProcessPane_parse_paste_non_ascii(qtapp):
     """
     Given some non-ascii yet printable text, ensure that the first character is
     correctly handled and the remaining text to be processed is scheduled to be
@@ -1465,7 +1467,7 @@ def test_PythonProcessPane_parse_paste_non_ascii():
     assert mock_timer.singleShot.call_count == 1
 
 
-def test_PythonProcessPane_parse_paste_newline():
+def test_PythonProcessPane_parse_paste_newline(qtapp):
     """
     As above, but ensure the correct handling of a newline character.
     """
@@ -1478,7 +1480,7 @@ def test_PythonProcessPane_parse_paste_newline():
     assert mock_timer.singleShot.call_count == 1
 
 
-def test_PythonProcessPane_parse_paste_final_character():
+def test_PythonProcessPane_parse_paste_final_character(qtapp):
     """
     As above, but ensure that if there a no more remaining characters to parse
     in the pasted text, then don't schedule any more recursive calls.
@@ -1492,7 +1494,7 @@ def test_PythonProcessPane_parse_paste_final_character():
     assert mock_timer.singleShot.call_count == 0
 
 
-def test_PythonProcessPane_keyPressEvent_a():
+def test_PythonProcessPane_keyPressEvent_a(qtapp):
     """
     A character is typed and passed into parse_input in the expected manner.
     """
@@ -1506,7 +1508,7 @@ def test_PythonProcessPane_keyPressEvent_a():
     ppp.parse_input.assert_called_once_with(Qt.Key_A, "a", None)
 
 
-def test_PythonProcessPane_on_process_halt():
+def test_PythonProcessPane_on_process_halt(qtapp):
     """
     Ensure the output from the halted process is dumped to the UI.
     """
@@ -1523,7 +1525,7 @@ def test_PythonProcessPane_on_process_halt():
     ppp.set_start_of_current_line.assert_called_once_with()
 
 
-def test_PythonProcessPane_on_process_halt_badly_formed_bytes():
+def test_PythonProcessPane_on_process_halt_badly_formed_bytes(qtapp):
     """
     If the bytes read from the child process's stdout starts with a badly
     formed unicode character (e.g. a fragment of a multi-byte character such as
@@ -1543,7 +1545,7 @@ def test_PythonProcessPane_on_process_halt_badly_formed_bytes():
     ppp.set_start_of_current_line.assert_called_once_with()
 
 
-def test_PythonProcessPane_parse_input_a():
+def test_PythonProcessPane_parse_input_a(qtapp):
     """
     Ensure a regular printable character is inserted into the text area.
     """
@@ -1556,7 +1558,7 @@ def test_PythonProcessPane_parse_input_a():
     ppp.insert.assert_called_once_with(b"a")
 
 
-def test_PythonProcessPane_parse_input_non_ascii():
+def test_PythonProcessPane_parse_input_non_ascii(qtapp):
     """
     Ensure a non-ascii printable character is inserted into the text area.
     """
@@ -1569,7 +1571,7 @@ def test_PythonProcessPane_parse_input_non_ascii():
     ppp.insert.assert_called_once_with("Å".encode("utf-8"))
 
 
-def test_PythonProcessPane_parse_input_ctrl_c():
+def test_PythonProcessPane_parse_input_ctrl_c(qtapp):
     """
     Control-C (SIGINT / KeyboardInterrupt) character is typed.
     """
@@ -1591,7 +1593,7 @@ def test_PythonProcessPane_parse_input_ctrl_c():
     mock_timer.singleShot.assert_called_once_with(1, ppp.on_process_halt)
 
 
-def test_PythonProcessPane_parse_input_ctrl_d():
+def test_PythonProcessPane_parse_input_ctrl_d(qtapp):
     """
     Control-D (Kill process) character is typed.
     """
@@ -1611,7 +1613,7 @@ def test_PythonProcessPane_parse_input_ctrl_d():
     mock_timer.singleShot.assert_called_once_with(1, ppp.on_process_halt)
 
 
-def test_PythonProcessPane_parse_input_ctrl_c_after_process_finished():
+def test_PythonProcessPane_parse_input_ctrl_c_after_process_finished(qtapp):
     """
     Control-C (SIGINT / KeyboardInterrupt) character is typed.
     """
@@ -1630,7 +1632,7 @@ def test_PythonProcessPane_parse_input_ctrl_c_after_process_finished():
     assert mock_kill.call_count == 0
 
 
-def test_PythonProcessPane_parse_input_ctrl_d_after_process_finished():
+def test_PythonProcessPane_parse_input_ctrl_d_after_process_finished(qtapp):
     """
     Control-D (Kill process) character is typed.
     """
@@ -1647,7 +1649,7 @@ def test_PythonProcessPane_parse_input_ctrl_d_after_process_finished():
         assert ppp.process.kill.call_count == 0
 
 
-def test_PythonProcessPane_parse_input_up_arrow():
+def test_PythonProcessPane_parse_input_up_arrow(qtapp):
     """
     Up Arrow causes the input line to be replaced with movement back in
     command history.
@@ -1661,7 +1663,7 @@ def test_PythonProcessPane_parse_input_up_arrow():
     assert ppp.history_back.call_count == 1
 
 
-def test_PythonProcessPane_parse_input_down_arrow():
+def test_PythonProcessPane_parse_input_down_arrow(qtapp):
     """
     Down Arrow causes the input line to be replaced with movement forward
     through command line.
@@ -1675,7 +1677,7 @@ def test_PythonProcessPane_parse_input_down_arrow():
     assert ppp.history_forward.call_count == 1
 
 
-def test_PythonProcessPane_parse_input_right_arrow():
+def test_PythonProcessPane_parse_input_right_arrow(qtapp):
     """
     Right Arrow causes the cursor to move to the right one place.
     """
@@ -1691,7 +1693,7 @@ def test_PythonProcessPane_parse_input_right_arrow():
     ppp.setTextCursor.assert_called_once_with(mock_cursor)
 
 
-def test_PythonProcessPane_parse_input_left_arrow():
+def test_PythonProcessPane_parse_input_left_arrow(qtapp):
     """
     Left Arrow causes the cursor to move to the left one place if not at the
     start of the input line.
@@ -1710,7 +1712,7 @@ def test_PythonProcessPane_parse_input_left_arrow():
     ppp.setTextCursor.assert_called_once_with(mock_cursor)
 
 
-def test_PythonProcessPane_parse_input_left_arrow_at_start_of_line():
+def test_PythonProcessPane_parse_input_left_arrow_at_start_of_line(qtapp):
     """
     Left Arrow doesn't do anything if the current cursor position is at the
     start of the input line.
@@ -1729,7 +1731,7 @@ def test_PythonProcessPane_parse_input_left_arrow_at_start_of_line():
     assert ppp.setTextCursor.call_count == 0
 
 
-def test_PythonProcessPane_parse_input_home():
+def test_PythonProcessPane_parse_input_home(qtapp):
     """
     Home moves cursor to the start of the input line.
     """
@@ -1748,7 +1750,7 @@ def test_PythonProcessPane_parse_input_home():
     ppp.setTextCursor.assert_called_once_with(mock_cursor)
 
 
-def test_PythonProcessPane_parse_input_end():
+def test_PythonProcessPane_parse_input_end(qtapp):
     """
     End moves cursor to the end of the input line.
     """
@@ -1764,7 +1766,7 @@ def test_PythonProcessPane_parse_input_end():
     ppp.setTextCursor.assert_called_once_with(mock_cursor)
 
 
-def test_PythonProcessPane_parse_input_paste():
+def test_PythonProcessPane_parse_input_paste(qtapp):
     """
     Control-Shift-V (paste) character causes a paste to happen.
     """
@@ -1777,7 +1779,7 @@ def test_PythonProcessPane_parse_input_paste():
     ppp.paste.assert_called_once_with()
 
 
-def test_PythonProcessPane_parse_input_copy():
+def test_PythonProcessPane_parse_input_copy(qtapp):
     """
     Control-Shift-C (copy) character causes copy to happen.
     """
@@ -1790,7 +1792,7 @@ def test_PythonProcessPane_parse_input_copy():
     ppp.copy.assert_called_once_with()
 
 
-def test_PythonProcessPane_parse_input_backspace():
+def test_PythonProcessPane_parse_input_backspace(qtapp):
     """
     Backspace call causes a backspace from the character at the cursor
     position.
@@ -1804,7 +1806,7 @@ def test_PythonProcessPane_parse_input_backspace():
     ppp.backspace.assert_called_once_with()
 
 
-def test_PythonProcessPane_parse_input_delete():
+def test_PythonProcessPane_parse_input_delete(qtapp):
     """
     Delete deletes the character to the right of the cursor position.
     """
@@ -1817,7 +1819,7 @@ def test_PythonProcessPane_parse_input_delete():
     ppp.delete.assert_called_once_with()
 
 
-def test_PythonProcessPane_parse_input_newline():
+def test_PythonProcessPane_parse_input_newline(qtapp):
     """
     Newline causes the input line to be written to the child process's stdin.
     """
@@ -1840,7 +1842,9 @@ def test_PythonProcessPane_parse_input_newline():
     assert ppp.start_of_current_line == 4  # len('abc\n')
 
 
-def test_PythonProcessPane_parse_input_newline_ignore_empty_input_in_history():
+def test_PythonProcessPane_parse_input_newline_ignore_empty_input_in_history(
+    qtapp,
+):
     """
     Newline causes the input line to be written to the child process's stdin,
     but if the resulting line is either empty or only contains whitespace, do
@@ -1859,7 +1863,7 @@ def test_PythonProcessPane_parse_input_newline_ignore_empty_input_in_history():
     assert ppp.history_position == 0
 
 
-def test_PythonProcessPane_parse_input_newline_with_cursor_midline():
+def test_PythonProcessPane_parse_input_newline_with_cursor_midline(qtapp):
     """
     Ensure that when the cursor is placed in the middle of a line and enter is
     pressed the whole line is sent to std_in.
@@ -1872,7 +1876,7 @@ def test_PythonProcessPane_parse_input_newline_with_cursor_midline():
     ppp.write_to_stdin.assert_called_with(b"abc\n")
 
 
-def test_PythonProcessPane_set_start_of_current_line():
+def test_PythonProcessPane_set_start_of_current_line(qtapp):
     """
     Ensure the start of the current line is set to the current length of the
     text in the editor pane.
@@ -1883,7 +1887,7 @@ def test_PythonProcessPane_set_start_of_current_line():
     assert ppp.start_of_current_line == len("Hello𠜎")
 
 
-def test_PythonProcessPane_history_back():
+def test_PythonProcessPane_history_back(qtapp):
     """
     Ensure the current input line is replaced by the next item back in time
     from the current history position.
@@ -1898,7 +1902,7 @@ def test_PythonProcessPane_history_back():
     assert ppp.history_position == -1
 
 
-def test_PythonProcessPane_history_back_at_first_item():
+def test_PythonProcessPane_history_back_at_first_item(qtapp):
     """
     Ensure the current input line is replaced by the next item back in time
     from the current history position.
@@ -1913,7 +1917,7 @@ def test_PythonProcessPane_history_back_at_first_item():
     assert ppp.history_position == -3
 
 
-def test_PythonProcessPane_history_forward():
+def test_PythonProcessPane_history_forward(qtapp):
     """
     Ensure the current input line is replaced by the next item forward in time
     from the current history position.
@@ -1928,7 +1932,7 @@ def test_PythonProcessPane_history_forward():
     assert ppp.history_position == -2
 
 
-def test_PythonProcessPane_history_forward_at_last_item():
+def test_PythonProcessPane_history_forward_at_last_item(qtapp):
     """
     Ensure the current input line is cleared if the history position was at
     the most recent item.
@@ -1945,7 +1949,7 @@ def test_PythonProcessPane_history_forward_at_last_item():
     assert ppp.history_position == 0
 
 
-def test_PythonProcessPane_try_read_from_stdout_not_started():
+def test_PythonProcessPane_try_read_from_stdout_not_started(qtapp):
     """
     If the process pane is NOT already reading from STDOUT then ensure it
     starts to.
@@ -1957,7 +1961,7 @@ def test_PythonProcessPane_try_read_from_stdout_not_started():
     ppp.read_from_stdout.assert_called_once_with()
 
 
-def test_PythonProcessPane_try_read_from_stdout_has_started():
+def test_PythonProcessPane_try_read_from_stdout_has_started(qtapp):
     """
     If the process pane is already reading from STDOUT then ensure it
     doesn't keep trying.
@@ -1970,7 +1974,7 @@ def test_PythonProcessPane_try_read_from_stdout_has_started():
     assert ppp.read_from_stdout.call_count == 0
 
 
-def test_PythonProcessPane_read_from_stdout():
+def test_PythonProcessPane_read_from_stdout(qtapp):
     """
     Ensure incoming bytes from sub-process's stout are processed correctly.
     """
@@ -1990,7 +1994,7 @@ def test_PythonProcessPane_read_from_stdout():
     mock_timer.singleShot.assert_called_once_with(2, ppp.read_from_stdout)
 
 
-def test_PythonProcessPane_read_from_stdout_with_stdout_buffer():
+def test_PythonProcessPane_read_from_stdout_with_stdout_buffer(qtapp):
     """
     Ensure incoming bytes from sub-process's stdout are processed correctly if
     there was a split between reads in a multi-byte character (such as "𠜎").
@@ -2015,7 +2019,7 @@ def test_PythonProcessPane_read_from_stdout_with_stdout_buffer():
     assert ppp.stdout_buffer == b""
 
 
-def test_PythonProcessPane_read_from_stdout_with_unicode_error():
+def test_PythonProcessPane_read_from_stdout_with_unicode_error(qtapp):
     """
     Ensure incoming bytes from sub-process's stdout are processed correctly if
     there was a split between reads in a multi-byte character (such as "𠜎").
@@ -2040,7 +2044,7 @@ def test_PythonProcessPane_read_from_stdout_with_unicode_error():
     assert ppp.stdout_buffer == msg[:7]
 
 
-def test_PythonProcessPane_read_from_stdout_no_data():
+def test_PythonProcessPane_read_from_stdout_no_data(qtapp):
     """
     If no data is returned, ensure the reading_stdout flag is reset to False.
     """
@@ -2052,7 +2056,7 @@ def test_PythonProcessPane_read_from_stdout_no_data():
     assert ppp.reading_stdout is False
 
 
-def test_PythonProcessPane_write_to_stdin():
+def test_PythonProcessPane_write_to_stdin(qtapp):
     """
     Ensure input from the user is written to the child process.
     """
@@ -2062,7 +2066,7 @@ def test_PythonProcessPane_write_to_stdin():
     ppp.process.write.assert_called_once_with(b"hello")
 
 
-def test_PythonProcessPane_append():
+def test_PythonProcessPane_append(qtapp):
     """
     Ensure the referenced byte_stream is added to the textual content of the
     QTextEdit.
@@ -2076,7 +2080,7 @@ def test_PythonProcessPane_append():
     assert mock_cursor.movePosition.call_count == 2
 
 
-def test_PythonProcessPane_insert_within_input_line():
+def test_PythonProcessPane_insert_within_input_line(qtapp):
     """
     Ensure text is inserted at the end of the document if the current cursor
     position is not within the bounds of the input line.
@@ -2092,7 +2096,7 @@ def test_PythonProcessPane_insert_within_input_line():
     mock_cursor.insertText.assert_called_once_with("hello")
 
 
-def test_PythonProcessPane_insert():
+def test_PythonProcessPane_insert(qtapp):
     """
     Ensure text is inserted at the current cursor position.
     """
@@ -2107,7 +2111,7 @@ def test_PythonProcessPane_insert():
     mock_cursor.insertText.assert_called_once_with("hello")
 
 
-def test_PythonProcessPane_backspace():
+def test_PythonProcessPane_backspace(qtapp):
     """
     Make sure that removing a character to the left of the current cursor
     position works as expected.
@@ -2124,7 +2128,7 @@ def test_PythonProcessPane_backspace():
     ppp.setTextCursor.assert_called_once_with(mock_cursor)
 
 
-def test_PythonProcessPane_backspace_at_start_of_input_line():
+def test_PythonProcessPane_backspace_at_start_of_input_line(qtapp):
     """
     Make sure that removing a character will not work if the cursor is at the
     left-hand boundary of the input line.
@@ -2139,7 +2143,7 @@ def test_PythonProcessPane_backspace_at_start_of_input_line():
     assert mock_cursor.deletePreviousChar.call_count == 0
 
 
-def test_PythonProcessPane_delete():
+def test_PythonProcessPane_delete(qtapp):
     """
     Make sure that removing a character to the right of the current cursor
     position works as expected.
@@ -2156,7 +2160,7 @@ def test_PythonProcessPane_delete():
     ppp.setTextCursor.assert_called_once_with(mock_cursor)
 
 
-def test_PythonProcessPane_delete_at_start_of_input_line():
+def test_PythonProcessPane_delete_at_start_of_input_line(qtapp):
     """
     Make sure that removing a character will not work if the cursor is at the
     left-hand boundary of the input line.
@@ -2171,7 +2175,7 @@ def test_PythonProcessPane_delete_at_start_of_input_line():
     assert mock_cursor.deleteChar.call_count == 0
 
 
-def test_PythonProcessPane_clear_input_line():
+def test_PythonProcessPane_clear_input_line(qtapp):
     """
     Ensure the input line is cleared back to the start of the input line.
     """
@@ -2187,7 +2191,7 @@ def test_PythonProcessPane_clear_input_line():
     ppp.setTextCursor.assert_called_once_with(mock_cursor)
 
 
-def test_PythonProcessPane_replace_input_line():
+def test_PythonProcessPane_replace_input_line(qtapp):
     """
     Ensure that the input line is cleared and then the replacement text is
     appended to the text area.
@@ -2200,7 +2204,7 @@ def test_PythonProcessPane_replace_input_line():
     ppp.append.assert_called_once_with("hello")
 
 
-def test_PythonProcessPane_set_font_size():
+def test_PythonProcessPane_set_font_size(qtapp):
     """
     Ensure the font size is set to the expected point size.
     """
@@ -2213,7 +2217,7 @@ def test_PythonProcessPane_set_font_size():
     ppp.setFont.assert_called_once_with(mock_font)
 
 
-def test_PythonProcessPane_set_zoom():
+def test_PythonProcessPane_set_zoom(qtapp):
     """
     Ensure the expected point size is set from the given "t-shirt" size.
     """
@@ -2224,7 +2228,7 @@ def test_PythonProcessPane_set_zoom():
     ppp.set_font_size.assert_called_once_with(expected)
 
 
-def test_PythonProcessPane_set_theme():
+def test_PythonProcessPane_set_theme(qtapp):
     """
     Setting the theme shouldn't do anything
     """
@@ -2232,13 +2236,13 @@ def test_PythonProcessPane_set_theme():
     ppp.set_theme("test")
 
 
-def test_DebugInspectorItem():
+def test_DebugInspectorItem(qtapp):
     item = mu.interface.panes.DebugInspectorItem("test")
     assert item.text() == "test"
     assert not item.isEditable()
 
 
-def test_DebugInspector_set_font_size():
+def test_DebugInspector_set_font_size(qtapp):
     """
     Check the correct stylesheet values are being set.
     """
@@ -2250,7 +2254,7 @@ def test_DebugInspector_set_font_size():
     assert "font-family: Monospace;" in style
 
 
-def test_DebugInspector_set_zoom():
+def test_DebugInspector_set_zoom(qtapp):
     """
     Ensure the expected point size is set from the given "t-shirt" size.
     """
@@ -2261,7 +2265,7 @@ def test_DebugInspector_set_zoom():
     di.set_font_size.assert_called_once_with(expected)
 
 
-def test_DebugInspector_set_theme():
+def test_DebugInspector_set_theme(qtapp):
     """
     Setting the theme shouldn't do anything
     """
@@ -2269,7 +2273,7 @@ def test_DebugInspector_set_theme():
     di.set_theme("test")
 
 
-def test_PlotterPane_init():
+def test_PlotterPane_init(qtapp):
     """
     Ensure the plotter pane is created in the expected manner.
     """
@@ -2287,7 +2291,7 @@ def test_PlotterPane_init():
     assert isinstance(pp.axis_y, QValueAxis)
 
 
-def test_PlotterPane_process_bytes():
+def test_PlotterPane_process_bytes(qtapp):
     """
     If a byte representation of a Python tuple containing numeric values,
     starting at the beginning of a new line and terminating with a new line is
@@ -2300,7 +2304,7 @@ def test_PlotterPane_process_bytes():
     pp.add_data.assert_called_once_with((1, 2.3, 4))
 
 
-def test_PlotterPane_process_bytes_guards_against_data_flood():
+def test_PlotterPane_process_bytes_guards_against_data_flood(qtapp):
     """
     If the process_bytes method gets data of more than 1024 bytes then trigger
     a data_flood signal and ensure the plotter no longer processes incoming
@@ -2321,7 +2325,7 @@ def test_PlotterPane_process_bytes_guards_against_data_flood():
     assert pp.add_data.call_count == 0
 
 
-def test_PlotterPane_process_bytes_tuple_not_numeric():
+def test_PlotterPane_process_bytes_tuple_not_numeric(qtapp):
     """
     If a byte representation of a tuple is received but it doesn't contain
     numeric values, then the add_data method MUST NOT be called.
@@ -2332,7 +2336,7 @@ def test_PlotterPane_process_bytes_tuple_not_numeric():
     assert pp.add_data.call_count == 0
 
 
-def test_PlotterPane_process_bytes_overrun_input_buffer():
+def test_PlotterPane_process_bytes_overrun_input_buffer(qtapp):
     """
     If the incoming bytes are not complete, ensure the input_buffer caches them
     until the newline is detected.
@@ -2351,7 +2355,7 @@ def test_PlotterPane_process_bytes_overrun_input_buffer():
     pp.add_data.assert_called_once_with((1, 2.3, 4))
 
 
-def test_PlotterPane_add_data():
+def test_PlotterPane_add_data(qtapp):
     """
     Given a tuple with a single value, ensure it is logged and correctly added
     to the chart.
@@ -2367,7 +2371,7 @@ def test_PlotterPane_add_data():
     mock_line_series.append.call_args_list[99][0] == (99, 1)
 
 
-def test_PlotterPane_add_data_adjust_values_up():
+def test_PlotterPane_add_data_adjust_values_up(qtapp):
     """
     If more values than have been encountered before are added to the incoming
     data then increase the number of QLineSeries instances.
@@ -2384,7 +2388,7 @@ def test_PlotterPane_add_data_adjust_values_up():
     assert len(pp.data) == 4
 
 
-def test_PlotterPane_add_data_adjust_values_down():
+def test_PlotterPane_add_data_adjust_values_down(qtapp):
     """
     If less values are encountered, before they are added to the incoming
     data then decrease the number of QLineSeries instances.
@@ -2401,7 +2405,7 @@ def test_PlotterPane_add_data_adjust_values_down():
     assert pp.chart.removeSeries.call_count == 2
 
 
-def test_PlotterPane_add_data_re_scale_up():
+def test_PlotterPane_add_data_re_scale_up(qtapp):
     """
     If the y axis contains data greater than the current range, then ensure
     the range is doubled.
@@ -2415,7 +2419,7 @@ def test_PlotterPane_add_data_re_scale_up():
     pp.axis_y.setRange.assert_called_once_with(-2000, 2000)
 
 
-def test_PlotterPane_add_data_re_scale_down():
+def test_PlotterPane_add_data_re_scale_down(qtapp):
     """
     If the y axis contains data less than half of the current range, then
     ensure the range is halved.
@@ -2430,7 +2434,7 @@ def test_PlotterPane_add_data_re_scale_down():
     pp.axis_y.setRange.assert_called_once_with(-2000, 2000)
 
 
-def test_PlotterPane_set_label_format_to_float_when_range_small():
+def test_PlotterPane_set_label_format_to_float_when_range_small(qtapp):
     """
     If the max_y is 5 or less, make sure the label format is set to being a
     float with two decimal places.
@@ -2446,7 +2450,7 @@ def test_PlotterPane_set_label_format_to_float_when_range_small():
     pp.axis_y.setLabelFormat.assert_called_once_with("%2.2f")
 
 
-def test_PlotterPane_set_label_format_to_int_when_range_large():
+def test_PlotterPane_set_label_format_to_int_when_range_large(qtapp):
     """
     If the max_y is 5 or less, make sure the label format is set to being a
     float with two decimal places.
@@ -2462,7 +2466,7 @@ def test_PlotterPane_set_label_format_to_int_when_range_large():
     pp.axis_y.setLabelFormat.assert_called_once_with("%d")
 
 
-def test_PlotterPane_set_theme():
+def test_PlotterPane_set_theme(qtapp):
     """
     Ensure the themes for the chart relate correctly to the theme names used
     by Mu.

--- a/tests/interface/test_panes.py
+++ b/tests/interface/test_panes.py
@@ -2,7 +2,7 @@
 """
 Tests for the user interface elements of Mu.
 """
-from PyQt5.QtWidgets import QApplication, QMessageBox, QLabel
+from PyQt5.QtWidgets import QMessageBox, QLabel
 from PyQt5.QtChart import QChart, QLineSeries, QValueAxis
 from PyQt5.QtCore import Qt
 from PyQt5.QtGui import QTextCursor
@@ -14,11 +14,6 @@ import mu
 import platform
 from collections import deque
 import mu.interface.panes
-
-# Required so the QWidget tests don't abort with the message:
-# "QWidget: Must construct a QApplication before a QWidget"
-# The QApplication need only be instantiated once.
-app = QApplication([])
 
 
 def test_PANE_ZOOM_SIZES():

--- a/tests/interface/test_themes.py
+++ b/tests/interface/test_themes.py
@@ -44,7 +44,7 @@ def test_Font():
     assert f.italic
 
 
-def test_theme_apply_to():
+def test_theme_apply_to(qtapp):
     """
     Ensure that the apply_to class method updates the passed in lexer with the
     expected font settings.

--- a/tests/modes/test_pygamezero.py
+++ b/tests/modes/test_pygamezero.py
@@ -49,7 +49,7 @@ def test_pgzero_api():
     assert result == SHARED_APIS + PYTHON3_APIS + PI_APIS + PYGAMEZERO_APIS
 
 
-def test_pgzero_play_toggle_on():
+def test_pgzero_play_toggle_on(qtapp):
     """
     Check the handler for clicking play starts the new process and updates the
     UI state.
@@ -89,7 +89,7 @@ def test_pgzero_play_toggle_on_cancelled():
     assert slot.setIcon.call_count == 0
 
 
-def test_pgzero_play_toggle_off():
+def test_pgzero_play_toggle_off(qtapp):
     """
     Check the handler for clicking play stops the process and reverts the UI
     state.

--- a/tests/modes/test_python3.py
+++ b/tests/modes/test_python3.py
@@ -140,7 +140,7 @@ def test_python_api():
     assert result == SHARED_APIS + PYTHON3_APIS + PI_APIS
 
 
-def test_python_run_toggle_on():
+def test_python_run_toggle_on(qtapp):
     """
     Check the handler for clicking run starts the new process and updates the
     UI state.
@@ -185,7 +185,7 @@ def test_python_run_toggle_on_cancelled():
     assert slot.setIcon.call_count == 0
 
 
-def test_python_run_toggle_off():
+def test_python_run_toggle_off(qtapp):
     """
     Check the handler for clicking run stops the process and reverts the UI
     state.

--- a/tests/modes/test_web.py
+++ b/tests/modes/test_web.py
@@ -48,7 +48,7 @@ def test_web_api():
     assert result == SHARED_APIS + PYTHON3_APIS + FLASK_APIS
 
 
-def test_run_toggle_on():
+def test_run_toggle_on(qtapp):
     """
     Check the handler for running the local server starts the sub-process and
     updates the UI state.
@@ -72,7 +72,7 @@ def test_run_toggle_on():
     wm.set_buttons.assert_called_once_with(modes=False)
 
 
-def test_run_toggle_off():
+def test_run_toggle_off(qtapp):
     """
     Check the handler for toggling the local server stops the process and
     reverts the UI state.

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -87,7 +87,7 @@ def test_setup_modes_without_pgzero():
         assert "pygamezero" not in modes
 
 
-def test_run():
+def test_run(qtapp):
     """
     Ensure the run function sets things up in the expected way.
 

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -17,7 +17,7 @@ def test_path():
         r.assert_called_once_with(mu.resources.__name__, "images/foo")
 
 
-def test_load_icon():
+def test_load_icon(qtapp):
     """
     Check the load_icon function returns the expected QIcon object.
     """
@@ -25,7 +25,7 @@ def test_load_icon():
     assert isinstance(result, QIcon)
 
 
-def test_load_pixmap():
+def test_load_pixmap(qtapp):
     """
     Check the load_pixmap function returns the expected QPixmap object.
     """


### PR DESCRIPTION
Perhaps this will fix the Segmentation fault during testing that causing Travis to fail. 

**EDIT:** Forgot to write that all tests that does anything with Qt Widgets, Windows, etc. now needs to specify that they require the "qtapp" fixture in their argument list