### PR TITLE
Temporarily pin boto3 to v1.15.18 to fix urllib3 version conflicts

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,10 @@ extras_require = {
         # Windows native packaging (see win_installer.py).
         'requests==2.23.0;platform_system == "Windows"',
         'yarg==0.1.9;platform_system == "Windows"',
+        # Temporarily pin boto3 (briefcase dependency) to fix urllib3  version
+        # conflicts, it can be removed after the dependencies have been updated
+        # https://github.com/mu-editor/mu/issues/1155
+        "boto3==1.15.18",
         # macOS native packaging (see Makefile)
         'briefcase==0.2.9;platform_system == "Darwin"',
     ],


### PR DESCRIPTION
Fixes https://github.com/mu-editor/mu/issues/1155, as there is conflicts with required urllib3 versions by different dependencies.

This will likely not be needed once we update all the dependencies (specially if we use pup instead of briefcase), but in the meantime we'll need this fix (or other way to fix the issue) for the CI to pass.
