### PR TITLE
Make splash screen close on mouse clicks

### DIFF
--- a/mu/app.py
+++ b/mu/app.py
@@ -26,7 +26,7 @@ import platform
 import pkgutil
 import sys
 
-from PyQt5.QtCore import QTimer, Qt
+from PyQt5.QtCore import QTimer, Qt, QCoreApplication
 from PyQt5.QtWidgets import QApplication, QSplashScreen
 
 from mu import __version__, language_code
@@ -152,10 +152,17 @@ def run():
     splash = QSplashScreen(load_pixmap("splash-screen"))
     splash.show()
 
-    # Make sure the splash screen stays on top while
-    # the mode selection dialog might open
+    def raise_and_process_events():
+        # Make sure the splash screen stays on top while
+        # the mode selection dialog might open
+        splash.raise_()
+
+        # Make sure splash screen reacts to mouse clicks, even when
+        # the event loop is not yet started
+        QCoreApplication.processEvents()
+
     raise_splash = QTimer()
-    raise_splash.timeout.connect(lambda: splash.raise_())
+    raise_splash.timeout.connect(raise_and_process_events)
     raise_splash.start(10)
 
     # Hide the splash icon.

--- a/mu/logic.py
+++ b/mu/logic.py
@@ -1662,7 +1662,6 @@ class Editor(QObject):
             change_confirmation = self._view.show_confirmation(
                 heading, msg_body, icon="Question"
             )
-            print(change_confirmation)
             if change_confirmation == QMessageBox.Ok:
                 self.change_mode(new_mode)
 


### PR DESCRIPTION
The splash screen didn't close when clicked, as the event loop was not running at that point in time. This change makes it react by continuously call the method `QCoreApplication.processEvent()` as described in the docs:

> Since the splash screen is typically displayed before the event loop has started running, it is necessary to periodically call QCoreApplication::processEvents() to receive the mouse clicks.

https://doc.qt.io/qt-5/qsplashscreen.html

(also removes a left over print-statement, which I discovered in logic.py, probably from someones debug-session)

Relates to comments on issue #498