### PR TITLE
Add check for PYBFLASH.

### DIFF
--- a/mu/modes/circuitpython.py
+++ b/mu/modes/circuitpython.py
@@ -125,8 +125,11 @@ class CircuitPythonMode(MicroPythonMode):
                     mount_output = check_output(mount_command).splitlines()
                     mounted_volumes = [x.split()[2] for x in mount_output]
                     for volume in mounted_volumes:
-                        if volume.endswith(b"CIRCUITPY"):
+                        tail =  os.path.split(volume)[-1]
+                        if tail.startswith(b"CIRCUITPY") or \
+                                tail.startswith(b"PYBFLASH"):
                             device_dir = volume.decode("utf-8")
+                            break
                 except FileNotFoundError:
                     next
         elif os.name == "nt":


### PR DESCRIPTION
the MP device I have has a volume label of PYBFLASH, and a 2nd CP device will show up as CIRCUITPY1.

this PR helps with these cases. 

carl@twist:~/src/mu/carlfk/mu$ mount |grep media 
/dev/sdc1 on /media/carl/PYBFLASH type vfat (rw,nosuid,nodev,relatime,uid=1000,gid=1000,fmask=0022,dmask=0022,codepage=437,iocharset=iso8859-1,shortname=mixed,showexec,utf8,flush,errors=remount-ro,uhelper=udisks2)
/dev/sdd1 on /media/carl/CIRCUITPY type vfat (rw,nosuid,nodev,relatime,uid=1000,gid=1000,fmask=0022,dmask=0022,codepage=437,iocharset=iso8859-1,shortname=mixed,showexec,utf8,flush,errors=remount-ro,uhelper=udisks2)
/dev/sde1 on /media/carl/CIRCUITPY1 type vfat (rw,nosuid,nodev,relatime,uid=1000,gid=1000,fmask=0022,dmask=0022,codepage=437,iocharset=iso8859-1,shortname=mixed,showexec,utf8,flush,errors=remount-ro,uhelper=udisks2)

however, vaguely related to #1117 it does not properly support multiple devices.

The "break" changes it from defaulting to the last device found in all cases (not great) to defaulting to the first device found (also not great.)  The break is there just to have a place in the code to look at to help see why in all cases it returns the same mount point.   I'm not sure how to do this right, but this PR is at least better.










