### PR TITLE
CI: Add initial GitHub Actions workflows.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Build Mu
 
 on:
   push:
-    branches: '*'
+    branches: 'master'
   pull_request:
     branches: '*'
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,5 +47,5 @@ jobs:
       - name: Upload Mu installer
         uses: actions/upload-artifact@v1
         with:
-          name: mu-editor-${{ runner.os }}-${{ github.sha }}.app
+          name: mu-editor-${{ runner.os }}-${{ github.sha }}
           path: dist

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,51 @@
+name: Build Mu
+
+on:
+  push:
+    branches: '*'
+  pull_request:
+    branches: '*'
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        os: [macos-10.15, windows-2016]
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
+    name: Build ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.6'
+      - name: Display Python info
+        run: |
+          python -c "import sys; print(sys.version)"
+          python -c "import platform, struct; print(platform.machine(), struct.calcsize('P') * 8)"
+          python -c "import sys; print(sys.executable)"
+          python -m pip --version
+          pip --version
+          pip config list
+          pip freeze
+      - name: Install Mu dependencies
+        run: |
+          pip install .[dev]
+          pip list
+      - name: Build Windows
+        if: runner.os == 'Windows'
+        run: |
+          python make.py win32
+          python make.py win64
+      - name: Build macOS
+        if: runner.os == 'macOS'
+        run: |
+          make macos
+          mkdir dist
+          mv macOS/mu-editor.app dist/
+      - name: Upload Mu installer
+        uses: actions/upload-artifact@v1
+        with:
+          name: mu-editor-${{ runner.os }}-${{ github.sha }}.app
+          path: dist

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,47 @@
+name: Run tests
+
+on:
+  push:
+    branches: '*'
+  pull_request:
+    branches: '*'
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        os: [ubuntu-16.04, ubuntu-latest, macos-10.15, macos-11.0, windows-2016, windows-latest]
+        python-version: ['3.6', '3.7']
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
+    name: Test Py ${{ matrix.python-version }} - ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Display Python info
+        run: |
+          python -c "import sys; print(sys.version)"
+          python -c "import platform, struct; print(platform.machine(), struct.calcsize('P') * 8)"
+          python -c "import sys; print(sys.executable)"
+          python -m pip --version
+          pip --version
+          pip config list
+          pip freeze
+      - name: Prepare Ubuntu
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libxkbcommon-x11-0 xvfb
+      - name: Install Mu dependencies
+        run: |
+          pip install .[dev]
+          pip list
+      - name: Run tests
+        if: runner.os == 'Linux'
+        run: xvfb-run make check
+      - name: Run tests
+        if: runner.os != 'Linux'
+        run: python make.py check


### PR DESCRIPTION
Fixes https://github.com/mu-editor/mu/issues/1140.

Now that there a reduced minutes in TravisCI we will likely hit the max rate fairly quickly, so I've prioritised this since it was a relatively quick win and to ensure we still have CI running all the tests.

The test workflow runs the `make check` tests in Python 3.6 and 3.7 in the oldest and newest version available of Windows, macOS and Linux.

The build workflow creates the executables for macOS and Windows and uploads them to GitHub as a workflow artifact. This one is currently using PyNsist and Briefcase, as Travis and AppVeyor are doing, but can be easily switched in the future to pup.