### PR TITLE
Show splash screen before mode selector, and fix theming on first run (fixes #429)

### DIFF
--- a/mu/app.py
+++ b/mu/app.py
@@ -136,26 +136,6 @@ def run():
     # unless this flag is set
     app.setAttribute(Qt.AA_UseHighDpiPixmaps)
 
-    # Display a friendly "splash" icon.
-    splash = QSplashScreen(load_pixmap("splash-screen"))
-    # splash.setWindowFlags(Qt.WindowStaysOnTopHint)
-    splash.show()
-
-    # Make sure the splash screen stays on top while
-    # the mode selection dialog might open
-    raise_splash = QTimer()
-    raise_splash.timeout.connect(lambda: splash.raise_())
-    raise_splash.start(10)
-
-    # Hide the splash icon.
-    splash_be_gone = QTimer()
-    def remove_splash():
-        splash.finish(editor_window)
-        raise_splash.stop()
-    splash_be_gone.timeout.connect(remove_splash)
-    splash_be_gone.setSingleShot(True)
-    splash_be_gone.start(2000)
-
     # Create the "window" we'll be looking at.
     editor_window = Window()
 
@@ -167,6 +147,26 @@ def run():
             app.setStyleSheet(NIGHT_STYLE)
         else:
             app.setStyleSheet(DAY_STYLE)
+
+    # Display a friendly "splash" icon.
+    splash = QSplashScreen(load_pixmap("splash-screen"))
+    splash.show()
+
+    # Make sure the splash screen stays on top while
+    # the mode selection dialog might open
+    raise_splash = QTimer()
+    raise_splash.timeout.connect(lambda: splash.raise_())
+    raise_splash.start(10)
+
+    # Hide the splash icon.
+    def remove_splash():
+        splash.finish(editor_window)
+        raise_splash.stop()
+
+    splash_be_gone = QTimer()
+    splash_be_gone.timeout.connect(remove_splash)
+    splash_be_gone.setSingleShot(True)
+    splash_be_gone.start(2000)
 
     # Make sure all windows have the Mu icon as a fallback
     app.setWindowIcon(load_icon(editor_window.icon))

--- a/mu/app.py
+++ b/mu/app.py
@@ -136,6 +136,25 @@ def run():
     # unless this flag is set
     app.setAttribute(Qt.AA_UseHighDpiPixmaps)
 
+    # Display a friendly "splash" icon.
+    splash = QSplashScreen(load_pixmap("splash-screen"))
+    # splash.setWindowFlags(Qt.WindowStaysOnTopHint)
+    splash.show()
+
+    # Hide the splash icon.
+    raise_splash = QTimer()
+    raise_splash.timeout.connect(lambda: splash.raise_())
+    raise_splash.start(10)
+
+    # Hide the splash icon.
+    splash_be_gone = QTimer()
+    def remove_splash():
+        splash.finish(editor_window)
+        raise_splash.stop()
+    splash_be_gone.timeout.connect(remove_splash)
+    splash_be_gone.setSingleShot(True)
+    splash_be_gone.start(2000)
+
     # Create the "window" we'll be looking at.
     editor_window = Window()
 
@@ -163,16 +182,6 @@ def run():
     editor_window.connect_find_replace(editor.find_replace, "Ctrl+F")
     editor_window.connect_toggle_comments(editor.toggle_comments, "Ctrl+K")
     editor.connect_to_status_bar(editor_window.status_bar)
-
-    # Display a friendly "splash" icon.
-    splash = QSplashScreen(load_pixmap("splash-screen"))
-    splash.show()
-
-    # Hide the splash icon.
-    splash_be_gone = QTimer()
-    splash_be_gone.timeout.connect(lambda: splash.finish(editor_window))
-    splash_be_gone.setSingleShot(True)
-    splash_be_gone.start(2000)
 
     # Stop the program after the application finishes executing.
     sys.exit(app.exec_())

--- a/mu/app.py
+++ b/mu/app.py
@@ -141,7 +141,8 @@ def run():
     # splash.setWindowFlags(Qt.WindowStaysOnTopHint)
     splash.show()
 
-    # Hide the splash icon.
+    # Make sure the splash screen stays on top while
+    # the mode selection dialog might open
     raise_splash = QTimer()
     raise_splash.timeout.connect(lambda: splash.raise_())
     raise_splash.start(10)

--- a/mu/logic.py
+++ b/mu/logic.py
@@ -970,7 +970,7 @@ class Editor(QObject):
                 logger.debug(old_session)
                 if "theme" in old_session:
                     self.theme = old_session["theme"]
-                    self._view.set_theme(self.theme)
+                self._view.set_theme(self.theme)
                 if "mode" in old_session:
                     old_mode = old_session["mode"]
                     if old_mode in self.modes:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -144,6 +144,53 @@ def test_run():
         qa.assert_has_calls([mock.call().setStyleSheet(CONTRAST_STYLE)])
 
 
+def test_close_splash_screen():
+    """
+    Test that the splash screen is closed.
+    """
+
+    # Create a dummy window
+    class Win(mock.MagicMock):
+        load_theme = DumSig()
+        icon = "icon"
+
+    window = Win()
+
+    # Create a dummy timer class
+    class DummyTimer:
+        def __init__(self):
+            self.callback = lambda x: None
+            self.stop = lambda: None
+            self.setSingleShot = lambda x: None
+
+            def set_callback(fun):
+                self.callback = fun
+
+            class Object(object):
+                pass
+
+            self.timeout = Object()
+            self.timeout.connect = set_callback
+
+        def start(self, t):
+            # Just call the callback immediately
+            self.callback()
+
+    # Mock Splash screen
+    splash = mock.MagicMock()
+
+    # Mock QTimer, QApplication, Window, Editor, sys.exit
+    with mock.patch("mu.app.QTimer", new=DummyTimer), mock.patch(
+        "mu.app.Window", window
+    ), mock.patch("mu.app.QApplication"), mock.patch("sys.exit"), mock.patch(
+        "mu.app.Editor"
+    ), mock.patch(
+        "mu.app.QSplashScreen", return_value=splash
+    ):
+        run()
+        assert splash.finish.call_count == 1
+
+
 def test_excepthook():
     """
     Test that custom excepthook logs error and calls sys.exit.

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -129,8 +129,8 @@ def test_run():
         assert len(qa.mock_calls) == 8
         assert qsp.call_count == 1
         assert len(qsp.mock_calls) == 2
-        assert timer.call_count == 1
-        assert len(timer.mock_calls) == 4
+        assert timer.call_count == 2
+        assert len(timer.mock_calls) == 7
         assert ed.call_count == 1
         assert len(ed.mock_calls) == 4
         assert win.call_count == 1


### PR DESCRIPTION
An attempt at fixing issue #429. However, I'm not certain how to add tests for the 3 lines which are currently not tested. Any suggestions for how to test that and get coverage back to 100% would be helpful.

The problem is that we need to keep calling `raise_()` on the splash screen, if we open them in the opposite order, otherwise the mode selection will still open on top of it.

The relevant lines from `app.run` is here, where my question is how to test `remove_splash`. I will try to look at it myself some other time.

```python
    # Display a friendly "splash" icon.
    splash = QSplashScreen(load_pixmap("splash-screen"))
    # splash.setWindowFlags(Qt.WindowStaysOnTopHint)
    splash.show()

    # Make sure the splash screen stays on top while
    # the mode selection dialog might open
    raise_splash = QTimer()
    raise_splash.timeout.connect(lambda: splash.raise_())
    raise_splash.start(10)

    # Hide the splash icon.
    splash_be_gone = QTimer()
    def remove_splash():
        splash.finish(editor_window)
        raise_splash.stop()
    splash_be_gone.timeout.connect(remove_splash)
    splash_be_gone.setSingleShot(True)
    splash_be_gone.start(2000)
```