### PR TITLE
Travis: Update Xcode version to 9.4 to fix brew build issues.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ matrix:
     - os: osx
       # match xcode version with earliest supported by current PyQt 
       # (earliest to maximize compatibility)
-      osx_image: xcode9.3
+      osx_image: xcode9.4
       sudo: required
       language: generic
       python: 3.6


### PR DESCRIPTION
This version still stays in macOS 10.13, so general build compatibility should be the same.
Turns out the macOS build failures were due to issues building stuff with brew and this tiny update fixes it.