### PR TITLE
Add support for Arduino Nano 33 IoT board (fixes #1019)

### DIFF
--- a/mu/modes/circuitpython.py
+++ b/mu/modes/circuitpython.py
@@ -59,6 +59,7 @@ class CircuitPythonMode(MicroPythonMode):
         (0x1D50, 0x60E8, None, "PewPew Game Console"),
         (0x2886, 0x802D, None, "Seeed Wio Terminal"),
         (0x1B4F, 0x0016, None, "Sparkfun Thing Plus - SAMD51"),
+        (0x2341, 0x8057, None, "Arduino Nano 33 IoT board"),
     ]
     # Modules built into CircuitPython which mustn't be used as file names
     # for source code.


### PR DESCRIPTION
Add a board to CircuitPython mode, and as mentioned in #1019 it can be verified over here:
https://github.com/arduino/ArduinoCore-samd/blob/master/boards.txt

Perhaps we should reach out to Arduino and other "big" vendors before a 1.1 release, to make sure we have all their devices, instead of adding them one by one when users have problems.