### PR TITLE
Handle malformed unicode using "replace" error-handling strategy (fixes #1124)

### DIFF
--- a/mu/interface/panes.py
+++ b/mu/interface/panes.py
@@ -176,7 +176,7 @@ class MicroPythonREPLPane(QTextEdit):
         self.setObjectName("replpane")
         self.set_theme(theme)
         self.unprocessed_input = b""  # used by process_bytes
-        self.decoder = codecs.getincrementaldecoder("utf8")()
+        self.decoder = codecs.getincrementaldecoder("utf8")("replace")
         self.vt100_regex = re.compile(
             r"\x1B\[(?P<count>[\d]*)(;?[\d]*)*(?P<action>[A-Za-z])"
         )

--- a/tests/interface/test_panes.py
+++ b/tests/interface/test_panes.py
@@ -611,6 +611,34 @@ def test_MicroPythonREPLPane_process_tty_data():
     rp.ensureCursorVisible.assert_called_once_with()
 
 
+def test_MicroPythonREPLPane_process_tty_data_multibyte_sequence():
+    """
+    Ensure multibyte unicode characters are correctly parsed, even
+    over multiple invocations of process_tty_data
+    """
+    mock_repl_connection = mock.MagicMock()
+    rp = mu.interface.panes.MicroPythonREPLPane(mock_repl_connection)
+    rp.insertPlainText = mock.MagicMock(return_value=None)
+
+    # Copyright symbol: ©
+    rp.process_tty_data(b"\xc2")
+    rp.process_tty_data(b"\xa9")
+
+    assert rp.insertPlainText.call_args_list[0][0][0] == "©"
+
+
+def test_MicroPythonREPLPane_process_tty_data_handle_malformed_unicode():
+    """
+    Ensure no exception is raised due to malformed unicode sequences
+    from the device
+    """
+    mock_repl_connection = mock.MagicMock()
+    rp = mu.interface.panes.MicroPythonREPLPane(mock_repl_connection)
+    rp.process_tty_data(b"foo \xd8 bar")
+
+    # test passes if no exception is raised
+
+
 def test_MicroPythonREPLPane_process_tty_data_VT100():
     """
     Ensure bytes coming from the device to the application are processed as

--- a/tests/interface/test_panes.py
+++ b/tests/interface/test_panes.py
@@ -620,7 +620,7 @@ def test_MicroPythonREPLPane_process_tty_data_multibyte_sequence():
     rp = mu.interface.panes.MicroPythonREPLPane(mock_repl_connection)
     rp.insertPlainText = mock.MagicMock(return_value=None)
 
-    # Copyright symbol: ©
+    # Copyright symbol: © (0xC2A9)
     rp.process_tty_data(b"\xc2")
     rp.process_tty_data(b"\xa9")
 
@@ -634,9 +634,13 @@ def test_MicroPythonREPLPane_process_tty_data_handle_malformed_unicode():
     """
     mock_repl_connection = mock.MagicMock()
     rp = mu.interface.panes.MicroPythonREPLPane(mock_repl_connection)
+    rp.insertPlainText = mock.MagicMock(return_value=None)
+
     rp.process_tty_data(b"foo \xd8 bar")
 
-    # test passes if no exception is raised
+    # Test that malformed input are correctly replaced with the standard
+    # unicode replacement character (�, U+FFFD)
+    assert rp.insertPlainText.call_args_list[4][0][0] == u"\uFFFD"
 
 
 def test_MicroPythonREPLPane_process_tty_data_VT100():


### PR DESCRIPTION
This fixes a problem where a `UnicodeDecodeError` was raised. This occurred when a serial device was sending malformed UTF-8 sequences, which the IncrementalDecoder was not able to parse (see #1124)

My suggestion included in this PR is to use the built-in "replace" error handler, as described here: 
https://docs.python.org/3/library/codecs.html#error-handlers

> Python will use the official U+FFFD REPLACEMENT CHARACTER for the built-in codecs on decoding

Alternatively, the "backslashreplace" error handler might also be relevant to consider:
> Replace with backslashed escape sequences