### PR TITLE
Attempt at addressing issue #1147 and get Mu running on Mac OS 11 (Big Sur)

### DIFF
--- a/mu/app.py
+++ b/mu/app.py
@@ -126,6 +126,12 @@ def run():
     logging.info("Python path: {}".format(sys.path))
     logging.info("Language code: {}".format(language_code))
 
+    # An issue in PyQt5 v5.13.2 to v5.15.1 makes PyQt5 application
+    # hang on Mac OS 11 (Big Sur)
+    # Setting this environment variable fixes the problem.
+    # See issue #1147 for more information
+    os.environ["QT_MAC_WANTS_LAYER"] = "1"
+
     # The app object is the application running on your computer.
     app = QApplication(sys.argv)
     # By default PyQt uses the script name (run.py)


### PR DESCRIPTION
An attempt at addressing the Qt issue we see on Mac OS 11 (Big Sur), by setting the `os.environ["QT_MAC_WANTS_LAYER"] = "1"` variable before initializing the Qt application.

I'm not on Mac OS 11 myself, but I expect this to fix it. Would be nice if someone could confirm it.