### PR TITLE
Add support for DynOSSAT-EDU boards

### DIFF
--- a/mu/modes/circuitpython.py
+++ b/mu/modes/circuitpython.py
@@ -60,6 +60,8 @@ class CircuitPythonMode(MicroPythonMode):
         (0x2886, 0x802D, None, "Seeed Wio Terminal"),
         (0x1B4F, 0x0016, None, "Sparkfun Thing Plus - SAMD51"),
         (0x2341, 0x8057, None, "Arduino Nano 33 IoT board"),
+        (0x04D8, 0xEAD1, None, "DynOSSAT-EDU-EPS"),
+        (0x04D8, 0xEAD2, None, "DynOSSAT-EDU-OBC"),
     ]
     # Modules built into CircuitPython which mustn't be used as file names
     # for source code.


### PR DESCRIPTION
Hi,

We're adding support for our project DynOSSAT-EDU, an open source nanosatellite (PocketQube, 5x5cm) educational kit.

We just got the VID&PID from Microchip and will be uploading the board definitions to the CircuitPython repo next week, in addition to releasing the source code. Because of that we would love that Mu would be compatible with the boards ASAP :)

Best regards,

Enrique