### PR TITLE
Ensure the filename is fully-qualified when attempting to open via br…

### DIFF
--- a/mu/interface/panes.py
+++ b/mu/interface/panes.py
@@ -618,7 +618,7 @@ class LocalFileList(MuFileList):
         action = menu.exec_(self.mapToGlobal(event.pos()))
         if action == open_action:
             # Get the file's path
-            path = os.path.join(self.home, local_filename)
+            path = os.path.abspath(os.path.join(self.home, local_filename))
             logger.info("Opening {}".format(path))
             msg = _("Opening '{}'").format(local_filename)
             logger.info(msg)


### PR DESCRIPTION
…owser action: if not, Qt will produce a filename of the style "file:abc.def" which it will not recognise as a local filename and will attempt to open via a browser.