### PR TITLE
Support .pyw files, explore a solution for #1160

### DIFF
--- a/mu/logic.py
+++ b/mu/logic.py
@@ -1105,7 +1105,7 @@ class Editor(QObject):
                 return
         name, text, newline, file_mode = None, None, None, None
         try:
-            if path.lower().endswith(".py"):
+            if path.lower().endswith(".py") or path.lower().endswith(".pyw"):
                 # Open the file, read the textual content and set the name as
                 # the path to the file.
                 try:
@@ -1204,7 +1204,7 @@ class Editor(QObject):
         extracts a Python script from a hex file.
         """
         # Get all supported extensions from the different modes
-        extensions = ["py"]
+        extensions = ["py", "pyw"]
         for mode_name, mode in self.modes.items():
             if mode.file_extensions:
                 extensions += mode.file_extensions
@@ -1303,7 +1303,7 @@ class Editor(QObject):
         return False.
         """
         logger.info('Checking path "{}" for shadow module.'.format(path))
-        filename = os.path.basename(path).replace(".py", "")
+        filename = os.path.basename(path).replace(".pyw", "").replace(".py", "")
         return filename in self.modes[self.mode].module_names
 
     def save(self, *args, default=None):
@@ -1376,7 +1376,7 @@ class Editor(QObject):
         if tab is None:
             # There is no active text editor so abort.
             return
-        if tab.path and not tab.path.endswith(".py"):
+        if tab.path and not (tab.path.endswith(".py") or tab.path.endswith(".pyw")):
             # Only works on Python files, so abort.
             return
         tab.has_annotations = not tab.has_annotations
@@ -1747,7 +1747,7 @@ class Editor(QObject):
                     "Attempting to rename {} to {}".format(tab.path, new_path)
                 )
                 # The user specified a path to a file.
-                if not os.path.basename(new_path).endswith(".py"):
+                if not (os.path.basename(new_path).endswith(".py") or os.path.basename(new_path).endswith(".pyw")):
                     # No extension given, default to .py
                     new_path += ".py"
                 # Check for duplicate path with currently open tab.
@@ -1831,7 +1831,7 @@ class Editor(QObject):
         if not tab or sys.version_info[:2] < (3, 6):
             return
         # Only works on Python, so abort.
-        if tab.path and not tab.path.endswith(".py"):
+        if tab.path and not (tab.path.endswith(".py") or tab.path.endswith(".pyw")):
             return
         from black import format_str, FileMode, PY36_VERSIONS
 

--- a/mu/logic.py
+++ b/mu/logic.py
@@ -1209,8 +1209,7 @@ class Editor(QObject):
         for mode_name, mode in self.modes.items():
             if mode.file_extensions:
                 extensions += mode.file_extensions
-        # Sort extensions to get deterministic output
-        extensions = list(sorted(set([e.lower() for e in extensions])))
+        extensions = [e.lower() for e in extensions]
         extensions = "*.{} *.{}".format(
             " *.".join(extensions), " *.".join(extensions).upper()
         )
@@ -1305,9 +1304,10 @@ class Editor(QObject):
         return False.
         """
         logger.info('Checking path "{}" for shadow module.'.format(path))
-        filename = (
-            os.path.basename(path).replace(".pyw", "").replace(".py", "")
-        )
+        pyextensions = [".pyw", ".PYW", ".py", ".PY"]
+        filename = os.path.basename(path)
+        for ext in pyextensions:
+            filename = filename.replace(ext, "")
         return filename in self.modes[self.mode].module_names
 
     def save(self, *args, default=None):
@@ -1869,7 +1869,4 @@ class Editor(QObject):
         Check whether the given filename matches recognized Python extensions.
         """
         file_ends = filename.lower().endswith
-        for ext in self.python_extensions:
-            if file_ends(ext):
-                return True
-        return False
+        return any(file_ends(ext) for ext in self.python_extensions)

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -1700,7 +1700,7 @@ def test_load_no_current_path():
     ed.load()
     expected = os.path.abspath("old_path")
     view.get_load_path.assert_called_once_with(
-        expected, "*.py *.PY", allow_previous=True
+        expected, "*.py *.pyw *.PY *.PYW", allow_previous=True
     )
 
 
@@ -1725,7 +1725,7 @@ def test_load_no_current_path_no_current_tab():
     ed.load()
     expected = mock_mode.workspace_dir()
     view.get_load_path.assert_called_once_with(
-        expected, "*.py *.PY", allow_previous=True
+        expected, "*.py *.pyw *.PY *.PYW", allow_previous=True
     )
 
 
@@ -1749,7 +1749,7 @@ def test_load_has_current_path_does_not_exist():
     ed.load()
     expected = mock_mode.workspace_dir()
     view.get_load_path.assert_called_once_with(
-        expected, "*.py *.PY", allow_previous=True
+        expected, "*.py *.pyw *.PY *.PYW", allow_previous=True
     )
 
 
@@ -1773,7 +1773,7 @@ def test_load_has_current_path():
     with mock.patch("os.path.isdir", return_value=True):
         ed.load()
     view.get_load_path.assert_called_once_with(
-        "foo", "*.py *.PY", allow_previous=True
+        "foo", "*.py *.pyw *.PY *.PYW", allow_previous=True
     )
 
 
@@ -1796,7 +1796,7 @@ def test_load_has_default_path():
     with mock.patch("os.path.isdir", return_value=True):
         ed.load(default_path="foo")
     view.get_load_path.assert_called_once_with(
-        "foo", "*.py *.PY", allow_previous=False
+        "foo", "*.py *.pyw *.PY *.PYW", allow_previous=False
     )
 
 


### PR DESCRIPTION
This PR changes a few places in logic.py that expected .py files to also accept .pyw files, allowing opening, checking, and tidying (saving already worked).

[The first commit](https://github.com/mu-editor/mu/commit/f9ce9d630aa4c2514764e7ae5b67546ce77a11a4#diff-50021fc2523f19f6dbad358e978343012cd08531c4675a8f087973a5547220ee) just duplicates the checks, but I refactored that into a helper method. 

Regardless of whether this will be the approach we take, we need a design for tests: lots of duplication? Check both extensions in cases only .py was tested? Just a couple specific .pyw tests?