### PR TITLE
Tests: Add more qtapp fixtures to fix random test crashes

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,11 @@
 import pytest
 from PyQt5.QtWidgets import QApplication
 
+# Keep global reference to avoid being garbage collected
+_qapp_instance = None
 
-@pytest.fixture(scope="session")
+
+@pytest.fixture(scope="session", autouse=True)
 def qtapp():
     app = QApplication.instance()
     if app is None:

--- a/tests/interface/test_dialogs.py
+++ b/tests/interface/test_dialogs.py
@@ -37,7 +37,7 @@ def test_ModeItem_init():
     mock_icon.assert_called_once_with(icon)
 
 
-def test_ModeSelector_setup(qtapp):
+def test_ModeSelector_setup():
     """
     Ensure the ModeSelector dialog is setup properly given a list of modes.
 
@@ -64,7 +64,7 @@ def test_ModeSelector_setup(qtapp):
     assert mock_item.call_count == 3
 
 
-def test_ModeSelector_select_and_accept(qtapp):
+def test_ModeSelector_select_and_accept():
     """
     Ensure the accept slot is fired when this event handler is called.
     """
@@ -75,7 +75,7 @@ def test_ModeSelector_select_and_accept(qtapp):
     ms.accept.assert_called_once_with()
 
 
-def test_ModeSelector_get_mode(qtapp):
+def test_ModeSelector_get_mode():
     """
     Ensure that the ModeSelector will correctly return a selected mode (or
     raise the expected exception if cancelled).
@@ -94,7 +94,7 @@ def test_ModeSelector_get_mode(qtapp):
         ms.get_mode()
 
 
-def test_LogWidget_setup(qtapp):
+def test_LogWidget_setup():
     """
     Ensure the log widget displays the referenced log file string in the
     expected way.
@@ -106,7 +106,7 @@ def test_LogWidget_setup(qtapp):
     assert lw.log_text_area.isReadOnly()
 
 
-def test_EnvironmentVariablesWidget_setup(qtapp):
+def test_EnvironmentVariablesWidget_setup():
     """
     Ensure the widget for editing user defined environment variables displays
     the referenced string in the expected way.
@@ -118,7 +118,7 @@ def test_EnvironmentVariablesWidget_setup(qtapp):
     assert not evw.text_area.isReadOnly()
 
 
-def test_MicrobitSettingsWidget_setup(qtapp):
+def test_MicrobitSettingsWidget_setup():
     """
     Ensure the widget for editing settings related to the BBC microbit
     displays the referenced settings data in the expected way.
@@ -131,7 +131,7 @@ def test_MicrobitSettingsWidget_setup(qtapp):
     assert mbsw.runtime_path.text() == "/foo/bar"
 
 
-def test_PackagesWidget_setup(qtapp):
+def test_PackagesWidget_setup():
     """
     Ensure the widget for editing settings related to third party packages
     displays the referenced data in the expected way.
@@ -142,7 +142,7 @@ def test_PackagesWidget_setup(qtapp):
     assert pw.text_area.toPlainText() == packages
 
 
-def test_AdminDialog_setup(qtapp):
+def test_AdminDialog_setup():
     """
     Ensure the admin dialog is setup properly given the content of a log
     file and envars.
@@ -164,7 +164,7 @@ def test_AdminDialog_setup(qtapp):
     assert s == settings
 
 
-def test_FindReplaceDialog_setup(qtapp):
+def test_FindReplaceDialog_setup():
     """
     Ensure the find/replace dialog is setup properly given only the theme
     as an argument.
@@ -176,7 +176,7 @@ def test_FindReplaceDialog_setup(qtapp):
     assert frd.replace_flag() is False
 
 
-def test_FindReplaceDialog_setup_with_args(qtapp):
+def test_FindReplaceDialog_setup_with_args():
     """
     Ensure the find/replace dialog is setup properly given only the theme
     as an argument.
@@ -191,7 +191,7 @@ def test_FindReplaceDialog_setup_with_args(qtapp):
     assert frd.replace_flag()
 
 
-def test_PackageDialog_setup(qtapp):
+def test_PackageDialog_setup():
     """
     Ensure the PackageDialog is set up correctly and kicks off the process of
     removing and adding packages.
@@ -209,7 +209,7 @@ def test_PackageDialog_setup(qtapp):
     assert pd.pkg_dirs == {}
 
 
-def test_PackageDialog_remove_packages(qtapp):
+def test_PackageDialog_remove_packages():
     """
     Ensure the pkg_dirs of to-be-removed packages is correctly filled and the
     remove_package method is scheduled.
@@ -237,7 +237,7 @@ def test_PackageDialog_remove_packages(qtapp):
         mock_qtimer.singleShot.assert_called_once_with(2, pd.remove_package)
 
 
-def test_PackageDialog_remove_package_dist_info(qtapp):
+def test_PackageDialog_remove_package_dist_info():
     """
     Ensures that if there are packages remaining to be deleted, then the next
     one is deleted as expected.
@@ -265,7 +265,7 @@ def test_PackageDialog_remove_package_dist_info(qtapp):
         mock_qtimer.singleShot.assert_called_once_with(2, pd.remove_package)
 
 
-def test_PackageDialog_remove_package_dist_info_cannot_delete(qtapp):
+def test_PackageDialog_remove_package_dist_info_cannot_delete():
     """
     Ensures that if there are packages remaining to be deleted, then the next
     one is deleted and any failures are logged.
@@ -297,7 +297,7 @@ def test_PackageDialog_remove_package_dist_info_cannot_delete(qtapp):
         mock_qtimer.singleShot.assert_called_once_with(2, pd.remove_package)
 
 
-def test_PackageDialog_remove_package_egg_info(qtapp):
+def test_PackageDialog_remove_package_egg_info():
     """
     Ensures that if there are packages remaining to be deleted, then the next
     one is deleted as expected.
@@ -325,7 +325,7 @@ def test_PackageDialog_remove_package_egg_info(qtapp):
         mock_qtimer.singleShot.assert_called_once_with(2, pd.remove_package)
 
 
-def test_PackageDialog_remove_package_egg_info_cannot_delete(qtapp):
+def test_PackageDialog_remove_package_egg_info_cannot_delete():
     """
     Ensures that if there are packages remaining to be deleted, then the next
     one is deleted and any failures are logged.
@@ -357,7 +357,7 @@ def test_PackageDialog_remove_package_egg_info_cannot_delete(qtapp):
         mock_qtimer.singleShot.assert_called_once_with(2, pd.remove_package)
 
 
-def test_PackageDialog_remove_package_egg_info_cannot_open_record(qtapp):
+def test_PackageDialog_remove_package_egg_info_cannot_open_record():
     """
     If the installed-files.txt file is not available (sometimes the case), then
     simply raise an exception and communicate this to the user.
@@ -384,7 +384,7 @@ def test_PackageDialog_remove_package_egg_info_cannot_open_record(qtapp):
         mock_qtimer.singleShot.assert_called_once_with(2, pd.remove_package)
 
 
-def test_PackageDialog_remove_package_end_state(qtapp):
+def test_PackageDialog_remove_package_end_state():
     """
     If there are no more packages to remove and there's nothing to be done for
     adding packages, then ensure all directories that do not contain files are
@@ -412,7 +412,7 @@ def test_PackageDialog_remove_package_end_state(qtapp):
     pd.end_state.assert_called_once_with()
 
 
-def test_PackageDialog_end_state(qtapp):
+def test_PackageDialog_end_state():
     """
     Ensure the expected end-state is correctly cofigured (for when all tasks
     relating to third party packages have finished).
@@ -425,7 +425,7 @@ def test_PackageDialog_end_state(qtapp):
     pd.button_box.button().setEnabled.assert_called_once_with(True)
 
 
-def test_PackageDialog_run_pip(qtapp):
+def test_PackageDialog_run_pip():
     """
     Ensure the expected package to be installed is done so via the expected
     correct call to "pip" in a new process (as per the recommended way to
@@ -451,7 +451,7 @@ def test_PackageDialog_run_pip(qtapp):
         pd.process.start.assert_called_once_with(sys.executable, args)
 
 
-def test_PackageDialog_finished_with_more_to_remove(qtapp):
+def test_PackageDialog_finished_with_more_to_remove():
     """
     When the pip process is finished, check if there are more packages to
     install and run again.
@@ -465,7 +465,7 @@ def test_PackageDialog_finished_with_more_to_remove(qtapp):
     pd.run_pip.assert_called_once_with()
 
 
-def test_PackageDialog_finished_to_end_state(qtapp):
+def test_PackageDialog_finished_to_end_state():
     """
     When the pip process is finished, if there are no more packages to install
     and there's no more activity for removing packages, move to the end state.
@@ -478,7 +478,7 @@ def test_PackageDialog_finished_to_end_state(qtapp):
     pd.end_state.assert_called_once_with()
 
 
-def test_PackageDialog_read_process(qtapp):
+def test_PackageDialog_read_process():
     """
     Ensure any data from the subprocess running "pip" is read and appended to
     the text area.
@@ -494,7 +494,7 @@ def test_PackageDialog_read_process(qtapp):
         mock_timer.singleShot.assert_called_once_with(2, pd.read_process)
 
 
-def test_PackageDialog_append_data(qtapp):
+def test_PackageDialog_append_data():
     """
     Ensure that when data is appended, it's added to the end of the text area!
     """

--- a/tests/interface/test_editor.py
+++ b/tests/interface/test_editor.py
@@ -12,7 +12,7 @@ from PyQt5.QtGui import QDropEvent
 import pytest
 
 
-def test_pythonlexer_keywords(qtapp):
+def test_pythonlexer_keywords():
     """
     Ensure both types of expected keywords are returned from the PythonLexer
     class.
@@ -26,7 +26,7 @@ def test_pythonlexer_keywords(qtapp):
     assert lexer.keywords(3) is None
 
 
-def test_csslexer_description_comments(qtapp):
+def test_csslexer_description_comments():
     """
     Ensure that if a Comment enum is passed in, the string "Comment" is
     returned. This is due to a bug in the base QsciLexerCSS class.
@@ -35,7 +35,7 @@ def test_csslexer_description_comments(qtapp):
     assert "Comment" == lexer.description(lexer.Comment)
 
 
-def test_csslexer_description_other(qtapp):
+def test_csslexer_description_other():
     """
     Ensure that if a Comment enum is passed in, the string "Comment" is
     returned. This is due to a bug in the base QsciLexerCSS class.
@@ -47,7 +47,7 @@ def test_csslexer_description_other(qtapp):
         assert "foo" == lexer.description(lexer.Value)
 
 
-def test_EditorPane_init_python(qtapp):
+def test_EditorPane_init_python():
     """
     Ensure everything is set and configured given a path and text passed into
     a new instance of the EditorPane. Python file.
@@ -73,7 +73,7 @@ def test_EditorPane_init_python(qtapp):
         assert isinstance(editor.lexer, mu.interface.editor.PythonLexer)
 
 
-def test_EditorPane_init_html(qtapp):
+def test_EditorPane_init_html():
     """
     Ensure everything is set and configured given a path and text passed into
     a new instance of the EditorPane. HTML file.
@@ -99,7 +99,7 @@ def test_EditorPane_init_html(qtapp):
         assert isinstance(editor.lexer, mu.interface.editor.QsciLexerHTML)
 
 
-def test_EditorPane_init_css(qtapp):
+def test_EditorPane_init_css():
     """
     Ensure everything is set and configured given a path and text passed into
     a new instance of the EditorPane. CSS file.
@@ -125,7 +125,7 @@ def test_EditorPane_init_css(qtapp):
         assert isinstance(editor.lexer, mu.interface.editor.QsciLexerCSS)
 
 
-def test_EditorPane_configure(qtapp):
+def test_EditorPane_configure():
     """
     Check the expected configuration takes place. NOTE - this is checking the
     expected attributes are configured, not what the actual configuration
@@ -192,7 +192,7 @@ def test_EditorPane_configure(qtapp):
     assert ep.set_zoom.call_count == 1
 
 
-def test_Editor_connect_margin(qtapp):
+def test_Editor_connect_margin():
     """
     Ensure that the passed in function is connected to the marginClick event.
     """
@@ -203,7 +203,7 @@ def test_Editor_connect_margin(qtapp):
     assert ep.marginClicked.connect.call_count == 1
 
 
-def test_Editor_connect_margin_ignores_margin_4(qtapp):
+def test_Editor_connect_margin_ignores_margin_4():
     """
     Ensure that the margin click handler is not called if margin 4 is clicked.
     """
@@ -217,7 +217,7 @@ def test_Editor_connect_margin_ignores_margin_4(qtapp):
     assert mock_fn.call_count == 0
 
 
-def test_Editor_connect_margin_1_works(qtapp):
+def test_Editor_connect_margin_1_works():
     """
     Ensure that the margin click handler is called if margin 1 is clicked.
     """
@@ -238,7 +238,7 @@ def test_Editor_connect_margin_1_works(qtapp):
     # to fail intermittently on macOS.
 
 
-def test_EditorPane_set_theme(qtapp):
+def test_EditorPane_set_theme():
     """
     Check all the expected configuration calls are made to ensure the widget's
     theme is updated.
@@ -256,7 +256,7 @@ def test_EditorPane_set_theme(qtapp):
         mock_api.prepare.assert_called_once_with()
 
 
-def test_EditorPane_set_zoom(qtapp):
+def test_EditorPane_set_zoom():
     """
     Ensure the t-shirt size is turned into a call to parent's zoomTo.
     """
@@ -266,7 +266,7 @@ def test_EditorPane_set_zoom(qtapp):
     ep.zoomTo.assert_called_once_with(8)
 
 
-def test_EditorPane_label(qtapp):
+def test_EditorPane_label():
     """
     Ensure the correct label is returned given a set of states:
 
@@ -285,7 +285,7 @@ def test_EditorPane_label(qtapp):
     assert ep.title == "bar.py •"
 
 
-def test_EditorPane_reset_annotations(qtapp):
+def test_EditorPane_reset_annotations():
     """
     Ensure annotation state is reset.
     """
@@ -301,7 +301,7 @@ def test_EditorPane_reset_annotations(qtapp):
     ep.reset_check_indicators.assert_called_once_with()
 
 
-def test_EditorPane_reset_check_indicators(qtapp):
+def test_EditorPane_reset_check_indicators():
     """
     Ensure code check indicators are reset.
     """
@@ -338,7 +338,7 @@ def test_EditorPane_reset_check_indicators(qtapp):
         assert ep.check_indicators[indicator]["markers"] == {}
 
 
-def test_EditorPane_reset_search_indicators(qtapp):
+def test_EditorPane_reset_search_indicators():
     """
     Ensure search indicators are reset.
     """
@@ -362,7 +362,7 @@ def test_EditorPane_reset_search_indicators(qtapp):
         assert ep.search_indicators[indicator]["positions"] == []
 
 
-def test_EditorPane_annotate_code(qtapp):
+def test_EditorPane_annotate_code():
     """
     Given a dict containing representations of feedback on the code contained
     within the EditorPane instance, ensure the correct indicators and markers
@@ -409,7 +409,7 @@ def test_EditorPane_annotate_code(qtapp):
     ep.ensureLineVisible.assert_called_once_with(17)  # first problem visible
 
 
-def test_EditorPane_debugger_at_line(qtapp):
+def test_EditorPane_debugger_at_line():
     """
     Ensure the right calls are made to highlight the referenced line with the
     DEBUG_INDICATOR.
@@ -428,7 +428,7 @@ def test_EditorPane_debugger_at_line(qtapp):
     ep.ensureLineVisible.assert_called_once_with(99)
 
 
-def test_EditorPane_debugger_at_line_windows_line_endings(qtapp):
+def test_EditorPane_debugger_at_line_windows_line_endings():
     """
     Ensure the right calls are made to highlight the referenced line with the
     DEBUG_INDICATOR.
@@ -447,7 +447,7 @@ def test_EditorPane_debugger_at_line_windows_line_endings(qtapp):
     ep.ensureLineVisible.assert_called_once_with(99)
 
 
-def test_EditorPane_reset_debugger_highlight(qtapp):
+def test_EditorPane_reset_debugger_highlight():
     """
     Ensure all DEBUG_INDICATORs are removed from the editor.
     """
@@ -466,7 +466,7 @@ def test_EditorPane_reset_debugger_highlight(qtapp):
     )
 
 
-def test_EditorPane_show_annotations(qtapp):
+def test_EditorPane_show_annotations():
     """
     Ensure the annotations are shown in "sentence" case and with an arrow to
     indicate the line to which they refer.
@@ -489,7 +489,7 @@ def test_EditorPane_show_annotations(qtapp):
     )
 
 
-def test_EditorPane_find_next_match(qtapp):
+def test_EditorPane_find_next_match():
     """
     Ensures that the expected arg values are passed through to QsciScintilla
     for highlighting matched text.
@@ -527,7 +527,7 @@ def _ranges_in_text(text, search_for):
             yield n_line, match.start(), n_line, match.end()
 
 
-def test_EditorPane_highlight_selected_matches_no_selection(qtapp):
+def test_EditorPane_highlight_selected_matches_no_selection():
     """
     Ensure that if the current selection is empty then all highlights
     are cleared.
@@ -544,7 +544,7 @@ def test_EditorPane_highlight_selected_matches_no_selection(qtapp):
     assert ep.search_indicators["selection"]["positions"] == []
 
 
-def test_EditorPane_highlight_selected_spans_two_or_more_lines(qtapp):
+def test_EditorPane_highlight_selected_spans_two_or_more_lines():
     """
     Ensure that if the current selection spans two or more lines then all
     highlights are cleared.
@@ -561,7 +561,7 @@ def test_EditorPane_highlight_selected_spans_two_or_more_lines(qtapp):
     assert ep.search_indicators["selection"]["positions"] == []
 
 
-def test_EditorPane_highlight_selected_matches_multi_word(qtapp):
+def test_EditorPane_highlight_selected_matches_multi_word():
     """
     Ensure that if the current selection is not a single word then don't cause
     a search/highlight call.
@@ -589,9 +589,7 @@ def test_EditorPane_highlight_selected_matches_multi_word(qtapp):
         ("résumé bar résumé baz résumé", "résumé"),
     ],
 )
-def test_EditorPane_highlight_selected_matches_with_match(
-    qtapp, text, search_for
-):
+def test_EditorPane_highlight_selected_matches_with_match(text, search_for):
     """
     Ensure that if the current selection is a single word then it causes the
     expected search/highlight call.
@@ -626,7 +624,7 @@ def test_EditorPane_highlight_selected_matches_with_match(
     assert ep.search_indicators["selection"]["positions"] == expected_ranges
 
 
-def test_EditorPane_highlight_selected_matches_incomplete_word(qtapp):
+def test_EditorPane_highlight_selected_matches_incomplete_word():
     """
     Ensure that if the current selection is not a complete word
     then no ranges are highlighted.
@@ -646,7 +644,7 @@ def test_EditorPane_highlight_selected_matches_incomplete_word(qtapp):
     assert ep.search_indicators["selection"]["positions"] == []
 
 
-def test_EditorPane_highlight_selected_matches_cursor_remains(qtapp):
+def test_EditorPane_highlight_selected_matches_cursor_remains():
     """
     Ensure that if a selection is made, the text cursor remains in the
     same place after any matching terms have been highlighted.
@@ -676,7 +674,7 @@ def test_EditorPane_highlight_selected_matches_cursor_remains(qtapp):
     assert ep.getCursorPosition() == (line1, index1 - select_n_chars)
 
 
-def test_EditorPane_selection_change_listener(qtapp):
+def test_EditorPane_selection_change_listener():
     """
     Enusure that is there is a change to the selected text then controll is
     passed to highlight_selected_matches.
@@ -692,7 +690,7 @@ def test_EditorPane_selection_change_listener(qtapp):
     assert ep.highlight_selected_matches.call_count == 1
 
 
-def test_EditorPane_drop_event(qtapp):
+def test_EditorPane_drop_event():
     """
     If there's a drop event associated with files, cause them to be passed into
     Mu's existing file loading code.
@@ -717,7 +715,7 @@ def test_EditorPane_drop_event(qtapp):
     assert m.call_count == 3
 
 
-def test_EditorPane_drop_event_not_file(qtapp):
+def test_EditorPane_drop_event_not_file():
     """
     If the drop event isn't for files (for example, it may be for dragging and
     dropping text into the editor), then pass the handling up to QScintilla.
@@ -731,7 +729,7 @@ def test_EditorPane_drop_event_not_file(qtapp):
         mock_de.assert_called_once_with(event)
 
 
-def test_EditorPane_toggle_line_starts_with_hash(qtapp):
+def test_EditorPane_toggle_line_starts_with_hash():
     """
     If the line starts with a hash ("#") immediately followed by code, then
     uncomment it.
@@ -748,7 +746,7 @@ def test_EditorPane_toggle_line_starts_with_hash(qtapp):
     assert ep.toggle_line("    #foo") == "    foo"
 
 
-def test_EditorPane_toggle_line_starts_with_hash_space(qtapp):
+def test_EditorPane_toggle_line_starts_with_hash_space():
     """
     If the line starts with a PEP-8 compliant hash followed by a space ("# ")
     then uncomment it.
@@ -767,7 +765,7 @@ def test_EditorPane_toggle_line_starts_with_hash_space(qtapp):
     assert ep.toggle_line("    # foo") == "    foo"
 
 
-def test_EditorPane_toggle_line_preserves_embedded_comment(qtapp):
+def test_EditorPane_toggle_line_preserves_embedded_comment():
     """
     If the line being un-commented has a trailing comment, only the first
     comment marker should be removed.
@@ -776,7 +774,7 @@ def test_EditorPane_toggle_line_preserves_embedded_comment(qtapp):
     assert ep.toggle_line("    # foo # comment") == "    foo # comment"
 
 
-def test_EditorPane_toggle_line_normal_line(qtapp):
+def test_EditorPane_toggle_line_normal_line():
     """
     If the line is an uncommented line of text, then comment it with hash-space
     ("# ").
@@ -793,7 +791,7 @@ def test_EditorPane_toggle_line_normal_line(qtapp):
     assert ep.toggle_line("    foo") == "#     foo"
 
 
-def test_EditorPane_toggle_line_whitespace_line(qtapp):
+def test_EditorPane_toggle_line_whitespace_line():
     """
     If the line is simply empty or contains only whitespace, then ignore it and
     return as-is.
@@ -802,7 +800,7 @@ def test_EditorPane_toggle_line_whitespace_line(qtapp):
     assert ep.toggle_line("    ") == "    "
 
 
-def test_EditorPane_toggle_line_preserves_multi_comment(qtapp):
+def test_EditorPane_toggle_line_preserves_multi_comment():
     """
     If the line starts with two or more "#" together, then return it as-is.
     """
@@ -812,7 +810,7 @@ def test_EditorPane_toggle_line_preserves_multi_comment(qtapp):
     assert ep.toggle_line("    ### triplet") == "    ### triplet"
 
 
-def test_EditorPane_toggle_comments_no_selection(qtapp):
+def test_EditorPane_toggle_comments_no_selection():
     """
     If no text is selected, toggle the line currently containing the cursor.
     """
@@ -829,7 +827,7 @@ def test_EditorPane_toggle_comments_no_selection(qtapp):
     ep.replaceSelectedText.assert_called_once_with("# foo")
 
 
-def test_EditorPane_toggle_comments_selected_normal_lines(qtapp):
+def test_EditorPane_toggle_comments_selected_normal_lines():
     """
     Check normal lines of code are properly commented and subsequently
     highlighted.
@@ -845,7 +843,7 @@ def test_EditorPane_toggle_comments_selected_normal_lines(qtapp):
     ep.setSelection.assert_called_once_with(0, 0, 2, 4)
 
 
-def test_EditorPane_toggle_comments_selected_hash_comment_lines(qtapp):
+def test_EditorPane_toggle_comments_selected_hash_comment_lines():
     """
     Check commented lines starting with "#" are now uncommented.
     """
@@ -860,7 +858,7 @@ def test_EditorPane_toggle_comments_selected_hash_comment_lines(qtapp):
     ep.setSelection.assert_called_once_with(0, 0, 2, 2)
 
 
-def test_EditorPane_toggle_comments_selected_hash_space_comment_lines(qtapp):
+def test_EditorPane_toggle_comments_selected_hash_space_comment_lines():
     """
     Check commented lines starting with "# " are now uncommented.
     """
@@ -875,7 +873,7 @@ def test_EditorPane_toggle_comments_selected_hash_space_comment_lines(qtapp):
     ep.setSelection.assert_called_once_with(0, 0, 2, 2)
 
 
-def test_EditorPane_toggle_comments_selected_spaces_before_comment_mark(qtapp):
+def test_EditorPane_toggle_comments_selected_spaces_before_comment_mark():
     """
     Check commented lines starting with "# " are now uncommented and on the
     last line selection ends at "baz" when there are spaces before the comment
@@ -892,7 +890,7 @@ def test_EditorPane_toggle_comments_selected_spaces_before_comment_mark(qtapp):
     ep.setSelection.assert_called_once_with(0, 0, 2, 4)
 
 
-def test_EditorPane_toggle_comments_selected_spaces_after_comment_mark(qtapp):
+def test_EditorPane_toggle_comments_selected_spaces_after_comment_mark():
     """
     Check commented lines starting with "# " are now uncommented and on the
     last line selection ends at "baz" when there are spaces between the comment
@@ -909,7 +907,7 @@ def test_EditorPane_toggle_comments_selected_spaces_after_comment_mark(qtapp):
     ep.setSelection.assert_called_once_with(0, 0, 2, 4)
 
 
-def test_EditorPane_toggle_comments_selection_follows_len_change(qtapp):
+def test_EditorPane_toggle_comments_selection_follows_len_change():
     """
     Check commented lines starting with "# " are now uncommented one level and
     selection adjustment doesn't assume lines starting with "# " had comment
@@ -926,7 +924,7 @@ def test_EditorPane_toggle_comments_selection_follows_len_change(qtapp):
     ep.setSelection.assert_called_once_with(0, 0, 2, 4)
 
 
-def test_EditorPane_wheelEvent(qtapp):
+def test_EditorPane_wheelEvent():
     """"""
     ep = mu.interface.editor.EditorPane(None, "baz")
     mock_app = mock.MagicMock()
@@ -938,7 +936,7 @@ def test_EditorPane_wheelEvent(qtapp):
         mw.assert_called_once_with(None)
 
 
-def test_EditorPane_wheelEvent_with_modifier_ignored(qtapp):
+def test_EditorPane_wheelEvent_with_modifier_ignored():
     """"""
     ep = mu.interface.editor.EditorPane(None, "baz")
     mock_app = mock.MagicMock()

--- a/tests/interface/test_main.py
+++ b/tests/interface/test_main.py
@@ -15,7 +15,7 @@ import mu.interface.editor
 import sys
 
 
-def test_ButtonBar_init(qtapp):
+def test_ButtonBar_init():
     """
     Ensure everything is set and configured given a new instance of the
     ButtonBar.
@@ -49,7 +49,7 @@ def test_ButtonBar_init(qtapp):
         assert mock_reset.call_count == 1
 
 
-def test_ButtonBar_reset(qtapp):
+def test_ButtonBar_reset():
     """
     Ensure reset clears the slots and actions.
     """
@@ -63,7 +63,7 @@ def test_ButtonBar_reset(qtapp):
         mock_clear.assert_called_once_with()
 
 
-def test_ButtonBar_change_mode(qtapp):
+def test_ButtonBar_change_mode():
     """
     Ensure the expected actions are added to the button bar when the mode is
     changed.
@@ -92,7 +92,7 @@ def test_ButtonBar_change_mode(qtapp):
         assert mock_add_separator.call_count == 5
 
 
-def test_ButtonBar_set_responsive_mode(qtapp):
+def test_ButtonBar_set_responsive_mode():
     """
     Does the button bar shrink in compact mode and grow out of it?
     """
@@ -114,7 +114,7 @@ def test_ButtonBar_set_responsive_mode(qtapp):
         bb.setStyleSheet.assert_called_with(style)
 
 
-def test_ButtonBar_add_action(qtapp):
+def test_ButtonBar_add_action():
     """
     Check the appropriately referenced QAction is created by a call to
     addAction.
@@ -127,7 +127,7 @@ def test_ButtonBar_add_action(qtapp):
     assert isinstance(bb.slots["save"], QAction)
 
 
-def test_ButtonBar_connect(qtapp):
+def test_ButtonBar_connect():
     """
     Check the named slot is connected to the slot handler.
     """
@@ -143,7 +143,7 @@ def test_ButtonBar_connect(qtapp):
     slot.setShortcut.assert_called_once_with(QKeySequence("Ctrl+S"))
 
 
-def test_FileTabs_init(qtapp):
+def test_FileTabs_init():
     """
     Ensure a FileTabs instance is initialised as expected.
     """
@@ -160,7 +160,7 @@ def test_FileTabs_init(qtapp):
         mcc.connect.assert_called_once_with(qtw.change_tab)
 
 
-def test_FileTabs_removeTab_cancel(qtapp):
+def test_FileTabs_removeTab_cancel():
     """
     Ensure removeTab asks the user for confirmation if there is a modification
     to the tab. If "cancel" is selected, the parent removeTab is NOT called.
@@ -187,7 +187,7 @@ def test_FileTabs_removeTab_cancel(qtapp):
         assert mock_tab.isModified.call_count == 1
 
 
-def test_FileTabs_removeTab_ok(qtapp):
+def test_FileTabs_removeTab_ok():
     """
     Ensure removeTab asks the user for confirmation if there is a modification
     to the tab. If user responds with "OK", the parent removeTab IS called.
@@ -214,7 +214,7 @@ def test_FileTabs_removeTab_ok(qtapp):
         assert mock_tab.isModified.call_count == 1
 
 
-def test_FileTabs_change_tab(qtapp):
+def test_FileTabs_change_tab():
     """
     Ensure change_tab updates the title of the application window with the
     label from the currently selected file.
@@ -230,7 +230,7 @@ def test_FileTabs_change_tab(qtapp):
     mock_window.update_title.assert_called_once_with(mock_tab.title)
 
 
-def test_FileTabs_change_tab_no_tabs(qtapp):
+def test_FileTabs_change_tab_no_tabs():
     """
     If there are no tabs left, ensure change_tab updates the title of the
     application window with the default value (None).
@@ -243,7 +243,7 @@ def test_FileTabs_change_tab_no_tabs(qtapp):
     mock_window.update_title.assert_called_once_with(None)
 
 
-def test_FileTabs_addTab(qtapp):
+def test_FileTabs_addTab():
     """
     Expect tabs to be added with the right label and a button
     """
@@ -319,7 +319,7 @@ def test_FileTabs_addTab(qtapp):
     assert mock_label.setPixmap.call_count == 3
 
 
-def test_Window_attributes(qtapp):
+def test_Window_attributes():
     """
     Expect the title and icon to be set correctly.
     """
@@ -330,7 +330,7 @@ def test_Window_attributes(qtapp):
     assert w.zooms == ("xs", "s", "m", "l", "xl", "xxl", "xxxl")
 
 
-def test_Window_wheelEvent_zoom_in(qtapp):
+def test_Window_wheelEvent_zoom_in():
     """
     If the CTRL+scroll in a positive direction, zoom in.
     """
@@ -348,7 +348,7 @@ def test_Window_wheelEvent_zoom_in(qtapp):
         mock_event.ignore.assert_called_once_with()
 
 
-def test_Window_wheelEvent_zoom_out(qtapp):
+def test_Window_wheelEvent_zoom_out():
     """
     If the CTRL+scroll in a negative direction, zoom out.
     """
@@ -366,7 +366,7 @@ def test_Window_wheelEvent_zoom_out(qtapp):
         mock_event.ignore.assert_called_once_with()
 
 
-def test_Window_resizeEvent(qtapp):
+def test_Window_resizeEvent():
     """
     Ensure resize events are passed along to the button bar.
     """
@@ -381,7 +381,7 @@ def test_Window_resizeEvent(qtapp):
     w.button_bar.set_responsive_mode.assert_called_with(1024, 768)
 
 
-def test_Window_select_mode_selected(qtapp):
+def test_Window_select_mode_selected():
     """
     Handle the selection of a new mode.
     """
@@ -399,7 +399,7 @@ def test_Window_select_mode_selected(qtapp):
         mock_selector.exec.assert_called_once_with()
 
 
-def test_Window_select_mode_cancelled(qtapp):
+def test_Window_select_mode_cancelled():
     """
     Handle the selection of a new mode.
     """
@@ -415,7 +415,7 @@ def test_Window_select_mode_cancelled(qtapp):
         assert result is None
 
 
-def test_Window_change_mode(qtapp):
+def test_Window_change_mode():
     """
     Ensure the change of mode is made by the button_bar.
     """
@@ -435,7 +435,7 @@ def test_Window_change_mode(qtapp):
     tab2.set_api.assert_called_once_with(api)
 
 
-def test_Window_set_zoom(qtapp):
+def test_Window_set_zoom():
     """
     Ensure the correct signal is emitted.
     """
@@ -445,7 +445,7 @@ def test_Window_set_zoom(qtapp):
     w._zoom_in.emit.assert_called_once_with("m")
 
 
-def test_Window_zoom_in(qtapp):
+def test_Window_zoom_in():
     """
     Ensure the correct signal is emitted.
     """
@@ -455,7 +455,7 @@ def test_Window_zoom_in(qtapp):
     w._zoom_in.emit.assert_called_once_with("l")
 
 
-def test_Window_zoom_out(qtapp):
+def test_Window_zoom_out():
     """
     Ensure the correct signal is emitted.
     """
@@ -465,7 +465,7 @@ def test_Window_zoom_out(qtapp):
     w._zoom_out.emit.assert_called_once_with("s")
 
 
-def test_Window_connect_zoom(qtapp):
+def test_Window_connect_zoom():
     """
     Ensure the zoom in/out signals are connected to the passed in widget's
     zoomIn and zoomOut handlers.
@@ -483,7 +483,7 @@ def test_Window_connect_zoom(qtapp):
     assert w._zoom_out.connect.called_once_with(widget.zoomOut)
 
 
-def test_Window_current_tab(qtapp):
+def test_Window_current_tab():
     """
     Ensure the correct tab is extracted from Window.tabs.
     """
@@ -493,7 +493,7 @@ def test_Window_current_tab(qtapp):
     assert w.current_tab == "foo"
 
 
-def test_Window_set_read_only(qtapp):
+def test_Window_set_read_only():
     """
     Ensure all the tabs have the setReadOnly method set to the boolean passed
     into set_read_only.
@@ -510,7 +510,7 @@ def test_Window_set_read_only(qtapp):
     tab2.setReadOnly.assert_called_once_with(True)
 
 
-def test_Window_get_load_path_no_previous(qtapp):
+def test_Window_get_load_path_no_previous():
     """
     Ensure the QFileDialog is called with the expected arguments and the
     resulting path is returned.
@@ -531,7 +531,7 @@ def test_Window_get_load_path_no_previous(qtapp):
     )
 
 
-def test_Window_get_load_path_with_previous(qtapp):
+def test_Window_get_load_path_with_previous():
     """
     Ensure the QFileDialog is called with the expected arguments and the
     resulting path is returned.
@@ -553,7 +553,7 @@ def test_Window_get_load_path_with_previous(qtapp):
     )
 
 
-def test_Window_get_load_path_force_path(qtapp):
+def test_Window_get_load_path_force_path():
     """
     Ensure the QFileDialog is called with the expected arguments and the
     resulting path is returned.
@@ -575,7 +575,7 @@ def test_Window_get_load_path_force_path(qtapp):
     )
 
 
-def test_Window_get_save_path(qtapp):
+def test_Window_get_save_path():
     """
     Ensure the QFileDialog is called with the expected arguments and the
     resulting path is returned.
@@ -598,7 +598,7 @@ def test_Window_get_save_path(qtapp):
     assert returned_path == path
 
 
-def test_Window_get_microbit_path(qtapp):
+def test_Window_get_microbit_path():
     """
     Ensures the QFileDialog is called with the expected arguments and the
     resulting path is returned.
@@ -618,7 +618,7 @@ def test_Window_get_microbit_path(qtapp):
     )
 
 
-def test_Window_add_tab(qtapp):
+def test_Window_add_tab():
     """
     Ensure adding a tab works as expected and the expected on_modified handler
     is created.
@@ -664,7 +664,7 @@ def test_Window_add_tab(qtapp):
     w.tabs.setTabText.assert_called_once_with(new_tab_index, ep.label)
 
 
-def test_Window_focus_tab(qtapp):
+def test_Window_focus_tab():
     """
     Given a tab instance, ensure it has focus.
     """
@@ -677,7 +677,7 @@ def test_Window_focus_tab(qtapp):
     tab.setFocus.assert_called_once_with()
 
 
-def test_Window_tab_count(qtapp):
+def test_Window_tab_count():
     """
     Ensure the number from Window.tabs.count() is returned.
     """
@@ -688,7 +688,7 @@ def test_Window_tab_count(qtapp):
     w.tabs.count.assert_called_once_with()
 
 
-def test_Window_widgets(qtapp):
+def test_Window_widgets():
     """
     Ensure a list derived from calls to Window.tabs.widget(i) is returned.
     """
@@ -703,7 +703,7 @@ def test_Window_widgets(qtapp):
     w.tabs.count.assert_called_once_with()
 
 
-def test_Window_modified(qtapp):
+def test_Window_modified():
     """
     Ensure the window's modified attribute is derived from the modified state
     of its tabs.
@@ -722,7 +722,7 @@ def test_Window_modified(qtapp):
     assert w.modified
 
 
-def test_Window_on_stdout_write(qtapp):
+def test_Window_on_stdout_write():
     """
     Ensure the data_received signal is emitted with the data.
     """
@@ -732,7 +732,7 @@ def test_Window_on_stdout_write(qtapp):
     w.data_received.emit.assert_called_once_with(b"hello")
 
 
-def test_Window_add_filesystem(qtapp):
+def test_Window_add_filesystem():
     """
     Ensure the expected settings are updated when adding a file system pane.
     """
@@ -797,7 +797,7 @@ def test_Window_add_filesystem(qtapp):
     w.connect_zoom.assert_called_once_with(mock_fs)
 
 
-def test_Window_add_filesystem_open_signal(qtapp):
+def test_Window_add_filesystem_open_signal():
     w = mu.interface.main.Window()
     w.open_file = mock.MagicMock()
     mock_open_emit = mock.MagicMock()
@@ -807,7 +807,7 @@ def test_Window_add_filesystem_open_signal(qtapp):
     mock_open_emit.assert_called_once_with("test")
 
 
-def test_Window_add_micropython_repl(qtapp):
+def test_Window_add_micropython_repl():
     """
     Ensure the expected object is instantiated and add_repl is called for a
     MicroPython based REPL.
@@ -828,7 +828,7 @@ def test_Window_add_micropython_repl(qtapp):
     w.add_repl.assert_called_once_with(mock_repl, "Test REPL")
 
 
-def test_Window_add_micropython_plotter(qtapp):
+def test_Window_add_micropython_plotter():
     """
     Ensure the expected object is instantiated and add_plotter is called for
     a MicroPython based plotter.
@@ -854,7 +854,7 @@ def test_Window_add_micropython_plotter(qtapp):
     w.add_plotter.assert_called_once_with(mock_plotter, "MicroPython Plotter")
 
 
-def test_Window_add_python3_plotter(qtapp):
+def test_Window_add_python3_plotter():
     """
     Ensure the plotter is created correctly when in Python 3 mode.
     """
@@ -876,7 +876,7 @@ def test_Window_add_python3_plotter(qtapp):
     w.add_plotter.assert_called_once_with(mock_plotter, "Python3 data tuple")
 
 
-def test_Window_add_jupyter_repl(qtapp):
+def test_Window_add_jupyter_repl():
     """
     Ensure the expected object is instantiated and add_repl is called for a
     Jupyter based REPL.
@@ -898,7 +898,7 @@ def test_Window_add_jupyter_repl(qtapp):
     w.add_repl.assert_called_once_with(mock_pane, "Python3 (Jupyter)")
 
 
-def test_Window_add_repl(qtapp):
+def test_Window_add_repl():
     """
     Ensure the expected settings are updated.
     """
@@ -918,7 +918,7 @@ def test_Window_add_repl(qtapp):
     w.addDockWidget.assert_called_once_with(Qt.BottomDockWidgetArea, mock_dock)
 
 
-def test_Window_add_plotter(qtapp):
+def test_Window_add_plotter():
     """
     Ensure the expected settings are updated.
     """
@@ -936,7 +936,7 @@ def test_Window_add_plotter(qtapp):
     w.addDockWidget.assert_called_once_with(Qt.BottomDockWidgetArea, mock_dock)
 
 
-def test_Window_add_python3_runner(qtapp):
+def test_Window_add_python3_runner():
     """
     Ensure a Python 3 runner (to capture stdin/out/err) is displayed correctly.
     """
@@ -961,7 +961,7 @@ def test_Window_add_python3_runner(qtapp):
     w.addDockWidget.assert_called_once_with(Qt.BottomDockWidgetArea, mock_dock)
 
 
-def test_Window_add_debug_inspector(qtapp):
+def test_Window_add_debug_inspector():
     """
     Ensure a debug inspector (to display local variables) is displayed
     correctly.
@@ -993,7 +993,7 @@ def test_Window_add_debug_inspector(qtapp):
     w.addDockWidget.assert_called_once_with(Qt.RightDockWidgetArea, mock_dock)
 
 
-def test_Window_update_debug_inspector(qtapp):
+def test_Window_update_debug_inspector():
     """
     Given a representation of the local objects in the debug runner's call
     stack. Ensure the debug inspector's model is populated in the correct way
@@ -1022,7 +1022,7 @@ def test_Window_update_debug_inspector(qtapp):
     assert mock_standard_item.call_count == 22
 
 
-def test_Window_update_debug_inspector_with_exception(qtapp):
+def test_Window_update_debug_inspector_with_exception():
     """
     If an exception is encountered when working out the type of the value,
     make sure it just reverts to the repr of the object.
@@ -1040,7 +1040,7 @@ def test_Window_update_debug_inspector_with_exception(qtapp):
     assert mock_standard_item.call_count == 2
 
 
-def test_Window_remove_filesystem(qtapp):
+def test_Window_remove_filesystem():
     """
     Check all the necessary calls to remove / reset the file system pane are
     made.
@@ -1056,7 +1056,7 @@ def test_Window_remove_filesystem(qtapp):
     assert w.fs is None
 
 
-def test_Window_remove_repl(qtapp):
+def test_Window_remove_repl():
     """
     Check all the necessary calls to remove / reset the REPL are made.
     """
@@ -1071,7 +1071,7 @@ def test_Window_remove_repl(qtapp):
     assert w.repl is None
 
 
-def test_Window_remove_plotter(qtapp):
+def test_Window_remove_plotter():
     """
     Check all the necessary calls to remove / reset the plotter are made.
     """
@@ -1086,7 +1086,7 @@ def test_Window_remove_plotter(qtapp):
     assert w.plotter is None
 
 
-def test_Window_remove_python_runner(qtapp):
+def test_Window_remove_python_runner():
     """
     Check all the necessary calls to remove / reset the Python3 runner are
     made.
@@ -1103,7 +1103,7 @@ def test_Window_remove_python_runner(qtapp):
     assert w.runner is None
 
 
-def test_Window_remove_debug_inspector(qtapp):
+def test_Window_remove_debug_inspector():
     """
     Check all the necessary calls to remove / reset the debug inspector are
     made.
@@ -1123,7 +1123,7 @@ def test_Window_remove_debug_inspector(qtapp):
     mock_inspector.deleteLater.assert_called_once_with()
 
 
-def test_Window_set_theme(qtapp):
+def test_Window_set_theme():
     """
     Check the theme is correctly applied to the window.
     """
@@ -1195,7 +1195,7 @@ def test_Window_set_theme(qtapp):
     w.plotter_pane.set_theme.assert_called_once_with("day")
 
 
-def test_Window_set_checker_icon(qtapp):
+def test_Window_set_checker_icon():
     w = mu.interface.main.Window()
     w.button_bar = mock.MagicMock()
     w.button_bar.slots = {"check": mock.MagicMock()}
@@ -1221,7 +1221,7 @@ def test_Window_set_checker_icon(qtapp):
     assert w.button_bar.slots["check"].setIcon.call_count == 2
 
 
-def test_Window_show_admin(qtapp):
+def test_Window_show_admin():
     """
     Ensure the modal widget for showing the admin features is correctly
     configured.
@@ -1241,7 +1241,7 @@ def test_Window_show_admin(qtapp):
         assert result == "this is the expected result"
 
 
-def test_Window_show_admin_cancelled(qtapp):
+def test_Window_show_admin_cancelled():
     """
     If the modal dialog for the admin functions is cancelled, ensure an
     empty dictionary (indicating a "falsey" no change) is returned.
@@ -1261,7 +1261,7 @@ def test_Window_show_admin_cancelled(qtapp):
         assert result == {}
 
 
-def test_Window_sync_packages(qtapp):
+def test_Window_sync_packages():
     """
     Ensure the expected modal dialog indicating progress of third party package
     add/removal is displayed with the expected settings.
@@ -1278,7 +1278,7 @@ def test_Window_sync_packages(qtapp):
         dialog.exec.assert_called_once_with()
 
 
-def test_Window_show_message(qtapp):
+def test_Window_show_message():
     """
     Ensure the show_message method configures a QMessageBox in the expected
     manner.
@@ -1304,7 +1304,7 @@ def test_Window_show_message(qtapp):
     mock_qmb.exec.assert_called_once_with()
 
 
-def test_Window_show_message_default(qtapp):
+def test_Window_show_message_default():
     """
     Ensure the show_message method configures a QMessageBox in the expected
     manner with default args.
@@ -1328,7 +1328,7 @@ def test_Window_show_message_default(qtapp):
     mock_qmb.exec.assert_called_once_with()
 
 
-def test_Window_show_confirmation(qtapp):
+def test_Window_show_confirmation():
     """
     Ensure the show_confirmation method configures a QMessageBox in the
     expected manner.
@@ -1362,7 +1362,7 @@ def test_Window_show_confirmation(qtapp):
     mock_qmb.exec.assert_called_once_with()
 
 
-def test_Window_show_confirmation_default(qtapp):
+def test_Window_show_confirmation_default():
     """
     Ensure the show_confirmation method configures a QMessageBox in the
     expected manner with default args.
@@ -1394,7 +1394,7 @@ def test_Window_show_confirmation_default(qtapp):
     mock_qmb.exec.assert_called_once_with()
 
 
-def test_Window_update_title(qtapp):
+def test_Window_update_title():
     """
     Ensure a passed in title results in the correct call to setWindowTitle.
     """
@@ -1419,7 +1419,7 @@ def _qdesktopwidget_mock(width, height):
     return mock.MagicMock(return_value=mock_sg)
 
 
-def test_Window_autosize_window(qtapp):
+def test_Window_autosize_window():
     """
     Check the correct calculations take place and methods are called so the
     window is resized and positioned correctly.
@@ -1442,7 +1442,7 @@ def test_Window_autosize_window(qtapp):
     w.move.assert_called_once_with(x, y)
 
 
-def test_Window_reset_annotations(qtapp):
+def test_Window_reset_annotations():
     """
     Ensure the current tab has its annotations reset.
     """
@@ -1454,7 +1454,7 @@ def test_Window_reset_annotations(qtapp):
     tab.reset_annotations.assert_called_once_with()
 
 
-def test_Window_annotate_code(qtapp):
+def test_Window_annotate_code():
     """
     Ensure the current tab is annotated with the passed in feedback.
     """
@@ -1467,7 +1467,7 @@ def test_Window_annotate_code(qtapp):
     tab.annotate_code.assert_called_once_with(feedback, "error")
 
 
-def test_Window_show_annotations(qtapp):
+def test_Window_show_annotations():
     """
     Ensure the current tab displays its annotations.
     """
@@ -1479,7 +1479,7 @@ def test_Window_show_annotations(qtapp):
     tab.show_annotations.assert_called_once_with()
 
 
-def test_Window_setup(qtapp):
+def test_Window_setup():
     """
     Ensures the various default attributes of the window are set to the
     expected value.
@@ -1534,7 +1534,7 @@ def test_Window_setup(qtapp):
     assert w.size_window.call_count == 0
 
 
-def test_Window_set_usb_checker(qtapp):
+def test_Window_set_usb_checker():
     """
     Ensure the callback for checking for connected devices is set as expected.
     """
@@ -1549,7 +1549,7 @@ def test_Window_set_usb_checker(qtapp):
         w.usb_checker.start.assert_called_once_with(1000)
 
 
-def test_Window_set_timer(qtapp):
+def test_Window_set_timer():
     """
     Ensure a repeating timer with the referenced callback is created.
     """
@@ -1564,7 +1564,7 @@ def test_Window_set_timer(qtapp):
         w.timer.start.assert_called_once_with(5 * 1000)
 
 
-def test_Window_stop_timer(qtapp):
+def test_Window_stop_timer():
     """
     Ensure the timer is stopped and destroyed.
     """
@@ -1576,7 +1576,7 @@ def test_Window_stop_timer(qtapp):
     mock_timer.stop.assert_called_once_with()
 
 
-def test_Window_connect_tab_rename(qtapp):
+def test_Window_connect_tab_rename():
     """
     Ensure the referenced handler and shortcuts are set up to fire when
     the tab is double-clicked.
@@ -1595,7 +1595,7 @@ def test_Window_connect_tab_rename(qtapp):
     mock_shortcut().activated.connect.assert_called_once_with(mock_handler)
 
 
-def test_Window_open_directory_from_os_windows(qtapp):
+def test_Window_open_directory_from_os_windows():
     """
     Ensure the file explorer for Windows is called for the expected path.
     """
@@ -1609,7 +1609,7 @@ def test_Window_open_directory_from_os_windows(qtapp):
         mock_os.startfile.assert_called_once_with(path)
 
 
-def test_Window_open_directory_from_os_darwin(qtapp):
+def test_Window_open_directory_from_os_darwin():
     """
     Ensure the file explorer for OSX is called for the expected path.
     """
@@ -1623,7 +1623,7 @@ def test_Window_open_directory_from_os_darwin(qtapp):
         mock_system.assert_called_once_with('open "{}"'.format(path))
 
 
-def test_Window_open_directory_from_os_freedesktop(qtapp):
+def test_Window_open_directory_from_os_freedesktop():
     """
     Ensure the file explorer for FreeDesktop (Linux) is called for the
     expected path.
@@ -1638,7 +1638,7 @@ def test_Window_open_directory_from_os_freedesktop(qtapp):
         mock_system.assert_called_once_with('xdg-open "{}"'.format(path))
 
 
-def test_Window_open_file_event(qtapp):
+def test_Window_open_file_event():
     """
     Ensure the open_file event is emitted when a tab's open_file is
     triggered.
@@ -1667,7 +1667,7 @@ def test_Window_open_file_event(qtapp):
     mock_emit.assert_called_once_with("/foo/bar.py")
 
 
-def test_Window_connect_find_replace(qtapp):
+def test_Window_connect_find_replace():
     """
     Ensure a shortcut is created with teh expected shortcut and handler
     function.
@@ -1687,7 +1687,7 @@ def test_Window_connect_find_replace(qtapp):
     shortcut.activated.connect.assert_called_once_with(mock_handler)
 
 
-def test_Window_show_find_replace(qtapp):
+def test_Window_show_find_replace():
     """
     The find/replace dialog is setup with the right arguments and, if
     successfully closed, returns the expected result.
@@ -1705,7 +1705,7 @@ def test_Window_show_find_replace(qtapp):
     assert result == ("foo", "bar", True)
 
 
-def test_Window_replace_text_not_current_tab(qtapp):
+def test_Window_replace_text_not_current_tab():
     """
     If there is currently no open tab in which to search, return 0 (to indicate
     no changes have been made).
@@ -1716,7 +1716,7 @@ def test_Window_replace_text_not_current_tab(qtapp):
     assert w.replace_text("foo", "bar", False) == 0
 
 
-def test_Window_replace_text_not_global_found(qtapp):
+def test_Window_replace_text_not_global_found():
     """
     If the text to be replaced is found in the source, and the global_replace
     flag is false, return 1 (to indicate the number of changes made).
@@ -1730,7 +1730,7 @@ def test_Window_replace_text_not_global_found(qtapp):
     mock_tab.replace.assert_called_once_with("bar")
 
 
-def test_Window_replace_text_not_global_missing(qtapp):
+def test_Window_replace_text_not_global_missing():
     """
     If the text to be replaced is missing in the source, and the global_replace
     flag is false, return 0 (to indicate no change made).
@@ -1743,7 +1743,7 @@ def test_Window_replace_text_not_global_missing(qtapp):
     assert w.replace_text("foo", "bar", False) == 0
 
 
-def test_Window_replace_text_global_found(qtapp):
+def test_Window_replace_text_global_found():
     """
     If the text to be replaced is found several times in the source, and the
     global_replace flag is true, return X (to indicate X changes made) -- where
@@ -1759,7 +1759,7 @@ def test_Window_replace_text_global_found(qtapp):
     assert mock_tab.replace.call_count == 2
 
 
-def test_Window_replace_text_global_missing(qtapp):
+def test_Window_replace_text_global_missing():
     """
     If the text to be replaced is missing in the source, and the global_replace
     flag is true, return 0 (to indicate no change made).
@@ -1772,7 +1772,7 @@ def test_Window_replace_text_global_missing(qtapp):
     assert w.replace_text("foo", "bar", True) == 0
 
 
-def test_Window_highlight_text(qtapp):
+def test_Window_highlight_text():
     """
     Given target_text, highlights the first instance via Scintilla's findFirst
     method.
@@ -1786,7 +1786,7 @@ def test_Window_highlight_text(qtapp):
     mock_tab.findFirst.assert_called_once_with("foo", True, True, False, True)
 
 
-def test_Window_highlight_text_no_tab(qtapp):
+def test_Window_highlight_text_no_tab():
     """
     If there's no current tab, just return False.
     """
@@ -1796,7 +1796,7 @@ def test_Window_highlight_text_no_tab(qtapp):
     assert w.highlight_text("foo") is False
 
 
-def test_Window_connect_toggle_comments(qtapp):
+def test_Window_connect_toggle_comments():
     """
     Ensure the passed in handler is connected to a shortcut triggered by the
     shortcut.
@@ -1816,7 +1816,7 @@ def test_Window_connect_toggle_comments(qtapp):
     shortcut.activated.connect.assert_called_once_with(mock_handler)
 
 
-def test_Window_toggle_comments(qtapp):
+def test_Window_toggle_comments():
     """
     If there's a current tab, call its toggle_comments method.
     """
@@ -1828,7 +1828,7 @@ def test_Window_toggle_comments(qtapp):
     mock_tab.toggle_comments.assert_called_once_with()
 
 
-def test_Window_show_hide_device_selector(qtapp):
+def test_Window_show_hide_device_selector():
     """
     Ensure that the device_selector is shown as expected.
     """
@@ -1845,7 +1845,7 @@ def test_Window_show_hide_device_selector(qtapp):
     assert not (window.status_bar.device_selector.isHidden())
 
 
-def test_device_selector_device_changed_to_none(qtapp):
+def test_device_selector_device_changed_to_none():
     """
     Check that when device changes to index out of range,
     the device selector emits None on the device_changed signal
@@ -1892,7 +1892,7 @@ def adafruit_feather():
     return adafruit_feather
 
 
-def test_device_selector_device_changed(qtapp, microbit, adafruit_feather):
+def test_device_selector_device_changed(microbit, adafruit_feather):
     """
     Test that device_changed signals are emitted, when the user
     changes device.
@@ -1907,7 +1907,7 @@ def test_device_selector_device_changed(qtapp, microbit, adafruit_feather):
     device_selector.device_changed.emit.assert_called_with(adafruit_feather)
 
 
-def test_DeviceSelector_device_connected(qtapp, microbit):
+def test_DeviceSelector_device_connected(microbit):
     """
     Test that _update_view is called when a device connects
     """
@@ -1917,7 +1917,7 @@ def test_DeviceSelector_device_connected(qtapp, microbit):
     device_selector._update_view.assert_called_once_with()
 
 
-def test_DeviceSelector_device_disconnected(qtapp, microbit):
+def test_DeviceSelector_device_disconnected(microbit):
     """
     Test that _update_view is called when a device disconnects
     """
@@ -1927,7 +1927,7 @@ def test_DeviceSelector_device_disconnected(qtapp, microbit):
     device_selector._update_view.assert_called_once_with()
 
 
-def test_DeviceSelector_update_view_selector_hidden_on_1_device(qtapp):
+def test_DeviceSelector_update_view_selector_hidden_on_1_device():
     """
     Test that _update_view hides the combobox selector when only
     one device connected
@@ -1942,7 +1942,7 @@ def test_DeviceSelector_update_view_selector_hidden_on_1_device(qtapp):
     assert device_selector.selector.isHidden()
 
 
-def test_DeviceSelector_update_view_selector_shown_on_2_devices(qtapp):
+def test_DeviceSelector_update_view_selector_shown_on_2_devices():
     """
     Test that _update_view displays the combobox selector when two
     devices connected
@@ -1957,7 +1957,7 @@ def test_DeviceSelector_update_view_selector_shown_on_2_devices(qtapp):
     assert not device_selector.selector.isHidden()
 
 
-def test_DeviceSelector_update_view_check_disconnected_icon(qtapp):
+def test_DeviceSelector_update_view_check_disconnected_icon():
     """
     Test that _update_view displays the disconnected icon when
     no device connected
@@ -1972,7 +1972,7 @@ def test_DeviceSelector_update_view_check_disconnected_icon(qtapp):
     )
 
 
-def test_DeviceSelector_update_view_check_connected_icon(qtapp):
+def test_DeviceSelector_update_view_check_connected_icon():
     """
     Test that _update_view displays the connected icon when
     one device connected
@@ -1990,7 +1990,7 @@ def test_DeviceSelector_update_view_check_connected_icon(qtapp):
     )
 
 
-def test_StatusBar_init(qtapp):
+def test_StatusBar_init():
     """
     Ensure the status bar is set up as expected.
     """
@@ -2007,7 +2007,7 @@ def test_StatusBar_init(qtapp):
     assert sb.logs_label
 
 
-def test_StatusBar_connect_logs(qtapp):
+def test_StatusBar_connect_logs():
     """
     Ensure the event handler / shortcut for viewing logs is correctly set.
     """
@@ -2027,7 +2027,7 @@ def test_StatusBar_connect_logs(qtapp):
     mock_shortcut().activated.connect.assert_called_once_with(handler)
 
 
-def test_StatusBar_connect_mode(qtapp):
+def test_StatusBar_connect_mode():
     """
     Ensure the event handler / shortcut for selecting the new mode is
     correctly set.
@@ -2048,7 +2048,7 @@ def test_StatusBar_connect_mode(qtapp):
     mock_shortcut().activated.connect.assert_called_once_with(handler)
 
 
-def test_StatusBar_set_message(qtapp):
+def test_StatusBar_set_message():
     """
     Ensure the default pause for displaying a message in the status bar is
     used.
@@ -2062,7 +2062,7 @@ def test_StatusBar_set_message(qtapp):
     sb.showMessage.assert_called_once_with("Hello", 1000)
 
 
-def test_StatusBar_set_mode(qtapp):
+def test_StatusBar_set_mode():
     """
     Ensure the mode displayed in the status bar is correctly updated.
     """
@@ -2073,7 +2073,7 @@ def test_StatusBar_set_mode(qtapp):
     sb.mode_label.setText.assert_called_once_with(mode)
 
 
-def test_StatusBar_device_connected_microbit(qtapp, microbit):
+def test_StatusBar_device_connected_microbit(microbit):
     """
     Test that a message is displayed when a new device is connected
     (with no board_name set)
@@ -2084,7 +2084,7 @@ def test_StatusBar_device_connected_microbit(qtapp, microbit):
     assert sb.set_message.call_count == 1
 
 
-def test_StatusBar_device_connected_adafruit_feather(qtapp, adafruit_feather):
+def test_StatusBar_device_connected_adafruit_feather(adafruit_feather):
     """
     Test that a message is displayed when a new device is connected
     (with board_name set)

--- a/tests/interface/test_main.py
+++ b/tests/interface/test_main.py
@@ -1828,7 +1828,7 @@ def test_Window_toggle_comments(qtapp):
     mock_tab.toggle_comments.assert_called_once_with()
 
 
-def test_Window_show_hide_device_selector():
+def test_Window_show_hide_device_selector(qtapp):
     """
     Ensure that the device_selector is shown as expected.
     """
@@ -1845,7 +1845,7 @@ def test_Window_show_hide_device_selector():
     assert not (window.status_bar.device_selector.isHidden())
 
 
-def test_device_selector_device_changed_to_none():
+def test_device_selector_device_changed_to_none(qtapp):
     """
     Check that when device changes to index out of range,
     the device selector emits None on the device_changed signal
@@ -1892,7 +1892,7 @@ def adafruit_feather():
     return adafruit_feather
 
 
-def test_device_selector_device_changed(microbit, adafruit_feather):
+def test_device_selector_device_changed(qtapp, microbit, adafruit_feather):
     """
     Test that device_changed signals are emitted, when the user
     changes device.
@@ -1907,7 +1907,7 @@ def test_device_selector_device_changed(microbit, adafruit_feather):
     device_selector.device_changed.emit.assert_called_with(adafruit_feather)
 
 
-def test_DeviceSelector_device_connected(microbit):
+def test_DeviceSelector_device_connected(qtapp, microbit):
     """
     Test that _update_view is called when a device connects
     """
@@ -1917,7 +1917,7 @@ def test_DeviceSelector_device_connected(microbit):
     device_selector._update_view.assert_called_once_with()
 
 
-def test_DeviceSelector_device_disconnected(microbit):
+def test_DeviceSelector_device_disconnected(qtapp, microbit):
     """
     Test that _update_view is called when a device disconnects
     """
@@ -1927,7 +1927,7 @@ def test_DeviceSelector_device_disconnected(microbit):
     device_selector._update_view.assert_called_once_with()
 
 
-def test_DeviceSelector_update_view_selector_hidden_on_1_device():
+def test_DeviceSelector_update_view_selector_hidden_on_1_device(qtapp):
     """
     Test that _update_view hides the combobox selector when only
     one device connected
@@ -1942,7 +1942,7 @@ def test_DeviceSelector_update_view_selector_hidden_on_1_device():
     assert device_selector.selector.isHidden()
 
 
-def test_DeviceSelector_update_view_selector_shown_on_2_devices():
+def test_DeviceSelector_update_view_selector_shown_on_2_devices(qtapp):
     """
     Test that _update_view displays the combobox selector when two
     devices connected
@@ -1957,7 +1957,7 @@ def test_DeviceSelector_update_view_selector_shown_on_2_devices():
     assert not device_selector.selector.isHidden()
 
 
-def test_DeviceSelector_update_view_check_disconnected_icon():
+def test_DeviceSelector_update_view_check_disconnected_icon(qtapp):
     """
     Test that _update_view displays the disconnected icon when
     no device connected
@@ -1972,7 +1972,7 @@ def test_DeviceSelector_update_view_check_disconnected_icon():
     )
 
 
-def test_DeviceSelector_update_view_check_connected_icon():
+def test_DeviceSelector_update_view_check_connected_icon(qtapp):
     """
     Test that _update_view displays the connected icon when
     one device connected
@@ -2073,7 +2073,7 @@ def test_StatusBar_set_mode(qtapp):
     sb.mode_label.setText.assert_called_once_with(mode)
 
 
-def test_StatusBar_device_connected_microbit(microbit):
+def test_StatusBar_device_connected_microbit(qtapp, microbit):
     """
     Test that a message is displayed when a new device is connected
     (with no board_name set)
@@ -2084,7 +2084,7 @@ def test_StatusBar_device_connected_microbit(microbit):
     assert sb.set_message.call_count == 1
 
 
-def test_StatusBar_device_connected_adafruit_feather(adafruit_feather):
+def test_StatusBar_device_connected_adafruit_feather(qtapp, adafruit_feather):
     """
     Test that a message is displayed when a new device is connected
     (with board_name set)

--- a/tests/interface/test_panes.py
+++ b/tests/interface/test_panes.py
@@ -26,7 +26,7 @@ def test_PANE_ZOOM_SIZES():
     assert len(expected_sizes) == len(mu.interface.panes.PANE_ZOOM_SIZES)
 
 
-def test_MicroPythonREPLPane_paste(qtapp):
+def test_MicroPythonREPLPane_paste():
     """
     Pasting into the REPL should send bytes via the serial connection.
     """
@@ -43,7 +43,7 @@ def test_MicroPythonREPLPane_paste(qtapp):
     )
 
 
-def test_MicroPythonREPLPane_paste_handle_unix_newlines(qtapp):
+def test_MicroPythonREPLPane_paste_handle_unix_newlines():
     """
     Pasting into the REPL should handle '\n' properly.
 
@@ -62,7 +62,7 @@ def test_MicroPythonREPLPane_paste_handle_unix_newlines(qtapp):
     )
 
 
-def test_MicroPythonREPLPane_paste_handle_windows_newlines(qtapp):
+def test_MicroPythonREPLPane_paste_handle_windows_newlines():
     """
     Pasting into the REPL should handle '\r\n' properly.
 
@@ -81,7 +81,7 @@ def test_MicroPythonREPLPane_paste_handle_windows_newlines(qtapp):
     )
 
 
-def test_MicroPythonREPLPane_paste_only_works_if_something_to_paste(qtapp):
+def test_MicroPythonREPLPane_paste_only_works_if_something_to_paste():
     """
     Pasting into the REPL should send bytes via the serial connection.
     """
@@ -96,7 +96,7 @@ def test_MicroPythonREPLPane_paste_only_works_if_something_to_paste(qtapp):
     assert mock_repl_connection.write.call_count == 0
 
 
-def test_MicroPythonREPLPane_context_menu(qtapp):
+def test_MicroPythonREPLPane_context_menu():
     """
     Ensure the context menu for the REPL is configured correctly for non-OSX
     platforms.
@@ -123,7 +123,7 @@ def test_MicroPythonREPLPane_context_menu(qtapp):
     assert mock_qmenu.exec_.call_count == 1
 
 
-def test_MicroPythonREPLPane_context_menu_darwin(qtapp):
+def test_MicroPythonREPLPane_context_menu_darwin():
     """
     Ensure the context menu for the REPL is configured correctly for non-OSX
     platforms.
@@ -150,7 +150,7 @@ def test_MicroPythonREPLPane_context_menu_darwin(qtapp):
     assert mock_qmenu.exec_.call_count == 1
 
 
-def test_MicroPythonREPLPane_keyPressEvent(qtapp):
+def test_MicroPythonREPLPane_keyPressEvent():
     """
     Ensure key presses in the REPL are handled correctly.
     """
@@ -164,7 +164,7 @@ def test_MicroPythonREPLPane_keyPressEvent(qtapp):
     mock_repl_connection.write.assert_called_once_with(bytes("a", "utf-8"))
 
 
-def test_MicroPythonREPLPane_keyPressEvent_backspace(qtapp):
+def test_MicroPythonREPLPane_keyPressEvent_backspace():
     """
     Ensure backspaces in the REPL are handled correctly.
     """
@@ -178,7 +178,7 @@ def test_MicroPythonREPLPane_keyPressEvent_backspace(qtapp):
     mock_repl_connection.write.assert_called_once_with(b"\b")
 
 
-def test_MicroPythonREPLPane_keyPressEvent_delete(qtapp):
+def test_MicroPythonREPLPane_keyPressEvent_delete():
     """
     Ensure delete in the REPL is handled correctly.
     """
@@ -192,7 +192,7 @@ def test_MicroPythonREPLPane_keyPressEvent_delete(qtapp):
     mock_repl_connection.write.assert_called_once_with(b"\x1B[\x33\x7E")
 
 
-def test_MicroPythonREPLPane_keyPressEvent_up(qtapp):
+def test_MicroPythonREPLPane_keyPressEvent_up():
     """
     Ensure up arrows in the REPL are handled correctly.
     """
@@ -206,7 +206,7 @@ def test_MicroPythonREPLPane_keyPressEvent_up(qtapp):
     mock_repl_connection.write.assert_called_once_with(b"\x1B[A")
 
 
-def test_MicroPythonREPLPane_keyPressEvent_down(qtapp):
+def test_MicroPythonREPLPane_keyPressEvent_down():
     """
     Ensure down arrows in the REPL are handled correctly.
     """
@@ -220,7 +220,7 @@ def test_MicroPythonREPLPane_keyPressEvent_down(qtapp):
     mock_repl_connection.write.assert_called_once_with(b"\x1B[B")
 
 
-def test_MicroPythonREPLPane_keyPressEvent_right(qtapp):
+def test_MicroPythonREPLPane_keyPressEvent_right():
     """
     Ensure right arrows in the REPL are handled correctly.
     """
@@ -234,7 +234,7 @@ def test_MicroPythonREPLPane_keyPressEvent_right(qtapp):
     mock_repl_connection.write.assert_called_once_with(b"\x1B[C")
 
 
-def test_MicroPythonREPLPane_keyPressEvent_left(qtapp):
+def test_MicroPythonREPLPane_keyPressEvent_left():
     """
     Ensure left arrows in the REPL are handled correctly.
     """
@@ -248,7 +248,7 @@ def test_MicroPythonREPLPane_keyPressEvent_left(qtapp):
     mock_repl_connection.write.assert_called_once_with(b"\x1B[D")
 
 
-def test_MicroPythonREPLPane_keyPressEvent_home(qtapp):
+def test_MicroPythonREPLPane_keyPressEvent_home():
     """
     Ensure home key in the REPL is handled correctly.
     """
@@ -262,7 +262,7 @@ def test_MicroPythonREPLPane_keyPressEvent_home(qtapp):
     mock_repl_connection.write.assert_called_once_with(b"\x1B[H")
 
 
-def test_MicroPythonREPLPane_keyPressEvent_end(qtapp):
+def test_MicroPythonREPLPane_keyPressEvent_end():
     """
     Ensure end key in the REPL is handled correctly.
     """
@@ -276,7 +276,7 @@ def test_MicroPythonREPLPane_keyPressEvent_end(qtapp):
     mock_repl_connection.write.assert_called_once_with(b"\x1B[F")
 
 
-def test_MicroPythonREPLPane_keyPressEvent_CTRL_C_Darwin(qtapp):
+def test_MicroPythonREPLPane_keyPressEvent_CTRL_C_Darwin():
     """
     Ensure end key in the REPL is handled correctly.
     """
@@ -291,7 +291,7 @@ def test_MicroPythonREPLPane_keyPressEvent_CTRL_C_Darwin(qtapp):
     rp.copy.assert_called_once_with()
 
 
-def test_MicroPythonREPLPane_keyPressEvent_CTRL_V_Darwin(qtapp):
+def test_MicroPythonREPLPane_keyPressEvent_CTRL_V_Darwin():
     """
     Ensure end key in the REPL is handled correctly.
     """
@@ -306,7 +306,7 @@ def test_MicroPythonREPLPane_keyPressEvent_CTRL_V_Darwin(qtapp):
     rp.paste.assert_called_once_with()
 
 
-def test_MicroPythonREPLPane_keyPressEvent_meta(qtapp):
+def test_MicroPythonREPLPane_keyPressEvent_meta():
     """
     Ensure backspaces in the REPL are handled correctly.
     """
@@ -324,7 +324,7 @@ def test_MicroPythonREPLPane_keyPressEvent_meta(qtapp):
     mock_repl_connection.write.assert_called_once_with(bytes([expected]))
 
 
-def test_MicroPythonREPLPane_process_tty_data(qtapp):
+def test_MicroPythonREPLPane_process_tty_data():
     """
     Ensure bytes coming from the device to the application are processed as
     expected. Backspace is enacted, carriage-return is ignored, newline moves
@@ -360,7 +360,7 @@ def test_MicroPythonREPLPane_process_tty_data(qtapp):
     rp.ensureCursorVisible.assert_called_once_with()
 
 
-def test_MicroPythonREPLPane_process_tty_data_VT100(qtapp):
+def test_MicroPythonREPLPane_process_tty_data_VT100():
     """
     Ensure bytes coming from the device to the application are processed as
     expected. In this case, make sure VT100 related codes are handled properly.
@@ -423,7 +423,7 @@ def test_MicroPythonREPLPane_process_tty_data_VT100(qtapp):
     rp.ensureCursorVisible.assert_called_once_with()
 
 
-def test_MicroPythonREPLPane_clear(qtapp):
+def test_MicroPythonREPLPane_clear():
     """
     Ensure setText is called with an empty string.
     """
@@ -434,7 +434,7 @@ def test_MicroPythonREPLPane_clear(qtapp):
     rp.setText.assert_called_once_with("")
 
 
-def test_MicroPythonREPLPane_set_font_size(qtapp):
+def test_MicroPythonREPLPane_set_font_size():
     """
     Ensure the font is updated to the expected point size.
     """
@@ -448,7 +448,7 @@ def test_MicroPythonREPLPane_set_font_size(qtapp):
     rp.setFont.assert_called_once_with(mock_font)
 
 
-def test_MicroPythonREPLPane_set_zoom(qtapp):
+def test_MicroPythonREPLPane_set_zoom():
     """
     Ensure the font size is correctly set from the t-shirt size.
     """
@@ -460,7 +460,7 @@ def test_MicroPythonREPLPane_set_zoom(qtapp):
     rp.set_font_size.assert_called_once_with(expected)
 
 
-def test_MuFileList_show_confirm_overwrite_dialog(qtapp):
+def test_MuFileList_show_confirm_overwrite_dialog():
     """
     Ensure the user is notified of an existing file.
     """
@@ -481,7 +481,7 @@ def test_MuFileList_show_confirm_overwrite_dialog(qtapp):
     mock_qmb.setIcon.assert_called_once_with(QMessageBox.Information)
 
 
-def test_MicroPythonDeviceFileList_init(qtapp):
+def test_MicroPythonDeviceFileList_init():
     """
     Check the widget references the user's home and allows drag and drop.
     """
@@ -490,7 +490,7 @@ def test_MicroPythonDeviceFileList_init(qtapp):
     assert mfs.dragDropMode() == mfs.DragDrop
 
 
-def test_MicroPythonDeviceFileList_dropEvent(qtapp):
+def test_MicroPythonDeviceFileList_dropEvent():
     """
     Ensure a valid drop event is handled as expected.
     """
@@ -511,7 +511,7 @@ def test_MicroPythonDeviceFileList_dropEvent(qtapp):
     mfs.put.emit.assert_called_once_with(fn)
 
 
-def test_MicroPythonDeviceFileList_dropEvent_wrong_source(qtapp):
+def test_MicroPythonDeviceFileList_dropEvent_wrong_source():
     """
     Ensure that only drop events whose origins are LocalFileList objects are
     handled.
@@ -525,7 +525,7 @@ def test_MicroPythonDeviceFileList_dropEvent_wrong_source(qtapp):
     assert mfs.findItems.call_count == 0
 
 
-def test_MicroPythonDeviceFileList_on_put(qtapp):
+def test_MicroPythonDeviceFileList_on_put():
     """
     A message and list_files signal should be emitted.
     """
@@ -538,7 +538,7 @@ def test_MicroPythonDeviceFileList_on_put(qtapp):
     mfs.list_files.emit.assert_called_once_with()
 
 
-def test_MicroPythonDeviceFileList_contextMenuEvent(qtapp):
+def test_MicroPythonDeviceFileList_contextMenuEvent():
     """
     Ensure that the menu displayed when a file on the micro:bit is
     right-clicked works as expected when activated.
@@ -563,7 +563,7 @@ def test_MicroPythonDeviceFileList_contextMenuEvent(qtapp):
     mfs.delete.emit.assert_called_once_with("foo.py")
 
 
-def test_MicroPythonFileList_on_delete(qtapp):
+def test_MicroPythonFileList_on_delete():
     """
     On delete should emit a message and list_files signal.
     """
@@ -576,7 +576,7 @@ def test_MicroPythonFileList_on_delete(qtapp):
     mfs.list_files.emit.assert_called_once_with()
 
 
-def test_LocalFileList_init(qtapp):
+def test_LocalFileList_init():
     """
     Ensure the class instantiates with the expected state.
     """
@@ -585,7 +585,7 @@ def test_LocalFileList_init(qtapp):
     assert lfl.dragDropMode() == lfl.DragDrop
 
 
-def test_LocalFileList_dropEvent(qtapp):
+def test_LocalFileList_dropEvent():
     """
     Ensure a valid drop event is handled as expected.
     """
@@ -607,7 +607,7 @@ def test_LocalFileList_dropEvent(qtapp):
     lfs.get.emit.assert_called_once_with("foo.py", fn)
 
 
-def test_LocalFileList_dropEvent_wrong_source(qtapp):
+def test_LocalFileList_dropEvent_wrong_source():
     """
     Ensure that only drop events whose origins are LocalFileList objects are
     handled.
@@ -621,7 +621,7 @@ def test_LocalFileList_dropEvent_wrong_source(qtapp):
     assert lfs.findItems.call_count == 0
 
 
-def test_LocalFileList_on_get(qtapp):
+def test_LocalFileList_on_get():
     """
     On get should emit two signals: a message and list_files.
     """
@@ -637,7 +637,7 @@ def test_LocalFileList_on_get(qtapp):
     lfs.list_files.emit.assert_called_once_with()
 
 
-def test_LocalFileList_contextMenuEvent(qtapp):
+def test_LocalFileList_contextMenuEvent():
     """
     Ensure that the menu displayed when a local file is
     right-clicked works as expected when activated.
@@ -663,7 +663,7 @@ def test_LocalFileList_contextMenuEvent(qtapp):
     mock_open.assert_called_once_with(os.path.join("homepath", "foo.py"))
 
 
-def test_LocalFileList_contextMenuEvent_external(qtapp):
+def test_LocalFileList_contextMenuEvent_external():
     """
     Ensure that the menu displayed when a local file is
     right-clicked works as expected when activated.
@@ -688,7 +688,7 @@ def test_LocalFileList_contextMenuEvent_external(qtapp):
     assert mock_open.call_count == 0
 
 
-def test_FileSystemPane_init(qtapp):
+def test_FileSystemPane_init():
     """
     Check things are set up as expected.
     """
@@ -719,7 +719,7 @@ def test_FileSystemPane_init(qtapp):
         )
 
 
-def test_FileSystemPane_disable(qtapp):
+def test_FileSystemPane_disable():
     """
     The child list widgets are disabled correctly.
     """
@@ -733,7 +733,7 @@ def test_FileSystemPane_disable(qtapp):
     fsp.local_fs.setAcceptDrops.assert_called_once_with(False)
 
 
-def test_FileSystemPane_enable(qtapp):
+def test_FileSystemPane_enable():
     """
     The child list widgets are enabled correctly.
     """
@@ -747,7 +747,7 @@ def test_FileSystemPane_enable(qtapp):
     fsp.local_fs.setAcceptDrops.assert_called_once_with(True)
 
 
-def test_FileSystemPane_set_theme(qtapp):
+def test_FileSystemPane_set_theme():
     """
     Setting theme doesn't error
     """
@@ -755,7 +755,7 @@ def test_FileSystemPane_set_theme(qtapp):
     fsp.set_theme("test")
 
 
-def test_FileSystemPane_show_message(qtapp):
+def test_FileSystemPane_show_message():
     """
     Ensure the expected message signal is emitted.
     """
@@ -765,7 +765,7 @@ def test_FileSystemPane_show_message(qtapp):
     fsp.set_message.emit.assert_called_once_with("Hello")
 
 
-def test_FileSystemPane_show_warning(qtapp):
+def test_FileSystemPane_show_warning():
     """
     Ensure the expected warning signal is emitted.
     """
@@ -775,7 +775,7 @@ def test_FileSystemPane_show_warning(qtapp):
     fsp.set_warning.emit.assert_called_once_with("Hello")
 
 
-def test_FileSystemPane_on_ls(qtapp):
+def test_FileSystemPane_on_ls():
     """
     When lists of files have been obtained from the micro:bit and local
     filesystem, make sure they're properly processed by the on_ls event
@@ -800,7 +800,7 @@ def test_FileSystemPane_on_ls(qtapp):
     fsp.enable.assert_called_once_with()
 
 
-def test_FileSystemPane_on_ls_fail(qtapp):
+def test_FileSystemPane_on_ls_fail():
     """
     A warning is emitted and the widget disabled if listing files fails.
     """
@@ -812,7 +812,7 @@ def test_FileSystemPane_on_ls_fail(qtapp):
     fsp.disable.assert_called_once_with()
 
 
-def test_FileSystem_Pane_on_put_fail(qtapp):
+def test_FileSystem_Pane_on_put_fail():
     """
     A warning is emitted if putting files on the micro:bit fails.
     """
@@ -822,7 +822,7 @@ def test_FileSystem_Pane_on_put_fail(qtapp):
     assert fsp.show_warning.call_count == 1
 
 
-def test_FileSystem_Pane_on_delete_fail(qtapp):
+def test_FileSystem_Pane_on_delete_fail():
     """
     A warning is emitted if deleting files on the micro:bit fails.
     """
@@ -832,7 +832,7 @@ def test_FileSystem_Pane_on_delete_fail(qtapp):
     assert fsp.show_warning.call_count == 1
 
 
-def test_FileSystem_Pane_on_get_fail(qtapp):
+def test_FileSystem_Pane_on_get_fail():
     """
     A warning is emitted if getting files from the micro:bit fails.
     """
@@ -842,7 +842,7 @@ def test_FileSystem_Pane_on_get_fail(qtapp):
     assert fsp.show_warning.call_count == 1
 
 
-def test_FileSystemPane_set_font_size(qtapp):
+def test_FileSystemPane_set_font_size():
     """
     Ensure the right size is set as the point size and the text based UI child
     widgets are updated.
@@ -861,7 +861,7 @@ def test_FileSystemPane_set_font_size(qtapp):
     fsp.local_fs.setFont.assert_called_once_with(fsp.font)
 
 
-def test_FileSystemPane_open_file(qtapp):
+def test_FileSystemPane_open_file():
     """
     FileSystemPane should propogate the open_file signal
     """
@@ -873,7 +873,7 @@ def test_FileSystemPane_open_file(qtapp):
     mock_open_emit.assert_called_once_with("test")
 
 
-def test_JupyterREPLPane_init(qtapp):
+def test_JupyterREPLPane_init():
     """
     Ensure the widget is setup with the correct defaults.
     """
@@ -881,7 +881,7 @@ def test_JupyterREPLPane_init(qtapp):
     assert jw.console_height == 10
 
 
-def test_JupyterREPLPane_append_plain_text(qtapp):
+def test_JupyterREPLPane_append_plain_text():
     """
     Ensure signal and expected bytes are emitted when _append_plain_text is
     called.
@@ -892,7 +892,7 @@ def test_JupyterREPLPane_append_plain_text(qtapp):
     jw.on_append_text.emit.assert_called_once_with("hello".encode("utf-8"))
 
 
-def test_JupyterREPLPane_set_font_size(qtapp):
+def test_JupyterREPLPane_set_font_size():
     """
     Check the new point size is succesfully applied.
     """
@@ -901,7 +901,7 @@ def test_JupyterREPLPane_set_font_size(qtapp):
     assert jw.font.pointSize() == 16
 
 
-def test_JupyterREPLPane_set_zoom(qtapp):
+def test_JupyterREPLPane_set_zoom():
     """
     Ensure the expected font point size is set from the zoom size.
     """
@@ -913,7 +913,7 @@ def test_JupyterREPLPane_set_zoom(qtapp):
     )
 
 
-def test_JupyterREPLPane_set_theme_day(qtapp):
+def test_JupyterREPLPane_set_theme_day():
     """
     Make sure the theme is correctly set for day.
     """
@@ -923,7 +923,7 @@ def test_JupyterREPLPane_set_theme_day(qtapp):
     jw.set_default_style.assert_called_once_with()
 
 
-def test_JupyterREPLPane_set_theme_night(qtapp):
+def test_JupyterREPLPane_set_theme_night():
     """
     Make sure the theme is correctly set for night.
     """
@@ -933,7 +933,7 @@ def test_JupyterREPLPane_set_theme_night(qtapp):
     jw.set_default_style.assert_called_once_with(colors="nocolor")
 
 
-def test_JupyterREPLPane_set_theme_contrast(qtapp):
+def test_JupyterREPLPane_set_theme_contrast():
     """
     Make sure the theme is correctly set for high contrast.
     """
@@ -943,7 +943,7 @@ def test_JupyterREPLPane_set_theme_contrast(qtapp):
     jw.set_default_style.assert_called_once_with(colors="nocolor")
 
 
-def test_JupyterREPLPane_setFocus(qtapp):
+def test_JupyterREPLPane_setFocus():
     """
     Ensures setFocus actually occurs to the _control containing the REPL.
     """
@@ -953,7 +953,7 @@ def test_JupyterREPLPane_setFocus(qtapp):
     jw._control.setFocus.assert_called_once_with()
 
 
-def test_PythonProcessPane_init(qtapp):
+def test_PythonProcessPane_init():
     """
     Check the font, input_buffer and other initial state is set as expected.
     """
@@ -968,7 +968,7 @@ def test_PythonProcessPane_init(qtapp):
     assert ppp.reading_stdout is False
 
 
-def test_PythonProcessPane_start_process(qtapp):
+def test_PythonProcessPane_start_process():
     """
     Ensure the default arguments for starting a new process work as expected.
     Interactive mode is True, no debugger flag nor additional arguments.
@@ -996,7 +996,7 @@ def test_PythonProcessPane_start_process(qtapp):
     assert ppp.running is True
 
 
-def test_PythonProcessPane_start_process_command_args(qtapp):
+def test_PythonProcessPane_start_process_command_args():
     """
     Ensure that the new process is passed the expected comand line args.
     """
@@ -1014,7 +1014,7 @@ def test_PythonProcessPane_start_process_command_args(qtapp):
     ppp.process.start.assert_called_once_with(runner, expected_args)
 
 
-def test_PythonProcessPane_start_process_debugger(qtapp):
+def test_PythonProcessPane_start_process_debugger():
     """
     Ensure starting a new process with the debugger flag set to True uses the
     debug runner to execute the script.
@@ -1037,7 +1037,7 @@ def test_PythonProcessPane_start_process_debugger(qtapp):
     ppp.process.start.assert_called_once_with(python_exec, expected_args)
 
 
-def test_PythonProcessPane_start_process_not_interactive(qtapp):
+def test_PythonProcessPane_start_process_not_interactive():
     """
     Ensure that if the interactive flag is unset, the "-i" flag passed into
     the Python process is missing.
@@ -1058,7 +1058,7 @@ def test_PythonProcessPane_start_process_not_interactive(qtapp):
     ppp.process.start.assert_called_once_with(runner, expected_args)
 
 
-def test_PythonProcessPane_start_process_windows_path(qtapp):
+def test_PythonProcessPane_start_process_windows_path():
     """
     If running on Windows via the installer ensure that the expected paths
     find their way into a temporary mu.pth file.
@@ -1107,7 +1107,7 @@ def test_PythonProcessPane_start_process_windows_path(qtapp):
         assert e + "\n" in added_paths
 
 
-def test_PythonProcessPane_start_process_windows_path_no_user_site(qtapp):
+def test_PythonProcessPane_start_process_windows_path_no_user_site():
     """
     If running on Windows via the installer ensure that the Mu logs the
     fact it's unable to use the temporary mu.pth file because there is no
@@ -1143,7 +1143,7 @@ def test_PythonProcessPane_start_process_windows_path_no_user_site(qtapp):
     assert expected in logs
 
 
-def test_PythonProcessPane_start_process_windows_path_with_exception(qtapp):
+def test_PythonProcessPane_start_process_windows_path_with_exception():
     """
     If running on Windows via the installer ensure that the expected paths
     find their way into a temporary mu.pth file.
@@ -1181,7 +1181,7 @@ def test_PythonProcessPane_start_process_windows_path_with_exception(qtapp):
     assert expected in logs
 
 
-def test_PythonProcessPane_start_process_user_enviroment_variables(qtapp):
+def test_PythonProcessPane_start_process_user_enviroment_variables():
     """
     Ensure that if environment variables are set, they are set in the context
     of the new child Python process.
@@ -1240,7 +1240,7 @@ def test_PythonProcessPane_start_process_user_enviroment_variables(qtapp):
     )
 
 
-def test_PythonProcessPane_start_process_custom_runner(qtapp):
+def test_PythonProcessPane_start_process_custom_runner():
     """
     Ensure that if the runner is set, it is used as the command to start the
     new child Python process.
@@ -1264,7 +1264,7 @@ def test_PythonProcessPane_start_process_custom_runner(qtapp):
     ppp.process.start.assert_called_once_with("foo", expected_args)
 
 
-def test_PythonProcessPane_start_process_custom_python_args(qtapp):
+def test_PythonProcessPane_start_process_custom_python_args():
     """
     Ensure that if there are arguments to be passed into the Python runtime
     starting the child process, these are passed on correctly.
@@ -1285,7 +1285,7 @@ def test_PythonProcessPane_start_process_custom_python_args(qtapp):
     ppp.process.start.assert_called_once_with(runner, expected_args)
 
 
-def test_PythonProcessPane_finished(qtapp):
+def test_PythonProcessPane_finished():
     """
     Check the functionality to handle the process finishing is correct.
     """
@@ -1303,7 +1303,7 @@ def test_PythonProcessPane_finished(qtapp):
     ppp.setTextCursor.assert_called_once_with(ppp.textCursor())
 
 
-def test_PythonProcessPane_context_menu(qtapp):
+def test_PythonProcessPane_context_menu():
     """
     Ensure the context menu for the REPL is configured correctly for non-OSX
     platforms.
@@ -1329,7 +1329,7 @@ def test_PythonProcessPane_context_menu(qtapp):
     assert mock_qmenu.exec_.call_count == 1
 
 
-def test_PythonProcessPane_context_menu_darwin(qtapp):
+def test_PythonProcessPane_context_menu_darwin():
     """
     Ensure the context menu for the REPL is configured correctly for non-OSX
     platforms.
@@ -1355,7 +1355,7 @@ def test_PythonProcessPane_context_menu_darwin(qtapp):
     assert mock_qmenu.exec_.call_count == 1
 
 
-def test_PythonProcessPane_paste(qtapp):
+def test_PythonProcessPane_paste():
     """
     Ensure pasted text is handed off to the parse_paste method.
     """
@@ -1371,7 +1371,7 @@ def test_PythonProcessPane_paste(qtapp):
     ppp.parse_paste.assert_called_once_with("Hello")
 
 
-def test_PythonProcessPane_paste_normalize_windows_newlines(qtapp):
+def test_PythonProcessPane_paste_normalize_windows_newlines():
     """
     Ensure that pasted text containing Windows style line-ends is normalised
     to '\n'.
@@ -1388,7 +1388,7 @@ def test_PythonProcessPane_paste_normalize_windows_newlines(qtapp):
     ppp.parse_paste.assert_called_once_with("h\ni")
 
 
-def test_PythonProcessPane_parse_paste(qtapp):
+def test_PythonProcessPane_parse_paste():
     """
     Given some text ensure that the first character is correctly handled and
     the remaining text to be processed is scheduled to be parsed in the future.
@@ -1407,7 +1407,7 @@ def test_PythonProcessPane_parse_paste(qtapp):
     assert mock_timer.singleShot.call_count == 1
 
 
-def test_PythonProcessPane_parse_paste_non_ascii(qtapp):
+def test_PythonProcessPane_parse_paste_non_ascii():
     """
     Given some non-ascii yet printable text, ensure that the first character is
     correctly handled and the remaining text to be processed is scheduled to be
@@ -1422,7 +1422,7 @@ def test_PythonProcessPane_parse_paste_non_ascii(qtapp):
     assert mock_timer.singleShot.call_count == 1
 
 
-def test_PythonProcessPane_parse_paste_newline(qtapp):
+def test_PythonProcessPane_parse_paste_newline():
     """
     As above, but ensure the correct handling of a newline character.
     """
@@ -1435,7 +1435,7 @@ def test_PythonProcessPane_parse_paste_newline(qtapp):
     assert mock_timer.singleShot.call_count == 1
 
 
-def test_PythonProcessPane_parse_paste_final_character(qtapp):
+def test_PythonProcessPane_parse_paste_final_character():
     """
     As above, but ensure that if there a no more remaining characters to parse
     in the pasted text, then don't schedule any more recursive calls.
@@ -1449,7 +1449,7 @@ def test_PythonProcessPane_parse_paste_final_character(qtapp):
     assert mock_timer.singleShot.call_count == 0
 
 
-def test_PythonProcessPane_keyPressEvent_a(qtapp):
+def test_PythonProcessPane_keyPressEvent_a():
     """
     A character is typed and passed into parse_input in the expected manner.
     """
@@ -1463,7 +1463,7 @@ def test_PythonProcessPane_keyPressEvent_a(qtapp):
     ppp.parse_input.assert_called_once_with(Qt.Key_A, "a", None)
 
 
-def test_PythonProcessPane_on_process_halt(qtapp):
+def test_PythonProcessPane_on_process_halt():
     """
     Ensure the output from the halted process is dumped to the UI.
     """
@@ -1480,7 +1480,7 @@ def test_PythonProcessPane_on_process_halt(qtapp):
     ppp.set_start_of_current_line.assert_called_once_with()
 
 
-def test_PythonProcessPane_on_process_halt_badly_formed_bytes(qtapp):
+def test_PythonProcessPane_on_process_halt_badly_formed_bytes():
     """
     If the bytes read from the child process's stdout starts with a badly
     formed unicode character (e.g. a fragment of a multi-byte character such as
@@ -1500,7 +1500,7 @@ def test_PythonProcessPane_on_process_halt_badly_formed_bytes(qtapp):
     ppp.set_start_of_current_line.assert_called_once_with()
 
 
-def test_PythonProcessPane_parse_input_a(qtapp):
+def test_PythonProcessPane_parse_input_a():
     """
     Ensure a regular printable character is inserted into the text area.
     """
@@ -1513,7 +1513,7 @@ def test_PythonProcessPane_parse_input_a(qtapp):
     ppp.insert.assert_called_once_with(b"a")
 
 
-def test_PythonProcessPane_parse_input_non_ascii(qtapp):
+def test_PythonProcessPane_parse_input_non_ascii():
     """
     Ensure a non-ascii printable character is inserted into the text area.
     """
@@ -1526,7 +1526,7 @@ def test_PythonProcessPane_parse_input_non_ascii(qtapp):
     ppp.insert.assert_called_once_with("Å".encode("utf-8"))
 
 
-def test_PythonProcessPane_parse_input_ctrl_c(qtapp):
+def test_PythonProcessPane_parse_input_ctrl_c():
     """
     Control-C (SIGINT / KeyboardInterrupt) character is typed.
     """
@@ -1548,7 +1548,7 @@ def test_PythonProcessPane_parse_input_ctrl_c(qtapp):
     mock_timer.singleShot.assert_called_once_with(1, ppp.on_process_halt)
 
 
-def test_PythonProcessPane_parse_input_ctrl_d(qtapp):
+def test_PythonProcessPane_parse_input_ctrl_d():
     """
     Control-D (Kill process) character is typed.
     """
@@ -1568,7 +1568,7 @@ def test_PythonProcessPane_parse_input_ctrl_d(qtapp):
     mock_timer.singleShot.assert_called_once_with(1, ppp.on_process_halt)
 
 
-def test_PythonProcessPane_parse_input_ctrl_c_after_process_finished(qtapp):
+def test_PythonProcessPane_parse_input_ctrl_c_after_process_finished():
     """
     Control-C (SIGINT / KeyboardInterrupt) character is typed.
     """
@@ -1587,7 +1587,7 @@ def test_PythonProcessPane_parse_input_ctrl_c_after_process_finished(qtapp):
     assert mock_kill.call_count == 0
 
 
-def test_PythonProcessPane_parse_input_ctrl_d_after_process_finished(qtapp):
+def test_PythonProcessPane_parse_input_ctrl_d_after_process_finished():
     """
     Control-D (Kill process) character is typed.
     """
@@ -1604,7 +1604,7 @@ def test_PythonProcessPane_parse_input_ctrl_d_after_process_finished(qtapp):
         assert ppp.process.kill.call_count == 0
 
 
-def test_PythonProcessPane_parse_input_up_arrow(qtapp):
+def test_PythonProcessPane_parse_input_up_arrow():
     """
     Up Arrow causes the input line to be replaced with movement back in
     command history.
@@ -1618,7 +1618,7 @@ def test_PythonProcessPane_parse_input_up_arrow(qtapp):
     assert ppp.history_back.call_count == 1
 
 
-def test_PythonProcessPane_parse_input_down_arrow(qtapp):
+def test_PythonProcessPane_parse_input_down_arrow():
     """
     Down Arrow causes the input line to be replaced with movement forward
     through command line.
@@ -1632,7 +1632,7 @@ def test_PythonProcessPane_parse_input_down_arrow(qtapp):
     assert ppp.history_forward.call_count == 1
 
 
-def test_PythonProcessPane_parse_input_right_arrow(qtapp):
+def test_PythonProcessPane_parse_input_right_arrow():
     """
     Right Arrow causes the cursor to move to the right one place.
     """
@@ -1648,7 +1648,7 @@ def test_PythonProcessPane_parse_input_right_arrow(qtapp):
     ppp.setTextCursor.assert_called_once_with(mock_cursor)
 
 
-def test_PythonProcessPane_parse_input_left_arrow(qtapp):
+def test_PythonProcessPane_parse_input_left_arrow():
     """
     Left Arrow causes the cursor to move to the left one place if not at the
     start of the input line.
@@ -1667,7 +1667,7 @@ def test_PythonProcessPane_parse_input_left_arrow(qtapp):
     ppp.setTextCursor.assert_called_once_with(mock_cursor)
 
 
-def test_PythonProcessPane_parse_input_left_arrow_at_start_of_line(qtapp):
+def test_PythonProcessPane_parse_input_left_arrow_at_start_of_line():
     """
     Left Arrow doesn't do anything if the current cursor position is at the
     start of the input line.
@@ -1686,7 +1686,7 @@ def test_PythonProcessPane_parse_input_left_arrow_at_start_of_line(qtapp):
     assert ppp.setTextCursor.call_count == 0
 
 
-def test_PythonProcessPane_parse_input_home(qtapp):
+def test_PythonProcessPane_parse_input_home():
     """
     Home moves cursor to the start of the input line.
     """
@@ -1705,7 +1705,7 @@ def test_PythonProcessPane_parse_input_home(qtapp):
     ppp.setTextCursor.assert_called_once_with(mock_cursor)
 
 
-def test_PythonProcessPane_parse_input_end(qtapp):
+def test_PythonProcessPane_parse_input_end():
     """
     End moves cursor to the end of the input line.
     """
@@ -1721,7 +1721,7 @@ def test_PythonProcessPane_parse_input_end(qtapp):
     ppp.setTextCursor.assert_called_once_with(mock_cursor)
 
 
-def test_PythonProcessPane_parse_input_paste(qtapp):
+def test_PythonProcessPane_parse_input_paste():
     """
     Control-Shift-V (paste) character causes a paste to happen.
     """
@@ -1734,7 +1734,7 @@ def test_PythonProcessPane_parse_input_paste(qtapp):
     ppp.paste.assert_called_once_with()
 
 
-def test_PythonProcessPane_parse_input_copy(qtapp):
+def test_PythonProcessPane_parse_input_copy():
     """
     Control-Shift-C (copy) character causes copy to happen.
     """
@@ -1747,7 +1747,7 @@ def test_PythonProcessPane_parse_input_copy(qtapp):
     ppp.copy.assert_called_once_with()
 
 
-def test_PythonProcessPane_parse_input_backspace(qtapp):
+def test_PythonProcessPane_parse_input_backspace():
     """
     Backspace call causes a backspace from the character at the cursor
     position.
@@ -1761,7 +1761,7 @@ def test_PythonProcessPane_parse_input_backspace(qtapp):
     ppp.backspace.assert_called_once_with()
 
 
-def test_PythonProcessPane_parse_input_delete(qtapp):
+def test_PythonProcessPane_parse_input_delete():
     """
     Delete deletes the character to the right of the cursor position.
     """
@@ -1774,7 +1774,7 @@ def test_PythonProcessPane_parse_input_delete(qtapp):
     ppp.delete.assert_called_once_with()
 
 
-def test_PythonProcessPane_parse_input_newline(qtapp):
+def test_PythonProcessPane_parse_input_newline():
     """
     Newline causes the input line to be written to the child process's stdin.
     """
@@ -1797,9 +1797,7 @@ def test_PythonProcessPane_parse_input_newline(qtapp):
     assert ppp.start_of_current_line == 4  # len('abc\n')
 
 
-def test_PythonProcessPane_parse_input_newline_ignore_empty_input_in_history(
-    qtapp,
-):
+def test_PythonProcessPane_parse_input_newline_ignore_empty_input_in_history():
     """
     Newline causes the input line to be written to the child process's stdin,
     but if the resulting line is either empty or only contains whitespace, do
@@ -1818,7 +1816,7 @@ def test_PythonProcessPane_parse_input_newline_ignore_empty_input_in_history(
     assert ppp.history_position == 0
 
 
-def test_PythonProcessPane_parse_input_newline_with_cursor_midline(qtapp):
+def test_PythonProcessPane_parse_input_newline_with_cursor_midline():
     """
     Ensure that when the cursor is placed in the middle of a line and enter is
     pressed the whole line is sent to std_in.
@@ -1831,7 +1829,7 @@ def test_PythonProcessPane_parse_input_newline_with_cursor_midline(qtapp):
     ppp.write_to_stdin.assert_called_with(b"abc\n")
 
 
-def test_PythonProcessPane_set_start_of_current_line(qtapp):
+def test_PythonProcessPane_set_start_of_current_line():
     """
     Ensure the start of the current line is set to the current length of the
     text in the editor pane.
@@ -1842,7 +1840,7 @@ def test_PythonProcessPane_set_start_of_current_line(qtapp):
     assert ppp.start_of_current_line == len("Hello𠜎")
 
 
-def test_PythonProcessPane_history_back(qtapp):
+def test_PythonProcessPane_history_back():
     """
     Ensure the current input line is replaced by the next item back in time
     from the current history position.
@@ -1857,7 +1855,7 @@ def test_PythonProcessPane_history_back(qtapp):
     assert ppp.history_position == -1
 
 
-def test_PythonProcessPane_history_back_at_first_item(qtapp):
+def test_PythonProcessPane_history_back_at_first_item():
     """
     Ensure the current input line is replaced by the next item back in time
     from the current history position.
@@ -1872,7 +1870,7 @@ def test_PythonProcessPane_history_back_at_first_item(qtapp):
     assert ppp.history_position == -3
 
 
-def test_PythonProcessPane_history_forward(qtapp):
+def test_PythonProcessPane_history_forward():
     """
     Ensure the current input line is replaced by the next item forward in time
     from the current history position.
@@ -1887,7 +1885,7 @@ def test_PythonProcessPane_history_forward(qtapp):
     assert ppp.history_position == -2
 
 
-def test_PythonProcessPane_history_forward_at_last_item(qtapp):
+def test_PythonProcessPane_history_forward_at_last_item():
     """
     Ensure the current input line is cleared if the history position was at
     the most recent item.
@@ -1904,7 +1902,7 @@ def test_PythonProcessPane_history_forward_at_last_item(qtapp):
     assert ppp.history_position == 0
 
 
-def test_PythonProcessPane_try_read_from_stdout_not_started(qtapp):
+def test_PythonProcessPane_try_read_from_stdout_not_started():
     """
     If the process pane is NOT already reading from STDOUT then ensure it
     starts to.
@@ -1916,7 +1914,7 @@ def test_PythonProcessPane_try_read_from_stdout_not_started(qtapp):
     ppp.read_from_stdout.assert_called_once_with()
 
 
-def test_PythonProcessPane_try_read_from_stdout_has_started(qtapp):
+def test_PythonProcessPane_try_read_from_stdout_has_started():
     """
     If the process pane is already reading from STDOUT then ensure it
     doesn't keep trying.
@@ -1929,7 +1927,7 @@ def test_PythonProcessPane_try_read_from_stdout_has_started(qtapp):
     assert ppp.read_from_stdout.call_count == 0
 
 
-def test_PythonProcessPane_read_from_stdout(qtapp):
+def test_PythonProcessPane_read_from_stdout():
     """
     Ensure incoming bytes from sub-process's stout are processed correctly.
     """
@@ -1949,7 +1947,7 @@ def test_PythonProcessPane_read_from_stdout(qtapp):
     mock_timer.singleShot.assert_called_once_with(2, ppp.read_from_stdout)
 
 
-def test_PythonProcessPane_read_from_stdout_with_stdout_buffer(qtapp):
+def test_PythonProcessPane_read_from_stdout_with_stdout_buffer():
     """
     Ensure incoming bytes from sub-process's stdout are processed correctly if
     there was a split between reads in a multi-byte character (such as "𠜎").
@@ -1974,7 +1972,7 @@ def test_PythonProcessPane_read_from_stdout_with_stdout_buffer(qtapp):
     assert ppp.stdout_buffer == b""
 
 
-def test_PythonProcessPane_read_from_stdout_with_unicode_error(qtapp):
+def test_PythonProcessPane_read_from_stdout_with_unicode_error():
     """
     Ensure incoming bytes from sub-process's stdout are processed correctly if
     there was a split between reads in a multi-byte character (such as "𠜎").
@@ -1999,7 +1997,7 @@ def test_PythonProcessPane_read_from_stdout_with_unicode_error(qtapp):
     assert ppp.stdout_buffer == msg[:7]
 
 
-def test_PythonProcessPane_read_from_stdout_no_data(qtapp):
+def test_PythonProcessPane_read_from_stdout_no_data():
     """
     If no data is returned, ensure the reading_stdout flag is reset to False.
     """
@@ -2011,7 +2009,7 @@ def test_PythonProcessPane_read_from_stdout_no_data(qtapp):
     assert ppp.reading_stdout is False
 
 
-def test_PythonProcessPane_write_to_stdin(qtapp):
+def test_PythonProcessPane_write_to_stdin():
     """
     Ensure input from the user is written to the child process.
     """
@@ -2021,7 +2019,7 @@ def test_PythonProcessPane_write_to_stdin(qtapp):
     ppp.process.write.assert_called_once_with(b"hello")
 
 
-def test_PythonProcessPane_append(qtapp):
+def test_PythonProcessPane_append():
     """
     Ensure the referenced byte_stream is added to the textual content of the
     QTextEdit.
@@ -2035,7 +2033,7 @@ def test_PythonProcessPane_append(qtapp):
     assert mock_cursor.movePosition.call_count == 2
 
 
-def test_PythonProcessPane_insert_within_input_line(qtapp):
+def test_PythonProcessPane_insert_within_input_line():
     """
     Ensure text is inserted at the end of the document if the current cursor
     position is not within the bounds of the input line.
@@ -2051,7 +2049,7 @@ def test_PythonProcessPane_insert_within_input_line(qtapp):
     mock_cursor.insertText.assert_called_once_with("hello")
 
 
-def test_PythonProcessPane_insert(qtapp):
+def test_PythonProcessPane_insert():
     """
     Ensure text is inserted at the current cursor position.
     """
@@ -2066,7 +2064,7 @@ def test_PythonProcessPane_insert(qtapp):
     mock_cursor.insertText.assert_called_once_with("hello")
 
 
-def test_PythonProcessPane_backspace(qtapp):
+def test_PythonProcessPane_backspace():
     """
     Make sure that removing a character to the left of the current cursor
     position works as expected.
@@ -2083,7 +2081,7 @@ def test_PythonProcessPane_backspace(qtapp):
     ppp.setTextCursor.assert_called_once_with(mock_cursor)
 
 
-def test_PythonProcessPane_backspace_at_start_of_input_line(qtapp):
+def test_PythonProcessPane_backspace_at_start_of_input_line():
     """
     Make sure that removing a character will not work if the cursor is at the
     left-hand boundary of the input line.
@@ -2098,7 +2096,7 @@ def test_PythonProcessPane_backspace_at_start_of_input_line(qtapp):
     assert mock_cursor.deletePreviousChar.call_count == 0
 
 
-def test_PythonProcessPane_delete(qtapp):
+def test_PythonProcessPane_delete():
     """
     Make sure that removing a character to the right of the current cursor
     position works as expected.
@@ -2115,7 +2113,7 @@ def test_PythonProcessPane_delete(qtapp):
     ppp.setTextCursor.assert_called_once_with(mock_cursor)
 
 
-def test_PythonProcessPane_delete_at_start_of_input_line(qtapp):
+def test_PythonProcessPane_delete_at_start_of_input_line():
     """
     Make sure that removing a character will not work if the cursor is at the
     left-hand boundary of the input line.
@@ -2130,7 +2128,7 @@ def test_PythonProcessPane_delete_at_start_of_input_line(qtapp):
     assert mock_cursor.deleteChar.call_count == 0
 
 
-def test_PythonProcessPane_clear_input_line(qtapp):
+def test_PythonProcessPane_clear_input_line():
     """
     Ensure the input line is cleared back to the start of the input line.
     """
@@ -2146,7 +2144,7 @@ def test_PythonProcessPane_clear_input_line(qtapp):
     ppp.setTextCursor.assert_called_once_with(mock_cursor)
 
 
-def test_PythonProcessPane_replace_input_line(qtapp):
+def test_PythonProcessPane_replace_input_line():
     """
     Ensure that the input line is cleared and then the replacement text is
     appended to the text area.
@@ -2159,7 +2157,7 @@ def test_PythonProcessPane_replace_input_line(qtapp):
     ppp.append.assert_called_once_with("hello")
 
 
-def test_PythonProcessPane_set_font_size(qtapp):
+def test_PythonProcessPane_set_font_size():
     """
     Ensure the font size is set to the expected point size.
     """
@@ -2172,7 +2170,7 @@ def test_PythonProcessPane_set_font_size(qtapp):
     ppp.setFont.assert_called_once_with(mock_font)
 
 
-def test_PythonProcessPane_set_zoom(qtapp):
+def test_PythonProcessPane_set_zoom():
     """
     Ensure the expected point size is set from the given "t-shirt" size.
     """
@@ -2183,7 +2181,7 @@ def test_PythonProcessPane_set_zoom(qtapp):
     ppp.set_font_size.assert_called_once_with(expected)
 
 
-def test_PythonProcessPane_set_theme(qtapp):
+def test_PythonProcessPane_set_theme():
     """
     Setting the theme shouldn't do anything
     """
@@ -2191,13 +2189,13 @@ def test_PythonProcessPane_set_theme(qtapp):
     ppp.set_theme("test")
 
 
-def test_DebugInspectorItem(qtapp):
+def test_DebugInspectorItem():
     item = mu.interface.panes.DebugInspectorItem("test")
     assert item.text() == "test"
     assert not item.isEditable()
 
 
-def test_DebugInspector_set_font_size(qtapp):
+def test_DebugInspector_set_font_size():
     """
     Check the correct stylesheet values are being set.
     """
@@ -2209,7 +2207,7 @@ def test_DebugInspector_set_font_size(qtapp):
     assert "font-family: Monospace;" in style
 
 
-def test_DebugInspector_set_zoom(qtapp):
+def test_DebugInspector_set_zoom():
     """
     Ensure the expected point size is set from the given "t-shirt" size.
     """
@@ -2220,7 +2218,7 @@ def test_DebugInspector_set_zoom(qtapp):
     di.set_font_size.assert_called_once_with(expected)
 
 
-def test_DebugInspector_set_theme(qtapp):
+def test_DebugInspector_set_theme():
     """
     Setting the theme shouldn't do anything
     """
@@ -2228,7 +2226,7 @@ def test_DebugInspector_set_theme(qtapp):
     di.set_theme("test")
 
 
-def test_PlotterPane_init(qtapp):
+def test_PlotterPane_init():
     """
     Ensure the plotter pane is created in the expected manner.
     """
@@ -2246,7 +2244,7 @@ def test_PlotterPane_init(qtapp):
     assert isinstance(pp.axis_y, QValueAxis)
 
 
-def test_PlotterPane_process_tty_data(qtapp):
+def test_PlotterPane_process_tty_data():
     """
     If a byte representation of a Python tuple containing numeric values,
     starting at the beginning of a new line and terminating with a new line is
@@ -2259,7 +2257,7 @@ def test_PlotterPane_process_tty_data(qtapp):
     pp.add_data.assert_called_once_with((1, 2.3, 4))
 
 
-def test_PlotterPane_process_tty_data_guards_against_data_flood(qtapp):
+def test_PlotterPane_process_tty_data_guards_against_data_flood():
     """
     If the process_tty_data method gets data of more than 1024 bytes
     then trigger a data_flood signal and ensure the plotter no longer
@@ -2281,7 +2279,7 @@ def test_PlotterPane_process_tty_data_guards_against_data_flood(qtapp):
     assert pp.add_data.call_count == 0
 
 
-def test_PlotterPane_process_tty_data_tuple_not_numeric(qtapp):
+def test_PlotterPane_process_tty_data_tuple_not_numeric():
     """
     If a byte representation of a tuple is received but it doesn't contain
     numeric values, then the add_data method MUST NOT be called.
@@ -2292,7 +2290,7 @@ def test_PlotterPane_process_tty_data_tuple_not_numeric(qtapp):
     assert pp.add_data.call_count == 0
 
 
-def test_PlotterPane_process_tty_data_overrun_input_buffer(qtapp):
+def test_PlotterPane_process_tty_data_overrun_input_buffer():
     """
     If the incoming bytes are not complete, ensure the input_buffer caches them
     until the newline is detected.
@@ -2311,7 +2309,7 @@ def test_PlotterPane_process_tty_data_overrun_input_buffer(qtapp):
     pp.add_data.assert_called_once_with((1, 2.3, 4))
 
 
-def test_PlotterPane_add_data(qtapp):
+def test_PlotterPane_add_data():
     """
     Given a tuple with a single value, ensure it is logged and correctly added
     to the chart.
@@ -2327,7 +2325,7 @@ def test_PlotterPane_add_data(qtapp):
     mock_line_series.append.call_args_list[99][0] == (99, 1)
 
 
-def test_PlotterPane_add_data_adjust_values_up(qtapp):
+def test_PlotterPane_add_data_adjust_values_up():
     """
     If more values than have been encountered before are added to the incoming
     data then increase the number of QLineSeries instances.
@@ -2344,7 +2342,7 @@ def test_PlotterPane_add_data_adjust_values_up(qtapp):
     assert len(pp.data) == 4
 
 
-def test_PlotterPane_add_data_adjust_values_down(qtapp):
+def test_PlotterPane_add_data_adjust_values_down():
     """
     If less values are encountered, before they are added to the incoming
     data then decrease the number of QLineSeries instances.
@@ -2361,7 +2359,7 @@ def test_PlotterPane_add_data_adjust_values_down(qtapp):
     assert pp.chart.removeSeries.call_count == 2
 
 
-def test_PlotterPane_add_data_re_scale_up(qtapp):
+def test_PlotterPane_add_data_re_scale_up():
     """
     If the y axis contains data greater than the current range, then ensure
     the range is doubled.
@@ -2375,7 +2373,7 @@ def test_PlotterPane_add_data_re_scale_up(qtapp):
     pp.axis_y.setRange.assert_called_once_with(-2000, 2000)
 
 
-def test_PlotterPane_add_data_re_scale_down(qtapp):
+def test_PlotterPane_add_data_re_scale_down():
     """
     If the y axis contains data less than half of the current range, then
     ensure the range is halved.
@@ -2390,7 +2388,7 @@ def test_PlotterPane_add_data_re_scale_down(qtapp):
     pp.axis_y.setRange.assert_called_once_with(-2000, 2000)
 
 
-def test_PlotterPane_set_label_format_to_float_when_range_small(qtapp):
+def test_PlotterPane_set_label_format_to_float_when_range_small():
     """
     If the max_y is 5 or less, make sure the label format is set to being a
     float with two decimal places.
@@ -2406,7 +2404,7 @@ def test_PlotterPane_set_label_format_to_float_when_range_small(qtapp):
     pp.axis_y.setLabelFormat.assert_called_once_with("%2.2f")
 
 
-def test_PlotterPane_set_label_format_to_int_when_range_large(qtapp):
+def test_PlotterPane_set_label_format_to_int_when_range_large():
     """
     If the max_y is 5 or less, make sure the label format is set to being a
     float with two decimal places.
@@ -2422,7 +2420,7 @@ def test_PlotterPane_set_label_format_to_int_when_range_large(qtapp):
     pp.axis_y.setLabelFormat.assert_called_once_with("%d")
 
 
-def test_PlotterPane_set_theme(qtapp):
+def test_PlotterPane_set_theme():
     """
     Ensure the themes for the chart relate correctly to the theme names used
     by Mu.

--- a/tests/interface/test_themes.py
+++ b/tests/interface/test_themes.py
@@ -44,7 +44,7 @@ def test_Font():
     assert f.italic
 
 
-def test_theme_apply_to(qtapp):
+def test_theme_apply_to():
     """
     Ensure that the apply_to class method updates the passed in lexer with the
     expected font settings.

--- a/tests/modes/test_pygamezero.py
+++ b/tests/modes/test_pygamezero.py
@@ -49,7 +49,7 @@ def test_pgzero_api():
     assert result == SHARED_APIS + PYTHON3_APIS + PI_APIS + PYGAMEZERO_APIS
 
 
-def test_pgzero_play_toggle_on(qtapp):
+def test_pgzero_play_toggle_on():
     """
     Check the handler for clicking play starts the new process and updates the
     UI state.
@@ -89,7 +89,7 @@ def test_pgzero_play_toggle_on_cancelled():
     assert slot.setIcon.call_count == 0
 
 
-def test_pgzero_play_toggle_off(qtapp):
+def test_pgzero_play_toggle_off():
     """
     Check the handler for clicking play stops the process and reverts the UI
     state.

--- a/tests/modes/test_python3.py
+++ b/tests/modes/test_python3.py
@@ -140,7 +140,7 @@ def test_python_api():
     assert result == SHARED_APIS + PYTHON3_APIS + PI_APIS
 
 
-def test_python_run_toggle_on(qtapp):
+def test_python_run_toggle_on():
     """
     Check the handler for clicking run starts the new process and updates the
     UI state.
@@ -185,7 +185,7 @@ def test_python_run_toggle_on_cancelled():
     assert slot.setIcon.call_count == 0
 
 
-def test_python_run_toggle_off(qtapp):
+def test_python_run_toggle_off():
     """
     Check the handler for clicking run stops the process and reverts the UI
     state.

--- a/tests/modes/test_web.py
+++ b/tests/modes/test_web.py
@@ -48,7 +48,7 @@ def test_web_api():
     assert result == SHARED_APIS + PYTHON3_APIS + FLASK_APIS
 
 
-def test_run_toggle_on(qtapp):
+def test_run_toggle_on():
     """
     Check the handler for running the local server starts the sub-process and
     updates the UI state.
@@ -72,7 +72,7 @@ def test_run_toggle_on(qtapp):
     wm.set_buttons.assert_called_once_with(modes=False)
 
 
-def test_run_toggle_off(qtapp):
+def test_run_toggle_off():
     """
     Check the handler for toggling the local server stops the process and
     reverts the UI state.

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -87,7 +87,7 @@ def test_setup_modes_without_pgzero():
         assert "pygamezero" not in modes
 
 
-def test_run(qtapp):
+def test_run():
     """
     Ensure the run function sets things up in the expected way.
 

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -960,7 +960,7 @@ def test_editor_setup():
     view.set_usb_checker.assert_called_once_with(1, e.check_usb)
 
 
-def test_editor_connect_to_status_bar():
+def test_editor_connect_to_status_bar(qtapp):
     """
     Check that the Window status bar is connected appropriately
     to Editor-pane and to modes

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -960,7 +960,7 @@ def test_editor_setup():
     view.set_usb_checker.assert_called_once_with(1, e.check_usb)
 
 
-def test_editor_connect_to_status_bar(qtapp):
+def test_editor_connect_to_status_bar():
     """
     Check that the Window status bar is connected appropriately
     to Editor-pane and to modes

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -17,7 +17,7 @@ def test_path():
         r.assert_called_once_with(mu.resources.__name__, "images/foo")
 
 
-def test_load_icon(qtapp):
+def test_load_icon():
     """
     Check the load_icon function returns the expected QIcon object.
     """
@@ -25,7 +25,7 @@ def test_load_icon(qtapp):
     assert isinstance(result, QIcon)
 
 
-def test_load_pixmap(qtapp):
+def test_load_pixmap():
     """
     Check the load_pixmap function returns the expected QPixmap object.
     """


### PR DESCRIPTION
Fixes https://github.com/mu-editor/mu/issues/1105, thanks @dybber for the tip about adding the fixture!

I've tested this locally in macOS and I haven't been able to get the same error when the affected tests are run in isolation (which before this patch always triggers the issue), or when running all the tests in a loop for about 1h.

Currently as a draft PR while I restart the tests in travis to ensure nothing else pops up. I also need to remove the first two commits (useful for Travis debugging) before we can merge this.