### PR TITLE
Increase timeout for filelistings slightly to 2 seconds (Fixes #858)

### DIFF
--- a/mu/modes/base.py
+++ b/mu/modes/base.py
@@ -656,7 +656,7 @@ class FileManager(QObject):
         """
         # Create a new serial connection.
         try:
-            self.serial = Serial(self.port, 115200, timeout=3, parity="N")
+            self.serial = Serial(self.port, 115200, timeout=2, parity="N")
             self.ls()
         except Exception as ex:
             logger.exception(ex)

--- a/mu/modes/base.py
+++ b/mu/modes/base.py
@@ -656,7 +656,7 @@ class FileManager(QObject):
         """
         # Create a new serial connection.
         try:
-            self.serial = Serial(self.port, 115200, timeout=1, parity="N")
+            self.serial = Serial(self.port, 115200, timeout=3, parity="N")
             self.ls()
         except Exception as ex:
             logger.exception(ex)

--- a/tests/modes/test_base.py
+++ b/tests/modes/test_base.py
@@ -758,7 +758,7 @@ def test_FileManager_on_start():
     with mock.patch("mu.modes.base.Serial") as mock_serial:
         fm.on_start()
         mock_serial.assert_called_once_with(
-            "/dev/ttyUSB0", 115200, timeout=1, parity="N"
+            "/dev/ttyUSB0", 115200, timeout=2, parity="N"
         )
     fm.ls.assert_called_once_with()
 
@@ -776,7 +776,7 @@ def test_FileManager_on_start_fails():
     with mock.patch("mu.modes.base.Serial", mock_serial):
         fm.on_start()
         mock_serial.assert_called_once_with(
-            "/dev/ttyUSB0", 115200, timeout=1, parity="N"
+            "/dev/ttyUSB0", 115200, timeout=2, parity="N"
         )
     fm.on_list_fail.emit.assert_called_once_with()
 


### PR DESCRIPTION
Increasing the timeout for file listing to 2 seconds fixes issue #858, this does not address #985, which requires us to introduce a very long delay of around 15 seconds. A future option might be to make it possible to change this timeout from configuration files, but at least this fixes it for certain devices.