### PR TITLE
CI: Separate Win32 installer build and ensure it's uploaded.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,19 +33,24 @@ jobs:
         run: |
           pip install .[dev]
           pip list
-      - name: Build Windows
+      - run: mkdir upload
+      - name: Build Windows 32 bit
         if: runner.os == 'Windows'
         run: |
           python make.py win32
+          mv dist/mu-editor_32bit.exe upload/
+      - name: Build Windows 64 bit
+        if: runner.os == 'Windows'
+        run: |
           python make.py win64
+          mv dist/mu-editor_64bit.exe upload/
       - name: Build macOS
         if: runner.os == 'macOS'
         run: |
           make macos
-          mkdir dist
-          mv macOS/mu-editor.app dist/
+          mv macOS/mu-editor.app upload/
       - name: Upload Mu installer
         uses: actions/upload-artifact@v1
         with:
           name: mu-editor-${{ runner.os }}-${{ github.sha }}
-          path: dist
+          path: upload


### PR DESCRIPTION
Before this PR the workflow was uploading the `dist` folder, which got cleaned (and deleted the 32 bit installer) when the 64 bit installer was build.