### PR TITLE
Implement Find Again (F3), fixes #995

### DIFF
--- a/mu/app.py
+++ b/mu/app.py
@@ -205,6 +205,7 @@ def run():
     # Connect the various UI elements in the window to the editor.
     editor_window.connect_tab_rename(editor.rename_tab, "Ctrl+Shift+S")
     editor_window.connect_find_replace(editor.find_replace, "Ctrl+F")
+    editor_window.connect_find_again(editor.find_again, "F3")
     editor_window.connect_toggle_comments(editor.toggle_comments, "Ctrl+K")
     editor.connect_to_status_bar(editor_window.status_bar)
 

--- a/mu/app.py
+++ b/mu/app.py
@@ -205,7 +205,9 @@ def run():
     # Connect the various UI elements in the window to the editor.
     editor_window.connect_tab_rename(editor.rename_tab, "Ctrl+Shift+S")
     editor_window.connect_find_replace(editor.find_replace, "Ctrl+F")
-    editor_window.connect_find_again(editor.find_again, "F3")
+    # Connect find again both forward and backward ('Shift+F3')
+    find_again_handlers = (editor.find_again, editor.find_again_backward)
+    editor_window.connect_find_again(find_again_handlers, "F3")
     editor_window.connect_toggle_comments(editor.toggle_comments, "Ctrl+K")
     editor.connect_to_status_bar(editor_window.status_bar)
 

--- a/mu/interface/main.py
+++ b/mu/interface/main.py
@@ -1095,6 +1095,14 @@ class Window(QMainWindow):
         self.find_replace_shortcut = QShortcut(QKeySequence(shortcut), self)
         self.find_replace_shortcut.activated.connect(handler)
 
+    def connect_find_again(self, handler, shortcut):
+        """
+        Create a keyboard shortcut and associate it with a handler for doing
+        a find again.
+        """
+        self.find_again_shortcut = QShortcut(QKeySequence(shortcut), self)
+        self.find_again_shortcut.activated.connect(handler)
+
     def show_find_replace(self, find, replace, global_replace):
         """
         Display the find/replace dialog. If the dialog's OK button was clicked

--- a/mu/interface/main.py
+++ b/mu/interface/main.py
@@ -1098,7 +1098,9 @@ class Window(QMainWindow):
     def connect_find_again(self, handlers, shortcut):
         """
         Create keyboard shortcuts and associate them with handlers for doing
-        a find again in forward or backward direction.
+        a find again in forward or backward direction. Any given shortcut
+        will be used for forward find again, while Shift+shortcut will find
+        again backwards.
         """
         forward, backward = handlers
         self.find_again_shortcut = QShortcut(QKeySequence(shortcut), self)
@@ -1154,10 +1156,12 @@ class Window(QMainWindow):
         the current tab for the target_text. Returns True if there's a match.
         """
         if self.current_tab:
-            # Workaround for `findFirst(forward=False)` not advancing
-            # backwards: pass explicit line and index values.
-            start_line, start_index, _el, _ei = self.current_tab.getSelection()
-            index = -1 if forward else start_index
+            line = -1
+            index = -1
+            if not forward:
+                # Workaround for `findFirst(forward=False)` not advancing
+                # backwards: pass explicit line and index values.
+                line, index, _el, _ei = self.current_tab.getSelection()
             return self.current_tab.findFirst(
                 target_text,  # Text to find,
                 True,  # Treat as regular expression
@@ -1165,7 +1169,7 @@ class Window(QMainWindow):
                 False,  # Whole word matches only
                 True,  # Wrap search
                 forward=forward,  # Forward search
-                line=start_line,  # -1 starts at current position
+                line=line,  # -1 starts at current position
                 index=index,  # -1 starts at current position
             )
         else:

--- a/mu/logic.py
+++ b/mu/logic.py
@@ -1714,7 +1714,7 @@ class Editor(QObject):
 
     def find_again(self, forward=True):
         """
-        Handle find again (F3) functionality.
+        Handle find again (F3 and Shift+F3) functionality.
         """
         if self.find:
             matched = self._view.highlight_text(self.find, forward)
@@ -1732,6 +1732,9 @@ class Editor(QObject):
             self._view.show_message(message, information)
 
     def find_again_backward(self, forward=False):
+        """
+        Handle find again backward (Shift+F3) functionality.
+        """
         self.find_again(forward=False)
 
     def toggle_comments(self):

--- a/mu/logic.py
+++ b/mu/logic.py
@@ -1712,12 +1712,12 @@ class Editor(QObject):
                 )
                 self._view.show_message(message, information)
 
-    def find_again(self):
+    def find_again(self, forward=True):
         """
         Handle find again (F3) functionality.
         """
         if self.find:
-            matched = self._view.highlight_text(self.find)
+            matched = self._view.highlight_text(self.find, forward)
             if matched:
                 msg = _('Highlighting matches for "{}".')
             else:
@@ -1730,6 +1730,9 @@ class Editor(QObject):
                 "in the find box."
             )
             self._view.show_message(message, information)
+
+    def find_again_backward(self, forward=False):
+        self.find_again(forward=False)
 
     def toggle_comments(self):
         """

--- a/mu/logic.py
+++ b/mu/logic.py
@@ -1712,6 +1712,25 @@ class Editor(QObject):
                 )
                 self._view.show_message(message, information)
 
+    def find_again(self):
+        """
+        Handle find again (F3) functionality.
+        """
+        if self.find:
+            matched = self._view.highlight_text(self.find)
+            if matched:
+                msg = _('Highlighting matches for "{}".')
+            else:
+                msg = _('Could not find "{}".')
+            self.show_status_message(msg.format(self.find))
+        else:
+            message = _("You must provide something to find.")
+            information = _(
+                "Please try again, this time with something "
+                "in the find box."
+            )
+            self._view.show_message(message, information)
+
     def toggle_comments(self):
         """
         Ensure all highlighted lines are toggled between comments/uncommented.

--- a/tests/interface/test_main.py
+++ b/tests/interface/test_main.py
@@ -1805,7 +1805,24 @@ def test_Window_highlight_text():
     mock_tab.getSelection.return_value = 0, 0, 0, 0
     assert w.highlight_text("foo")
     mock_tab.findFirst.assert_called_once_with(
-        "foo", True, True, False, True, forward=True, index=-1, line=0
+        "foo", True, True, False, True, forward=True, index=-1, line=-1
+    )
+
+
+def test_Window_highlight_text_backward():
+    """
+    Given target_text, highlights the first instance via Scintilla's findFirst
+    method.
+    """
+    w = mu.interface.main.Window()
+    mock_tab = mock.MagicMock()
+    mock_tab.findFirst.return_value = True
+    w.tabs = mock.MagicMock()
+    w.tabs.currentWidget.return_value = mock_tab
+    mock_tab.getSelection.return_value = 0, 0, 0, 0
+    assert w.highlight_text("foo", forward=False)
+    mock_tab.findFirst.assert_called_once_with(
+        "foo", True, True, False, True, forward=False, index=0, line=0
     )
 
 

--- a/tests/interface/test_main.py
+++ b/tests/interface/test_main.py
@@ -1686,6 +1686,26 @@ def test_Window_connect_find_replace():
     shortcut.activated.connect.assert_called_once_with(mock_handler)
 
 
+def test_Window_connect_find_again():
+    """
+    Ensure a shortcut is created with the expected shortcut and handler
+    function.
+    """
+    window = mu.interface.main.Window()
+    mock_handler = mock.MagicMock()
+    mock_shortcut = mock.MagicMock()
+    mock_sequence = mock.MagicMock()
+    with mock.patch("mu.interface.main.QShortcut", mock_shortcut), mock.patch(
+        "mu.interface.main.QKeySequence", mock_sequence
+    ):
+        window.connect_find_again(mock_handler, "F3")
+    mock_sequence.assert_called_once_with("F3")
+    ks = mock_sequence("F3")
+    mock_shortcut.assert_called_once_with(ks, window)
+    shortcut = mock_shortcut(ks, window)
+    shortcut.activated.connect.assert_called_once_with(mock_handler)
+
+
 def test_Window_show_find_replace():
     """
     The find/replace dialog is setup with the right arguments and, if

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -119,7 +119,7 @@ def test_run():
         assert ed.call_count == 1
         assert len(ed.mock_calls) == 4
         assert win.call_count == 1
-        assert len(win.mock_calls) == 5
+        assert len(win.mock_calls) == 6
         assert ex.call_count == 1
         window.load_theme.emit("day")
         qa.assert_has_calls([mock.call().setStyleSheet(DAY_STYLE)])

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -3137,6 +3137,21 @@ def test_find_replace_no_find():
     mock_view.show_message.assert_called_once_with(msg, info)
 
 
+def test_find_again_no_find():
+    """
+    If the user fails to supply something to find again, display a modal
+    warning message to explain the problem.
+    """
+    mock_view = mock.MagicMock()
+    ed = mu.logic.Editor(mock_view)
+    ed.find = False
+    ed.show_message = mock.MagicMock()
+    ed.find_again()
+    msg = "You must provide something to find."
+    info = "Please try again, this time with something in the find box."
+    mock_view.show_message.assert_called_once_with(msg, info)
+
+
 def test_find_replace_find_matched():
     """
     If the user just supplies a find target and it is matched in the code then
@@ -3157,6 +3172,26 @@ def test_find_replace_find_matched():
     )
 
 
+def test_find_again_find_matched():
+    """
+    If the user just supplies a find target to find again and it is matched in the
+    code then the expected status message should be shown.
+    """
+    mock_view = mock.MagicMock()
+    mock_view.highlight_text.return_value = True
+    ed = mu.logic.Editor(mock_view)
+    ed.show_status_message = mock.MagicMock()
+    ed.find = "foo"
+    ed.find_again()
+    mock_view.highlight_text.assert_called_once_with("foo")
+    assert ed.find == "foo"
+    assert ed.replace == ""
+    assert ed.global_replace is False
+    ed.show_status_message.assert_called_once_with(
+        'Highlighting matches for "foo".'
+    )
+
+
 def test_find_replace_find_unmatched():
     """
     If the user just supplies a find target and it is UN-matched in the code
@@ -3168,6 +3203,20 @@ def test_find_replace_find_unmatched():
     ed = mu.logic.Editor(mock_view)
     ed.show_status_message = mock.MagicMock()
     ed.find_replace()
+    ed.show_status_message.assert_called_once_with('Could not find "foo".')
+
+
+def test_find_again_find_unmatched():
+    """
+    If the user just supplies a find target to find_again and it is UN-matched
+    in the code then the expected status message should be shown.
+    """
+    mock_view = mock.MagicMock()
+    mock_view.highlight_text.return_value = False
+    ed = mu.logic.Editor(mock_view)
+    ed.find = 'foo'
+    ed.show_status_message = mock.MagicMock()
+    ed.find_again()
     ed.show_status_message.assert_called_once_with('Could not find "foo".')
 
 

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -3139,8 +3139,8 @@ def test_find_replace_no_find():
 
 def test_find_again_no_find():
     """
-    If the user fails to supply something to find again, display a modal
-    warning message to explain the problem.
+    If the user fails to supply something to find again (forward or backward),
+    display a modal warning message to explain the problem.
     """
     mock_view = mock.MagicMock()
     ed = mu.logic.Editor(mock_view)
@@ -3176,8 +3176,9 @@ def test_find_replace_find_matched():
 
 def test_find_again_find_matched():
     """
-    If the user just supplies a find target to find again and it is matched in
-    the code then the expected status message should be shown.
+    If the user supplies a find target to find again (forward or backward) and
+    it is matched in the code then the expected status message should be
+    shown.
     """
     mock_view = mock.MagicMock()
     mock_view.highlight_text.return_value = True
@@ -3192,6 +3193,8 @@ def test_find_again_find_matched():
     ed.show_status_message.assert_called_once_with(
         'Highlighting matches for "foo".'
     )
+    ed.find_again_backward()
+    assert ed.show_status_message.call_count == 2
 
 
 def test_find_replace_find_unmatched():
@@ -3210,8 +3213,9 @@ def test_find_replace_find_unmatched():
 
 def test_find_again_find_unmatched():
     """
-    If the user just supplies a find target to find_again and it is UN-matched
-    in the code then the expected status message should be shown.
+    If the user supplies a find target to find_again or find_again_backward
+    and it is UN-matched in the code then the expected status message should
+    be shown.
     """
     mock_view = mock.MagicMock()
     mock_view.highlight_text.return_value = False

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -3174,8 +3174,8 @@ def test_find_replace_find_matched():
 
 def test_find_again_find_matched():
     """
-    If the user just supplies a find target to find again and it is matched in the
-    code then the expected status message should be shown.
+    If the user just supplies a find target to find again and it is matched in
+    the code then the expected status message should be shown.
     """
     mock_view = mock.MagicMock()
     mock_view.highlight_text.return_value = True
@@ -3214,7 +3214,7 @@ def test_find_again_find_unmatched():
     mock_view = mock.MagicMock()
     mock_view.highlight_text.return_value = False
     ed = mu.logic.Editor(mock_view)
-    ed.find = 'foo'
+    ed.find = "foo"
     ed.show_status_message = mock.MagicMock()
     ed.find_again()
     ed.show_status_message.assert_called_once_with('Could not find "foo".')

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -3150,6 +3150,8 @@ def test_find_again_no_find():
     msg = "You must provide something to find."
     info = "Please try again, this time with something in the find box."
     mock_view.show_message.assert_called_once_with(msg, info)
+    ed.find_again_backward(forward=False)
+    assert mock_view.show_message.call_count == 2
 
 
 def test_find_replace_find_matched():
@@ -3183,7 +3185,7 @@ def test_find_again_find_matched():
     ed.show_status_message = mock.MagicMock()
     ed.find = "foo"
     ed.find_again()
-    mock_view.highlight_text.assert_called_once_with("foo")
+    mock_view.highlight_text.assert_called_once_with("foo", True)
     assert ed.find == "foo"
     assert ed.replace == ""
     assert ed.global_replace is False
@@ -3218,6 +3220,9 @@ def test_find_again_find_unmatched():
     ed.show_status_message = mock.MagicMock()
     ed.find_again()
     ed.show_status_message.assert_called_once_with('Could not find "foo".')
+    ed.find_again_backward()
+    ed.show_status_message.assert_called_with('Could not find "foo".')
+    assert ed.show_status_message.call_count == 2
 
 
 def test_find_replace_replace_no_match():


### PR DESCRIPTION
Basic implementation for the Find Again feature suggested in #995: an `Editor.find_again() `  method that uses the  'find' parts of `find_replace()`. Testing is a copy-and-adapt deal right now. 

Refactoring the duplicated code into two helper methods (one for empty find string, one for present string) could make it more elegant. But that gets in the way if we want Find Again behavior to diverge from Find and Replace.

Currently, an empty find string will display a modal like for find and replace. We could mention `Ctrl+F` to provide a string (since the user didn't press that shortcut ). Or we could have F3 never pop up a modal, just a status bar message.

Open to and welcoming any suggestions, criticisms, alternative designs and requests.