### PR TITLE
Use a fixed unicode locale (en_GB.UTF8) when starting Flask server

### DIFF
--- a/mu/modes/web.py
+++ b/mu/modes/web.py
@@ -170,6 +170,8 @@ class WebMode(BaseMode):
             envars = self.editor.envars
             envars.append(("FLASK_APP", os.path.basename(tab.path)))
             envars.append(("FLASK_ENV", "development"))
+            envars.append(("LC_ALL", "en_GB.UTF8"))
+            envars.append(("LANG", "en_GB.UTF8"))
             args = ["-m", "flask", "run"]
             cwd = os.path.dirname(tab.path)
             self.runner = self.view.add_python3_runner(


### PR DESCRIPTION
Should be a fix for issue #889, but needs confirmation from someone experiencing the problem.