### PR TITLE
Travis: Run tests in arm64 architecture

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,8 @@ matrix:
       python: 3.5
       services:
         - xvfb
+      env:
+        - QT_QPA_PLATFORM="offscreen"
     - os: osx
       # match xcode version with earliest supported by current PyQt 
       # (earliest to maximize compatibility)

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,16 +6,30 @@ matrix:
       sudo: required
       language: python
       python: 3.5
+      services:
+        - xvfb
     - os: linux
       dist: xenial 
       sudo: required
       language: python
       python: 3.6
+      services:
+        - xvfb
     - os: linux
       dist: xenial
       sudo: required
       language: python
       python: 3.7
+      services:
+        - xvfb
+    - os: linux
+      dist: xenial
+      arch: arm64
+      sudo: required
+      language: python
+      python: 3.5
+      services:
+        - xvfb
     - os: osx
       # match xcode version with earliest supported by current PyQt 
       # (earliest to maximize compatibility)
@@ -40,11 +54,12 @@ before_install:
   # Check everything was correctly installed
   - echo $PATH
   - python --version
-  - python -c "import struct; print(struct.calcsize('P') * 8)"
+  - python -c "import platform, struct; print(platform.machine(), struct.calcsize('P') * 8)"
   - python -c "import sys; print(sys.executable)"
   - python -m pip --version
   - pip --version
-  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then virtualenv venv --python=python3; fi
+  - if [ "$TRAVIS_OS_NAME" = "linux" ] && [ "$TRAVIS_CPU_ARCH" != "arm64" ]; then virtualenv venv --python=python3; fi
+  - if [ "$TRAVIS_OS_NAME" = "linux" ] && [ "$TRAVIS_CPU_ARCH" = "arm64" ]; then virtualenv venv --python=python3 --system-site-packages; fi
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then source venv/bin/activate; fi
 
 install:
@@ -55,8 +70,8 @@ install:
 
 script:
   # For Linux run only the tests on 3.5 and the full checker elsewhere, all need the "X Virtual Framebuffer"
-  - if [ "$TRAVIS_OS_NAME" = "linux" ] && [ "$TRAVIS_PYTHON_VERSION" = "3.5" ]; then xvfb-run make coverage; fi
-  - if [ "$TRAVIS_OS_NAME" = "linux" ] && [ "$TRAVIS_PYTHON_VERSION" != "3.5" ]; then xvfb-run make check; fi
+  - if [ "$TRAVIS_OS_NAME" = "linux" ] && [ "$TRAVIS_PYTHON_VERSION" = "3.5" ]; then make coverage; fi
+  - if [ "$TRAVIS_OS_NAME" = "linux" ] && [ "$TRAVIS_PYTHON_VERSION" != "3.5" ]; then make check; fi
   - make clean
 
   # Run the tests on macOS and package it: "make macos" runs checks+tests first.

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,10 +48,6 @@ before_install:
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo apt-get install libxkbcommon-x11-0; fi
   # Use a new virtual environment with system packages for arm64
   - if [ "$TRAVIS_CPU_ARCH" = "arm64" ]; then deactivate && virtualenv venv --python=python3 --system-site-packages && source venv/bin/activate; fi
-  - if [ "$TRAVIS_CPU_ARCH" = "arm64" ]; then pip config set global.extra-index-url https://www.piwheels.org/simple; fi
-  - if [ "$TRAVIS_CPU_ARCH" = "arm64" ]; then pip config set global.platform "linux_armv7l"; fi
-  - if [ "$TRAVIS_CPU_ARCH" = "arm64" ]; then pip config set global.target "$(python3 -c 'import sysconfig; print(sysconfig.get_paths()["purelib"])')"; fi
-  - if [ "$TRAVIS_CPU_ARCH" = "arm64" ]; then pip config set global.only-binary ":all:"; fi
   # Python 3 installation required
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then pyenv install $TRAVIS_OSX_PY_VER; fi
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then pyenv global $TRAVIS_OSX_PY_VER; fi
@@ -68,8 +64,9 @@ before_install:
   - pip freeze
 
 install:
-  # Installing PyQt5 dependencies via apt for arm64 arch
+  # In arm64 install PyQt5 dependencies via apt, numpy and pygame via piwheels
   - if [ "$TRAVIS_CPU_ARCH" = "arm64" ]; then sudo apt-get install python3-pyqt5 python3-pyqt5.qsci python3-pyqt5.qtserialport python3-pyqt5.qtsvg libxmlsec1-dev libxml2 libxml2-dev; fi
+  - if [ "$TRAVIS_CPU_ARCH" = "arm64" ]; then pip install numpy pygame --extra-index-url="https://www.piwheels.org/simple" --platform="linux_armv7l" --only-binary=":all:" --target="$(python -c 'import sysconfig; print(sysconfig.get_paths()["purelib"])')"; fi
   # Install Mu and its dependencies
   - pip install .[dev]
   # Check everything was correctly installed

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,6 +63,13 @@ before_install:
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then source venv/bin/activate; fi
 
 install:
+  # Installing PyQt5 dependencies via apt for arm64 arch
+  - if [ "$TRAVIS_CPU_ARCH" = "arm64" ]; then sudo apt-get install python3-pyqt5 python3-pyqt5.qsci python3-pyqt5.qtserialport python3-pyqt5.qtsvg libxmlsec1-dev libxml2 libxml2-dev; fi
+  # Installing PyGame and numpy from PiWheels and set up extra-index-url
+  - if [ "$TRAVIS_CPU_ARCH" = "arm64" ]; then wget https://www.piwheels.org/simple/pygame/pygame-1.9.6-cp35-cp35m-linux_armv7l.whl -O pygame-1.9.6-cp35-cp35m-linux_aarch64.whl && pip install pygame-1.9.6-cp35-cp35m-linux_aarch64.whl; fi
+  - if [ "$TRAVIS_CPU_ARCH" = "arm64" ]; then wget https://www.piwheels.org/simple/numpy/numpy-1.18.5-cp35-cp35m-linux_armv7l.whl -O numpy-1.18.5-cp35-cp35m-linux_aarch64.whl && pip install numpy-1.18.5-cp35-cp35m-linux_aarch64.whl; fi
+  # piwheels doesn't yet support Requires-Python metadata: https://github.com/piwheels/piwheels/issues/208
+  #- if [ "$TRAVIS_CPU_ARCH" = "arm64" ]; then pip config set global.extra-index-url https://www.piwheels.org/simple; fi
   # Install Mu and its dependencies
   - pip install .[dev]
   # Check everything was correctly installed

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,10 @@ before_install:
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo apt-get install libxkbcommon-x11-0; fi
   # Use a new virtual environment with system packages for arm64
   - if [ "$TRAVIS_CPU_ARCH" = "arm64" ]; then deactivate && virtualenv venv --python=python3 --system-site-packages && source venv/bin/activate; fi
+  - if [ "$TRAVIS_CPU_ARCH" = "arm64" ]; then pip config set global.extra-index-url https://www.piwheels.org/simple; fi
+  - if [ "$TRAVIS_CPU_ARCH" = "arm64" ]; then pip config set global.platform "linux_armv7l"; fi
+  - if [ "$TRAVIS_CPU_ARCH" = "arm64" ]; then pip config set global.target "$(python3 -c 'import sysconfig; print(sysconfig.get_paths()["purelib"])')"; fi
+  - if [ "$TRAVIS_CPU_ARCH" = "arm64" ]; then pip config set global.only-binary ":all:"; fi
   # Python 3 installation required
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then pyenv install $TRAVIS_OSX_PY_VER; fi
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then pyenv global $TRAVIS_OSX_PY_VER; fi
@@ -60,16 +64,12 @@ before_install:
   - python -c "import sys; print(sys.executable)"
   - python -m pip --version
   - pip --version
+  - pip config list
   - pip freeze
 
 install:
   # Installing PyQt5 dependencies via apt for arm64 arch
   - if [ "$TRAVIS_CPU_ARCH" = "arm64" ]; then sudo apt-get install python3-pyqt5 python3-pyqt5.qsci python3-pyqt5.qtserialport python3-pyqt5.qtsvg libxmlsec1-dev libxml2 libxml2-dev; fi
-  # Installing PyGame and numpy from PiWheels and set up extra-index-url
-  - if [ "$TRAVIS_CPU_ARCH" = "arm64" ]; then wget https://www.piwheels.org/simple/pygame/pygame-1.9.6-cp35-cp35m-linux_armv7l.whl -O pygame-1.9.6-cp35-cp35m-linux_aarch64.whl && pip install pygame-1.9.6-cp35-cp35m-linux_aarch64.whl; fi
-  - if [ "$TRAVIS_CPU_ARCH" = "arm64" ]; then wget https://www.piwheels.org/simple/numpy/numpy-1.18.5-cp35-cp35m-linux_armv7l.whl -O numpy-1.18.5-cp35-cp35m-linux_aarch64.whl && pip install numpy-1.18.5-cp35-cp35m-linux_aarch64.whl; fi
-  # piwheels doesn't yet support Requires-Python metadata: https://github.com/piwheels/piwheels/issues/208
-  #- if [ "$TRAVIS_CPU_ARCH" = "arm64" ]; then pip config set global.extra-index-url https://www.piwheels.org/simple; fi
   # Install Mu and its dependencies
   - pip install .[dev]
   # Check everything was correctly installed

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,8 @@ before_install:
   # Linux packages needed for Qt to work.
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo apt-get update; fi
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo apt-get install libxkbcommon-x11-0; fi
+  # Use a new virtual environment with system packages for arm64
+  - if [ "$TRAVIS_CPU_ARCH" = "arm64" ]; then deactivate && virtualenv venv --python=python3 --system-site-packages && source venv/bin/activate; fi
   # Python 3 installation required
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then pyenv install $TRAVIS_OSX_PY_VER; fi
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then pyenv global $TRAVIS_OSX_PY_VER; fi
@@ -58,9 +60,7 @@ before_install:
   - python -c "import sys; print(sys.executable)"
   - python -m pip --version
   - pip --version
-  - if [ "$TRAVIS_OS_NAME" = "linux" ] && [ "$TRAVIS_CPU_ARCH" != "arm64" ]; then virtualenv venv --python=python3; fi
-  - if [ "$TRAVIS_OS_NAME" = "linux" ] && [ "$TRAVIS_CPU_ARCH" = "arm64" ]; then virtualenv venv --python=python3 --system-site-packages; fi
-  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then source venv/bin/activate; fi
+  - pip freeze
 
 install:
   # Installing PyQt5 dependencies via apt for arm64 arch

--- a/mu/interface/dialogs.py
+++ b/mu/interface/dialogs.py
@@ -377,7 +377,7 @@ class ESPFirmwareFlasherWidget(QWidget):
         self.process.readyReadStandardError.connect(self.read_process)
         self.process.readyReadStandardOutput.connect(self.read_process)
         self.process.finished.connect(self.esptool_finished)
-        self.process.errorOccurred.connect(self.esptool_error)
+        self.process.error.connect(self.esptool_error)
 
         command = self.commands.pop(0)
         self.log_text_area.appendPlainText(command + "\n")
@@ -385,7 +385,7 @@ class ESPFirmwareFlasherWidget(QWidget):
 
     def esptool_error(self, error_num):
         self.log_text_area.appendPlainText(
-            "Error occured: Error {}\n".format(error_num)
+            "Error occurred: Error {}\n".format(error_num)
         )
         self.process = None
 

--- a/setup.py
+++ b/setup.py
@@ -21,9 +21,12 @@ with open(os.path.join(base_dir, "CHANGES.rst"), encoding="utf8") as f:
 
 
 install_requires = [
-    'PyQt5==5.13.2;"arm" not in platform_machine',
-    'QScintilla==2.11.3;"arm" not in platform_machine',
-    'PyQtChart==5.13.1;"arm" not in platform_machine',
+    "PyQt5==5.13.2"
+    + ';"arm" not in platform_machine and "aarch" not in platform_machine',
+    "QScintilla==2.11.3"
+    + ';"arm" not in platform_machine and "aarch" not in platform_machine',
+    "PyQtChart==5.13.1"
+    + ';"arm" not in platform_machine and "aarch" not in platform_machine',
     # `flake8` is actually a testing/packaging dependency that, among other
     # packages, brings in `pycodestyle` and `pyflakes` which are runtime
     # dependencies. For the sake of "locality", it is being declared here,

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ install_requires = [
 
 extras_require = {
     "tests": [
-        "pytest",
+        "pytest>=4.6",
         "pytest-cov",
         "pytest-random-order>=1.0.0",
         "pytest-faulthandler",

--- a/tests/interface/test_panes.py
+++ b/tests/interface/test_panes.py
@@ -2865,6 +2865,7 @@ def test_PlotterPane_add_data_re_scale_down():
     pp.axis_y.setRange.assert_called_once_with(0, 2000)
 
 
+@pytest.mark.skipif(not CHARTS, reason="QtChart unavailable")
 def test_PlotterPane_add_data_re_scale_min_up():
     """
     If the y axis contains (negative) data smaller than the current
@@ -2879,6 +2880,7 @@ def test_PlotterPane_add_data_re_scale_min_up():
     pp.axis_y.setRange.assert_called_once_with(-2000, 0)
 
 
+@pytest.mark.skipif(not CHARTS, reason="QtChart unavailable")
 def test_PlotterPane_add_data_re_scale_min_down():
     """
     If the y axis contains (negative) data less than half of the


### PR DESCRIPTION
This is not ready for merge quite yet, but it is getting there, it needs PR https://github.com/mu-editor/mu/pull/1102 to be merged first.

This PR adds the arm64 architecture to Travis CI to run the tests. This will be useful to help make sure we don't break things on Raspberry Pi, and the environmental markers edited in this PR should also enable being able to run Mu in other single board computers, possibly on Arm Chromebooks, and on systems like the [Pinebook Pro](https://www.pine64.org/pinebook-pro/).



Also fixes https://github.com/mu-editor/mu/issues/826.