### PR TITLE
Allow updated version numbers for requirements.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,24 +21,24 @@ with open(os.path.join(base_dir, "CHANGES.rst"), encoding="utf8") as f:
 
 
 install_requires = [
-    'PyQt5==5.13.2;"arm" not in platform_machine',
-    'QScintilla==2.11.3;"arm" not in platform_machine',
-    'PyQtChart==5.13.1;"arm" not in platform_machine',
+    'PyQt5>=5.13.2;"arm" not in platform_machine',
+    'QScintilla>=2.11.3;"arm" not in platform_machine',
+    'PyQtChart>=5.13.1;"arm" not in platform_machine',
     # `flake8` is actually a testing/packaging dependency that, among other
     # packages, brings in `pycodestyle` and `pyflakes` which are runtime
     # dependencies. For the sake of "locality", it is being declared here,
     # though. Regarding these packages' versions, please refer to:
     # http://flake8.pycqa.org/en/latest/faq.html#why-does-flake8-use-ranges-for-its-dependencies
     "flake8 >= 3.8.3",
-    "pyserial==3.4",
-    "qtconsole==4.7.4",
-    "pgzero==1.2",
+    "pyserial>=3.4",
+    "qtconsole>=4.7.4",
+    "pgzero>=1.2",
     "appdirs>=1.4.3",
-    "semver>=2.8.0",
+    "semver>=2.8.0,<3",
     "nudatus>=0.0.3",
     'black>=19.10b0;python_version > "3.5"',
-    "Flask==1.1.2",
-    "python-dateutil==2.8.0",
+    "Flask>=1.1.2",
+    "python-dateutil>=2.8.0",
 ]
 
 
@@ -114,6 +114,8 @@ setup(
         "Programming Language :: Python :: 3 :: Only",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
         "Topic :: Education",
         "Topic :: Games/Entertainment",
         "Topic :: Software Development",


### PR DESCRIPTION
When using python 3.8 (the default python3 on ubuntu 20.04), the version of pgzero in the requirements will not work. A fix on the `pgzero` size seems relatively easy (see issue lordmauve/pgzero#225 and PR lordmauve/pgzero#207), but this also means the version number in mu's `setup.py` file should be updated.

While at it I allowed the latest release for all dependencies and mu appears be passing tests (and working so far).