### PR TITLE
Update tests for environments without QtCharts

### DIFF
--- a/tests/interface/test_panes.py
+++ b/tests/interface/test_panes.py
@@ -3,18 +3,19 @@
 Tests for the user interface elements of Mu.
 """
 from PyQt5.QtWidgets import QMessageBox, QLabel
-from PyQt5.QtChart import QChart, QLineSeries, QValueAxis
 from PyQt5.QtCore import Qt, QEvent, QPointF
 from PyQt5.QtGui import QTextCursor, QMouseEvent
+from collections import deque
 from unittest import mock
 
 import sys
 import os
 import signal
-import mu
+import pytest
 
-from collections import deque
+import mu
 import mu.interface.panes
+from mu.interface.panes import CHARTS
 
 
 def test_PANE_ZOOM_SIZES():
@@ -2694,6 +2695,7 @@ def test_DebugInspector_set_theme():
     di.set_theme("test")
 
 
+@pytest.mark.skipif(not CHARTS, reason="QtChart unavailable")
 def test_PlotterPane_init():
     """
     Ensure the plotter pane is created in the expected manner.
@@ -2706,12 +2708,13 @@ def test_PlotterPane_init():
     assert len(pp.data) == 1
     assert isinstance(pp.data[0], deque)
     assert len(pp.series) == 1
-    assert isinstance(pp.series[0], QLineSeries)
-    assert isinstance(pp.chart, QChart)
-    assert isinstance(pp.axis_x, QValueAxis)
-    assert isinstance(pp.axis_y, QValueAxis)
+    assert isinstance(pp.series[0], mu.interface.panes.QLineSeries)
+    assert isinstance(pp.chart, mu.interface.panes.QChart)
+    assert isinstance(pp.axis_x, mu.interface.panes.QValueAxis)
+    assert isinstance(pp.axis_y, mu.interface.panes.QValueAxis)
 
 
+@pytest.mark.skipif(not CHARTS, reason="QtChart unavailable")
 def test_PlotterPane_process_tty_data():
     """
     If a byte representation of a Python tuple containing numeric values,
@@ -2725,6 +2728,7 @@ def test_PlotterPane_process_tty_data():
     pp.add_data.assert_called_once_with((1, 2.3, 4))
 
 
+@pytest.mark.skipif(not CHARTS, reason="QtChart unavailable")
 def test_PlotterPane_process_tty_data_guards_against_data_flood():
     """
     If the process_tty_data method gets data of more than 1024 bytes
@@ -2747,6 +2751,7 @@ def test_PlotterPane_process_tty_data_guards_against_data_flood():
     assert pp.add_data.call_count == 0
 
 
+@pytest.mark.skipif(not CHARTS, reason="QtChart unavailable")
 def test_PlotterPane_process_tty_data_tuple_not_numeric():
     """
     If a byte representation of a tuple is received but it doesn't contain
@@ -2758,6 +2763,7 @@ def test_PlotterPane_process_tty_data_tuple_not_numeric():
     assert pp.add_data.call_count == 0
 
 
+@pytest.mark.skipif(not CHARTS, reason="QtChart unavailable")
 def test_PlotterPane_process_tty_data_overrun_input_buffer():
     """
     If the incoming bytes are not complete, ensure the input_buffer caches them
@@ -2777,6 +2783,7 @@ def test_PlotterPane_process_tty_data_overrun_input_buffer():
     pp.add_data.assert_called_once_with((1, 2.3, 4))
 
 
+@pytest.mark.skipif(not CHARTS, reason="QtChart unavailable")
 def test_PlotterPane_add_data():
     """
     Given a tuple with a single value, ensure it is logged and correctly added
@@ -2791,6 +2798,7 @@ def test_PlotterPane_add_data():
     mock_line_series.append.call_args_list[0][0] == (0, 1)
 
 
+@pytest.mark.skipif(not CHARTS, reason="QtChart unavailable")
 def test_PlotterPane_add_data_adjust_values_up():
     """
     If more values than have been encountered before are added to the incoming
@@ -2808,6 +2816,7 @@ def test_PlotterPane_add_data_adjust_values_up():
     assert len(pp.data) == 4
 
 
+@pytest.mark.skipif(not CHARTS, reason="QtChart unavailable")
 def test_PlotterPane_add_data_adjust_values_down():
     """
     If less values are encountered, before they are added to the incoming
@@ -2825,6 +2834,7 @@ def test_PlotterPane_add_data_adjust_values_down():
     assert pp.chart.removeSeries.call_count == 2
 
 
+@pytest.mark.skipif(not CHARTS, reason="QtChart unavailable")
 def test_PlotterPane_add_data_re_scale_up():
     """
     If the y axis contains data greater than the current range, then ensure
@@ -2839,6 +2849,7 @@ def test_PlotterPane_add_data_re_scale_up():
     pp.axis_y.setRange.assert_called_once_with(0, 2000)
 
 
+@pytest.mark.skipif(not CHARTS, reason="QtChart unavailable")
 def test_PlotterPane_add_data_re_scale_down():
     """
     If the y axis contains data less than half of the current range, then
@@ -2884,6 +2895,7 @@ def test_PlotterPane_add_data_re_scale_min_down():
     pp.axis_y.setRange.assert_called_once_with(-2000, 0)
 
 
+@pytest.mark.skipif(not CHARTS, reason="QtChart unavailable")
 def test_PlotterPane_set_label_format_to_float_when_range_small():
     """
     If the max_y is 5 or less, make sure the label format is set to being a
@@ -2900,6 +2912,7 @@ def test_PlotterPane_set_label_format_to_float_when_range_small():
     pp.axis_y.setLabelFormat.assert_called_once_with("%2.2f")
 
 
+@pytest.mark.skipif(not CHARTS, reason="QtChart unavailable")
 def test_PlotterPane_set_label_format_to_int_when_range_large():
     """
     If the max_y is 5 or less, make sure the label format is set to being a
@@ -2916,6 +2929,7 @@ def test_PlotterPane_set_label_format_to_int_when_range_large():
     pp.axis_y.setLabelFormat.assert_called_once_with("%d")
 
 
+@pytest.mark.skipif(not CHARTS, reason="QtChart unavailable")
 def test_PlotterPane_set_theme():
     """
     Ensure the themes for the chart relate correctly to the theme names used
@@ -2924,10 +2938,16 @@ def test_PlotterPane_set_theme():
     pp = mu.interface.panes.PlotterPane()
     pp.chart = mock.MagicMock()
     pp.set_theme("day")
-    pp.chart.setTheme.assert_called_once_with(QChart.ChartThemeLight)
+    pp.chart.setTheme.assert_called_once_with(
+        mu.interface.panes.QChart.ChartThemeLight
+    )
     pp.chart.setTheme.reset_mock()
     pp.set_theme("night")
-    pp.chart.setTheme.assert_called_once_with(QChart.ChartThemeDark)
+    pp.chart.setTheme.assert_called_once_with(
+        mu.interface.panes.QChart.ChartThemeDark
+    )
     pp.chart.setTheme.reset_mock()
     pp.set_theme("contrast")
-    pp.chart.setTheme.assert_called_once_with(QChart.ChartThemeHighContrast)
+    pp.chart.setTheme.assert_called_once_with(
+        mu.interface.panes.QChart.ChartThemeHighContrast
+    )

--- a/tests/modes/test_circuitpython.py
+++ b/tests/modes/test_circuitpython.py
@@ -22,7 +22,8 @@ def test_circuitpython_mode():
     assert am.editor == editor
     assert am.view == view
 
-    actions = am.actions()
+    with mock.patch("mu.modes.circuitpython.CHARTS", True):
+        actions = am.actions()
     assert len(actions) == 2
     assert actions[0]["name"] == "serial"
     assert actions[0]["handler"] == am.toggle_repl

--- a/tests/modes/test_esp.py
+++ b/tests/modes/test_esp.py
@@ -31,7 +31,8 @@ def test_ESPMode_actions(esp_mode):
     """
     Sanity check for mode actions.
     """
-    actions = esp_mode.actions()
+    with mock.patch("mu.modes.esp.CHARTS", True):
+        actions = esp_mode.actions()
     assert len(actions) == 4
     assert actions[0]["name"] == "run"
     assert actions[0]["handler"] == esp_mode.run
@@ -41,6 +42,21 @@ def test_ESPMode_actions(esp_mode):
     assert actions[2]["handler"] == esp_mode.toggle_repl
     assert actions[3]["name"] == "plotter"
     assert actions[3]["handler"] == esp_mode.toggle_plotter
+
+
+def test_ESPMode_actions_no_charts(esp_mode):
+    """
+    Sanity check for mode actions.
+    """
+    with mock.patch("mu.modes.esp.CHARTS", False):
+        actions = esp_mode.actions()
+    assert len(actions) == 3
+    assert actions[0]["name"] == "run"
+    assert actions[0]["handler"] == esp_mode.run
+    assert actions[1]["name"] == "files"
+    assert actions[1]["handler"] == esp_mode.toggle_files
+    assert actions[2]["name"] == "repl"
+    assert actions[2]["handler"] == esp_mode.toggle_repl
 
 
 def test_api(esp_mode):

--- a/tests/modes/test_microbit.py
+++ b/tests/modes/test_microbit.py
@@ -81,7 +81,8 @@ def test_microbit_mode():
     assert mm.editor == editor
     assert mm.view == view
 
-    actions = mm.actions()
+    with mock.patch("mu.modes.microbit.CHARTS", True):
+        actions = mm.actions()
     assert len(actions) == 4
     assert actions[0]["name"] == "flash"
     assert actions[0]["handler"] == mm.flash

--- a/tests/modes/test_python3.py
+++ b/tests/modes/test_python3.py
@@ -117,7 +117,8 @@ def test_python_mode():
     assert pm.editor == editor
     assert pm.view == view
 
-    actions = pm.actions()
+    with mock.patch("mu.modes.python3.CHARTS", True):
+        actions = pm.actions()
     assert len(actions) == 4
     assert actions[0]["name"] == "run"
     assert actions[0]["handler"] == pm.run_toggle
@@ -127,6 +128,31 @@ def test_python_mode():
     assert actions[2]["handler"] == pm.toggle_repl
     assert actions[3]["name"] == "plotter"
     assert actions[3]["handler"] == pm.toggle_plotter
+
+
+def test_python_mode_no_charts():
+    """
+    If QCharts is not available, ensure the plotter feature is not available.
+    """
+    editor = mock.MagicMock()
+    view = mock.MagicMock()
+    pm = PythonMode(editor, view)
+    assert pm.name == "Python 3"
+    assert pm.description is not None
+    assert pm.icon == "python"
+    assert pm.is_debugger is False
+    assert pm.editor == editor
+    assert pm.view == view
+
+    with mock.patch("mu.modes.python3.CHARTS", False):
+        actions = pm.actions()
+    assert len(actions) == 3
+    assert actions[0]["name"] == "run"
+    assert actions[0]["handler"] == pm.run_toggle
+    assert actions[1]["name"] == "debug"
+    assert actions[1]["handler"] == pm.debug
+    assert actions[2]["name"] == "repl"
+    assert actions[2]["handler"] == pm.toggle_repl
 
 
 def test_python_api():


### PR DESCRIPTION
The charts feature is optional in Mu, as it is not available in all platforms. This is mostly for Raspberry Pi with Raspbian Stretch, but other Arm-based devices like Chromebooks can have this dependency missing.

Right now the tests fail in those environments as they try to exercise the plotter feature, so this PR fixes that by skipping the tests if it cannot import QtChart. It also adds a couple of extra missing tests for checking the modes button creation with and without the charts available.