### PR TITLE
Ensure make check only checks with black. Use make tidy to apply black.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,17 @@ tidy: clean
 	black -l 79 tests
 	black -l 79 utils 
 
-check: clean tidy flake8 coverage
+black: clean
+	@echo "\nChecking code with black..."
+	black --check -l 79 setup.py
+	black --check -l 79 win_installer.py
+	black --check -l 79 make.py
+	black --check -l 79 mu
+	black --check -l 79 package
+	black --check -l 79 tests
+	black --check -l 79 utils
+
+check: clean black flake8 coverage
 
 dist: check
 	@echo "\nChecks pass, good to package..."

--- a/make.py
+++ b/make.py
@@ -166,10 +166,31 @@ def tidy():
 
 
 @export
+def black():
+    """Check code with the 'black' formatter."""
+    print("\nblack")
+    for target in [
+        "setup.py",
+        "win_installer.py",
+        "make.py",
+        "mu",
+        "package",
+        "tests",
+        "utils",
+    ]:
+        return_code = subprocess.run(
+            [TIDY, "--check", "-l", "79", target]
+        ).returncode
+        if return_code != 0:
+            return return_code
+    return 0
+
+
+@export
 def check():
     """Run all the checkers and tests"""
     print("\nCheck")
-    funcs = [clean, tidy, flake8, coverage]
+    funcs = [clean, black, flake8, coverage]
     for func in funcs:
         return_code = func()
         if return_code != 0:


### PR DESCRIPTION
Cherry pick of 65441dcf3bf8d6625b0c9c74eaee8acc938c1e34 from https://github.com/mu-editor/mu/pull/937/ with small amends (formatting fixes and https://github.com/mu-editor/mu/pull/937/commits/65441dcf3bf8d6625b0c9c74eaee8acc938c1e34#r333127531).

Currently the "make check" command fixes the formatting, so in the CI any files with issues are edited instead of failing the build. This change adds the make command "black", which replaces the "tidy" step inside "make check", so "make tidy" still works the same reformatting the files, and now "make check" fails if it finds formatting issues.

Creating this as a separate PR because https://github.com/mu-editor/mu/pull/937/ is also updating dependencies on setup.py, and since other people are working on the packaging it will be cleaner to merge this in isolation.