### PR TITLE
Reduce the Travis log output and build time in macOS (fixes current build failure)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,8 @@ matrix:
       osx_image: xcode9.4
       sudo: required
       language: generic
-      python: 3.6
+      env:
+        - TRAVIS_OSX_PY_VER="3.6.5"
 
 before_install:
   # OS and default Python info
@@ -32,10 +33,8 @@ before_install:
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo apt-get update; fi
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo apt-get install libxkbcommon-x11-0; fi
   # Python 3 installation required
-  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then bash package/install_osx.sh; fi
-  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then pyenv install 3.6.5; fi
-  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then pyenv versions; fi
-  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then pyenv global 3.6.5; fi
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then pyenv install $TRAVIS_OSX_PY_VER; fi
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then pyenv global $TRAVIS_OSX_PY_VER; fi
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then eval "$(pyenv init -)"; fi
   - pip install --upgrade pip setuptools
   # Check everything was correctly installed
@@ -63,7 +62,7 @@ script:
   # Run the tests on macOS and package it: "make macos" runs checks+tests first.
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then make macos; fi
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then mkdir dist; fi
-  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then zip -r -X dist/mu-editor.zip macOS/mu-editor.app; fi
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then zip -r -X -q dist/mu-editor.zip macOS/mu-editor.app; fi
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then du -sk dist/; fi
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then mv dist/mu-editor.zip dist/mu-editor_$(date '+%Y-%m-%d_%H_%M')_${TRAVIS_BRANCH}_${TRAVIS_COMMIT:0:7}.zip; fi
 

--- a/package/install_linux.sh
+++ b/package/install_linux.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-set -ev
-# Install pyenv
-curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash

--- a/package/install_osx.sh
+++ b/package/install_osx.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-set -ev
-brew update >/dev/null 2>&1  # This produces a lot of output that's not very interesting
-
-# Install Python 3.6
-#brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/f2a764ef944b1080be64bd88dca9a1d80130c558/Formula/python.rb
-brew upgrade pyenv 
-# The following are needed for Matplotlib
-brew install freetype


### PR DESCRIPTION
The current macOs Travis builds in master are failing due to the log size limit being reached:
```
The job exceeded the maximum log length, and has been terminated.
```
https://github.com/mu-editor/mu/compare/travis_macos?expand=1

This wasn't caught in https://github.com/mu-editor/mu/pull/1097 because the extra log data is added on deployment, which only happens with commits on master.

This PR reduces the log by making the zip command silent (used to list every single file included in the zip).

It also reduces almost **20min** of the build time by not updating brew and pyenv, as the versions included by default in the VM image are sufficient to build with Python 3.6.