### PR TITLE
Remove temporary font workaround for #552

### DIFF
--- a/mu/interface/themes.py
+++ b/mu/interface/themes.py
@@ -22,9 +22,6 @@ from PyQt5.QtGui import QColor, QFontDatabase
 from mu.resources import load_stylesheet, load_font_data
 
 
-logger = logging.getLogger(__name__)
-
-
 # The default font size.
 DEFAULT_FONT_SIZE = 14
 # All editor windows use the same font

--- a/mu/interface/themes.py
+++ b/mu/interface/themes.py
@@ -17,7 +17,6 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 import logging
-import platform
 
 from PyQt5.QtGui import QColor, QFontDatabase
 from mu.resources import load_stylesheet, load_font_data
@@ -26,31 +25,10 @@ from mu.resources import load_stylesheet, load_font_data
 logger = logging.getLogger(__name__)
 
 
-def should_patch_osx_mojave_font():
-    """
-    OSX mojave and qt5/qtscintilla has a bug where non-system installed fonts
-    are always rendered as black, regardless of the theme color.
-
-    This is inconvenient for light themes, but makes dark themes unusable.
-
-    Using a system-installed font doesn't exhibit this behaviour, so
-    update FONT_NAME to use the default terminal font in OSX on mojave.
-
-    This patch should be removed once the underlying issue has been resolved
-
-    github issue #552
-    """
-    return platform.platform().startswith("Darwin-18.")
-
-
 # The default font size.
 DEFAULT_FONT_SIZE = 14
 # All editor windows use the same font
-if should_patch_osx_mojave_font():  # pragma: no cover
-    logger.warning("Overriding built-in editor font due to Issue #552")
-    FONT_NAME = "Monaco"
-else:  # pragma: no cover
-    FONT_NAME = "Source Code Pro"
+FONT_NAME = "Source Code Pro"
 
 FONT_FILENAME_PATTERN = "SourceCodePro-{variant}.otf"
 FONT_VARIANTS = ("Bold", "BoldIt", "It", "Regular", "Semibold", "SemiboldIt")

--- a/tests/interface/test_themes.py
+++ b/tests/interface/test_themes.py
@@ -7,15 +7,6 @@ import mu.interface.themes
 import mu.interface.editor
 
 
-def test_patch_osx_mojave_font_issue_552():
-    with mock.patch("platform.platform", return_value="Windows"):
-        assert not mu.interface.themes.should_patch_osx_mojave_font()
-    with mock.patch(
-        "platform.platform", return_value="Darwin-18.0.0-x86_64-i386-64bit"
-    ):
-        assert mu.interface.themes.should_patch_osx_mojave_font()
-
-
 def test_constants():
     """
     Ensure the expected constant values exist.
@@ -63,22 +54,21 @@ def test_theme_apply_to():
 
 
 def test_Font_loading():
-    with mock.patch("mu.interface.themes.FONT_NAME", "Source Code Pro"):
+    mu.interface.themes.Font._DATABASE = None
+    try:
+        with mock.patch("mu.interface.themes.QFontDatabase") as db:
+            mu.interface.themes.Font().load()
+            mu.interface.themes.Font(bold=True).load()
+            mu.interface.themes.Font(italic=True).load()
+            mu.interface.themes.Font(bold=True, italic=True).load()
+    finally:
         mu.interface.themes.Font._DATABASE = None
-        try:
-            with mock.patch("mu.interface.themes.QFontDatabase") as db:
-                mu.interface.themes.Font().load()
-                mu.interface.themes.Font(bold=True).load()
-                mu.interface.themes.Font(italic=True).load()
-                mu.interface.themes.Font(bold=True, italic=True).load()
-        finally:
-            mu.interface.themes.Font._DATABASE = None
-        db.assert_called_once_with()
-        db().font.assert_has_calls(
-            [
-                mock.call("Source Code Pro", "Regular", 14),
-                mock.call("Source Code Pro", "Semibold", 14),
-                mock.call("Source Code Pro", "Italic", 14),
-                mock.call("Source Code Pro", "Semibold Italic", 14),
-            ]
-        )
+    db.assert_called_once_with()
+    db().font.assert_has_calls(
+        [
+            mock.call("Source Code Pro", "Regular", 14),
+            mock.call("Source Code Pro", "Semibold", 14),
+            mock.call("Source Code Pro", "Italic", 14),
+            mock.call("Source Code Pro", "Semibold Italic", 14),
+        ]
+    )


### PR DESCRIPTION
The code removed here was added in PR https://github.com/mu-editor/mu/pull/567/ and it is no longer necessary, as updating the PyQt/QScintilla packages had resolved the problem a long time ago.