### PR TITLE
Attempt at moving to briefcase-0.3.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,9 +61,9 @@ script:
   # Run the tests on macOS and package it: "make macos" runs checks+tests first.
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then make macos; fi
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then mkdir dist; fi
-  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then zip -r -X dist/mu-editor.zip macOS/mu-editor.app; fi
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then export DMGFILE=macOS/mu-editor-*.dmg; fi
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then du -sk dist/; fi
-  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then mv dist/mu-editor.zip dist/mu-editor_$(date '+%Y-%m-%d_%H_%M')_${TRAVIS_BRANCH}_${TRAVIS_COMMIT:0:7}.zip; fi
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then mv "$DMGFILE" dist/mu-editor_$(date '+%Y-%m-%d_%H_%M')_${TRAVIS_BRANCH}_${TRAVIS_COMMIT:0:7}.dmg; fi
 
 # Deploy the build version in an S3 bucket
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,7 @@ script:
   # Run the tests on macOS and package it: "make macos" runs checks+tests first.
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then make macos; fi
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then mkdir dist; fi
-  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then export DMGFILE=macOS/mu-editor-*.dmg; fi
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then export DMGFILE=`bash -c "echo macOS/mu-editor-*.dmg"`; fi
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then du -sk dist/; fi
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then mv "$DMGFILE" dist/mu-editor_$(date '+%Y-%m-%d_%H_%M')_${TRAVIS_BRANCH}_${TRAVIS_COMMIT:0:7}.dmg; fi
 

--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,9 @@ win64: check
 
 macos: check
 	@echo "\nPackaging Mu into a macOS native application."
-	python setup.py macos --support-pkg=https://github.com/mu-editor/mu_portable_python_macos/releases/download/0.0.6/python3-reduced.tar.gz
+	briefcase create
+	briefcase build
+	briefcase package --no-sign
 
 video: clean
 	@echo "\nFetching contributor avatars."

--- a/mu/resources/__init__.py
+++ b/mu/resources/__init__.py
@@ -19,7 +19,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 from pkg_resources import resource_filename, resource_string
 from PyQt5.QtGui import QPixmap, QIcon
-from PyQt5.QtCore import QDir
+from PyQt5.QtCore import QDir, QByteArray
 
 
 # The following lines add the images and css directories to the search path.
@@ -51,4 +51,4 @@ def load_font_data(name):
     """
     Load the (binary) content of a font as bytes
     """
-    return resource_string(__name__, "fonts/" + name)
+    return QByteArray(resource_string(__name__, "fonts/" + name))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,6 @@
 [build-system]
-requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"
+requires = ["setuptools", "wheel", "toml"]
 
 [tool.briefcase]
 project_name = "Mu Editor"
@@ -20,16 +21,14 @@ requires = ['PyQt5==5.13.2;"arm" not in platform_machine',
             # dependencies. For the sake of "locality", it is being declared here,
             # though. Regarding these packages' versions, please refer to:
             # http://flake8.pycqa.org/en/latest/faq.html#why-does-flake8-use-ranges-for-its-dependencies
-            "flake8 >= 3.7.8",
-            "pycodestyle >= 2.5.0, < 2.6.0",
-            "pyflakes >= 2.1.0, < 2.2.0",
+            "flake8 >= 3.8.3",
             "pyserial==3.4",
             "qtconsole==4.7.4",
             "pgzero==1.2",
             "appdirs>=1.4.3",
             "semver>=2.8.0",
             "nudatus>=0.0.3",
-            'black>=18.9b0;python_version > "3.5"',
+            'black>=19.10b0;python_version > "3.5"',
             "Flask==1.1.2"]
 
 sources = ['mu']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,44 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+
+[tool.briefcase]
+project_name = "Mu Editor"
+bundle = "mu.codewith.editor"
+version = "1.1.0a2"
+author = "Nicholas H. Tollervej"
+author_email = "ntoll@ntoll.org"
+requires = []
+
+[tool.briefcase.app.mu]
+formal_name = "mu-editor"
+description = "A simple Python editor for beginner programmers."
+requires = ['PyQt5==5.13.2;"arm" not in platform_machine',
+            'QScintilla==2.11.3;"arm" not in platform_machine',
+            'PyQtChart==5.13.1;"arm" not in platform_machine',
+            # `flake8` is actually a testing/packaging dependency that, among other
+            # packages, brings in `pycodestyle` and `pyflakes` which are runtime
+            # dependencies. For the sake of "locality", it is being declared here,
+            # though. Regarding these packages' versions, please refer to:
+            # http://flake8.pycqa.org/en/latest/faq.html#why-does-flake8-use-ranges-for-its-dependencies
+            "flake8 >= 3.7.8",
+            "pycodestyle >= 2.5.0, < 2.6.0",
+            "pyflakes >= 2.1.0, < 2.2.0",
+            "pyserial==3.4",
+            "qtconsole==4.7.4",
+            "pgzero==1.2",
+            "appdirs>=1.4.3",
+            "semver>=2.8.0",
+            "nudatus>=0.0.3",
+            'black>=18.9b0;python_version > "3.5"',
+            "Flask==1.1.2"]
+
+sources = ['mu']
+
+[tool.briefcase.app.mu.macOS]
+requires = []
+icon = "package/icons/mac_icon"
+# Previously Mu used the following support package, but it doesn't
+# seem to work well with newer versions of briefcase. I'm leaving
+# it here, as someone might want to reintroduce it instead of the
+# default Python version used by briefcase
+#support_package = "https://github.com/mu-editor/mu_portable_python_macos/releases/download/0.0.6/python3-reduced.tar.gz"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,8 +36,4 @@ sources = ['mu']
 [tool.briefcase.app.mu.macOS]
 requires = []
 icon = "package/icons/mac_icon"
-# Previously Mu used the following support package, but it doesn't
-# seem to work well with newer versions of briefcase. I'm leaving
-# it here, as someone might want to reintroduce it instead of the
-# default Python version used by briefcase
-#support_package = "https://github.com/mu-editor/mu_portable_python_macos/releases/download/0.0.6/python3-reduced.tar.gz"
+support_package = "https://github.com/mu-editor/mu_portable_python_macos/releases/download/0.0.6/python3-reduced.tar.gz"

--- a/setup.py
+++ b/setup.py
@@ -50,9 +50,11 @@ extras_require = {
         "pytest-faulthandler",
         "coverage",
     ],
-    "docs": ["docutils >= 0.12, < 0.16", # adding docutils requirement to avoid
-                                         # conflict between sphinx and briefcase
-             "sphinx"],
+    "docs": [
+        # require docutils to avoid conflict between sphinx and briefcase
+        "docutils >= 0.12, < 0.16",
+        "sphinx",
+    ],
     "package": [
         # Wheel building and PyPI uploading
         "wheel",

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ extras_require = {
         'requests==2.23.0;platform_system == "Windows"',
         'yarg==0.1.9;platform_system == "Windows"',
         # macOS native packaging (see Makefile)
-        'briefcase==0.2.9;platform_system == "Darwin"',
+        'briefcase==0.3.1;platform_system == "Darwin"',
     ],
     "utils": ["scrapy", "beautifulsoup4", "requests"],
 }
@@ -123,8 +123,4 @@ setup(
         "Topic :: Text Editors :: Integrated Development Environments (IDE)",
     ],
     entry_points={"console_scripts": ["mu-editor = mu.app:run"]},
-    options={  # Briefcase packaging options for OSX
-        "app": {"formal_name": "mu-editor", "bundle": "mu.codewith.editor"},
-        "macos": {"icon": "package/icons/mac_icon"},
-    },
 )

--- a/win_installer.py
+++ b/win_installer.py
@@ -183,7 +183,8 @@ def pypi_wheels_in(requirements):
 
 def package_name(requirement):
     """
-    Returns the name component of a `name==version` formated requirement.
+    Returns the name component of a `name==version` formatted requirement, or a
+    `name @ file://...` formatted requirement.
     """
     # Take chars until we reach either = or space
     name = takewhile(lambda x: not (x == "=" or x == " "), requirement)

--- a/win_installer.py
+++ b/win_installer.py
@@ -47,6 +47,7 @@ import zipfile
 
 import requests
 import yarg
+from itertools import takewhile
 
 
 # The pynsist requirement spec that will be used to install pynsist in
@@ -184,7 +185,9 @@ def package_name(requirement):
     """
     Returns the name component of a `name==version` formated requirement.
     """
-    return requirement.partition("==")[0]
+    # Take chars until we reach either = or space
+    name = takewhile(lambda x: not (x == "=" or x == " "), requirement)
+    return "".join(name)
 
 
 def packages_from(requirements, wheels):


### PR DESCRIPTION
This is a first attempt at moving to briefcase-0.3.1.

Known issues:
 - currently dependencies are listed in both setup.py and pyproject.toml, I guess setup.py could be rewritten to parse pyproject.toml and read the settings from there. Alternatively, people seem to suggest switching from setuptools to something like poetry
 - doesn't use the Python from https://github.com/mu-editor/mu_portable_python_macos/releases/download/0.0.6/python3-reduced.tar.gz - as it seems incompatible with the new briefcase (perhaps this is a minor thing - directory layout of the contents of the tarball). However, it works with the Python version briefcase supplies by default. I don't know the history for having our own support package, so I'm not sure what to do here.
 - I added a --no-sign flag in the Makefile, as I don't know anything about code signing