### PR TITLE
Serial timeout config, for code review.

### DIFF
--- a/mu/modes/base.py
+++ b/mu/modes/base.py
@@ -668,7 +668,7 @@ class FileManager(QObject):
         """
         # Create a new serial connection.
         try:
-            self.serial = Serial(self.port, 115200, timeout=self.settings.get("serial_timeout", 1), parity="N")
+            self.serial = Serial(self.port, 115200, timeout=self.settings.get("serial_timeout", 2), parity="N")
             self.ls()
         except Exception as ex:
             logger.exception(ex)

--- a/mu/modes/base.py
+++ b/mu/modes/base.py
@@ -668,7 +668,12 @@ class FileManager(QObject):
         """
         # Create a new serial connection.
         try:
-            self.serial = Serial(self.port, 115200, timeout=self.settings.get("serial_timeout", 2), parity="N")
+            self.serial = Serial(
+                self.port,
+                115200,
+                timeout=self.settings.get("serial_timeout", 2),
+                parity="N",
+            )
             self.ls()
         except Exception as ex:
             logger.exception(ex)

--- a/tests/modes/test_base.py
+++ b/tests/modes/test_base.py
@@ -758,7 +758,7 @@ def test_FileManager_on_start():
     with mock.patch("mu.modes.base.Serial") as mock_serial:
         fm.on_start()
         mock_serial.assert_called_once_with(
-            "/dev/ttyUSB0", 115200, timeout=1, parity="N"
+            "/dev/ttyUSB0", 115200, timeout=2, parity="N"
         )
     fm.ls.assert_called_once_with()
 
@@ -776,7 +776,7 @@ def test_FileManager_on_start_fails():
     with mock.patch("mu.modes.base.Serial", mock_serial):
         fm.on_start()
         mock_serial.assert_called_once_with(
-            "/dev/ttyUSB0", 115200, timeout=1, parity="N"
+            "/dev/ttyUSB0", 115200, timeout=2, parity="N"
         )
     fm.on_list_fail.emit.assert_called_once_with()
 


### PR DESCRIPTION
Allow the serial timeout to be overridden in `settings.json`, related to #858 and #985, then subsequently #1114 

Includes a tiny refactor related to obtaining the contents of `settings.json`.

Passes the self tests but I do not have any hardware to actually test against with me right now.


