### PR TITLE
Fix Mu doesn't recognize Seeed Wio Terminal VID / PID #1080

### DIFF
--- a/mu/modes/circuitpython.py
+++ b/mu/modes/circuitpython.py
@@ -48,6 +48,7 @@ class CircuitPythonMode(MicroPythonMode):
         (0x1B4F, 0x8D23),  # SparkFun SAMD21 Dev Breakout
         (0x1209, 0x2017),  # Mini SAM M4
         (0x1209, 0x7102),  # Mini SAM M0
+        (0x2886, 0x802D),  # Seeed Technology Co., Ltd. Wio Terminal
     ]
     # Modules built into CircuitPython which mustn't be used as file names
     # for source code.


### PR DESCRIPTION
Mu doesn't recognize Seeed Wio Terminal VID / PID #1080

CircuitPython firmware in Wio Terninal needs to know about its VID/PID
  (0x2886, 0x802D),

This pull request enables serial access from Mu to Seeed Wio Terminal