### PR TITLE
micro:bit flash() refactor (in preparation for V2 work)

### DIFF
--- a/mu/contrib/uflash.py
+++ b/mu/contrib/uflash.py
@@ -3,7 +3,7 @@
 This module contains functions for turning a Python script into a .hex file
 and flashing it onto a BBC micro:bit.
 
-Copyright (c) 2015-2018 Nicholas H.Tollervey and others.
+Copyright (c) 2015-2020 Nicholas H.Tollervey and others.
 
 See the LICENSE file for more information, or visit:
 
@@ -305,6 +305,8 @@ def save_hex(hex_file, path):
         raise ValueError("The path to flash must be for a .hex file.")
     with open(path, "wb") as output:
         output.write(hex_file.encode("ascii"))
+        output.flush()
+        os.fsync(output.fileno())
 
 
 def flash(

--- a/mu/contrib/uflash.py
+++ b/mu/contrib/uflash.py
@@ -21,7 +21,7 @@ import sys
 from subprocess import check_output
 import time
 
-# nudatus is an optional dependancy
+# nudatus is an optional dependency
 can_minify = True
 try:
     import nudatus
@@ -32,7 +32,7 @@ except ImportError:  # pragma: no cover
 _SCRIPT_ADDR = 0x3E000
 
 
-#: The help text to be shown when requested.
+#: The help text to be shown by uflash  when requested.
 _HELP_TEXT = """
 Flash Python onto the BBC micro:bit or extract Python from a .hex file.
 
@@ -45,9 +45,18 @@ version of the MicroPython runtime.
 Documentation is here: https://uflash.readthedocs.io/en/latest/
 """
 
+_PY2HEX_HELP_TEXT = """
+A simple utility script intended for creating hexified versions of MicroPython
+scripts on the local filesystem _NOT_ the microbit.  Does not autodetect a
+microbit.  Accepts multiple input scripts and optionally one output directory.
+"""
 
 #: MAJOR, MINOR, RELEASE, STATUS [alpha, beta, final], VERSION of uflash
-_VERSION = (1, 2, 4)
+_VERSION = (
+    1,
+    3,
+    0,
+)
 _MAX_SIZE = 8188
 
 
@@ -304,6 +313,7 @@ def flash(
     path_to_runtime=None,
     python_script=None,
     minify=False,
+    keepname=False,
 ):
     """
     Given a path to or source of a Python file will attempt to create a hex
@@ -321,6 +331,9 @@ def flash(
     If paths_to_microbits is unspecified it will attempt to find the device's
     path on the filesystem automatically.
 
+    If keepname is True the original filename (excluding the
+    extension) will be preserved.
+
     If the path_to_runtime is unspecified it will use the built in version of
     the MicroPython runtime. This feature is useful if a custom build of
     MicroPython is available.
@@ -336,6 +349,8 @@ def flash(
     # Grab the Python script (if needed).
     python_hex = ""
     if path_to_python:
+        (script_path, script_name) = os.path.split(path_to_python)
+        (script_name_root, script_name_ext) = os.path.splitext(script_name)
         if not path_to_python.endswith(".py"):
             raise ValueError('Python files must end in ".py".')
         with open(path_to_python, "rb") as python_script:
@@ -358,8 +373,18 @@ def flash(
     # Attempt to write the hex file to the micro:bit.
     if paths_to_microbits:
         for path in paths_to_microbits:
-            hex_path = os.path.join(path, "micropython.hex")
-            print("Flashing Python to: {}".format(hex_path))
+            if keepname and path_to_python:
+                hex_file_name = script_name_root + ".hex"
+                hex_path = os.path.join(path, hex_file_name)
+            else:
+                hex_path = os.path.join(path, "micropython.hex")
+            if path_to_python:
+                if not keepname:
+                    print("Flashing {} to: {}".format(script_name, hex_path))
+                else:
+                    print("Hexifying {} as: {}".format(script_name, hex_path))
+            else:
+                print("Flashing Python to: {}".format(hex_path))
             save_hex(micropython_hex, hex_path)
     else:
         raise IOError("Unable to find micro:bit. Is it plugged in?")
@@ -400,10 +425,57 @@ def watch_file(path, func, *args, **kwargs):
         pass
 
 
+def py2hex(argv=None):
+    """
+    Entry point for the command line tool 'py2hex'
+
+    Will print help text if the optional first argument is "help". Otherwise
+    it will ensure the first argument ends in ".py" (the source Python script).
+
+    An optional second argument is used to to reference the path where the
+    resultant hex file sill be saved (the default location is in the same
+    directory as the .py file).
+
+    Exceptions are caught and printed for the user.
+    """
+    if not argv:  # pragma: no cover
+        argv = sys.argv[1:]
+
+    parser = argparse.ArgumentParser(description=_PY2HEX_HELP_TEXT)
+    parser.add_argument("source", nargs="*", default=None)
+    parser.add_argument(
+        "-r",
+        "--runtime",
+        default=None,
+        help="Use the referenced MicroPython runtime.",
+    )
+    parser.add_argument(
+        "-o", "--outdir", default=None, help="Output directory"
+    )
+    parser.add_argument(
+        "-m", "--minify", action="store_true", help="Minify the source"
+    )
+    parser.add_argument(
+        "--version", action="version", version="%(prog)s " + get_version()
+    )
+    args = parser.parse_args(argv)
+
+    for py_file in args.source:
+        if not args.outdir:
+            (script_path, script_name) = os.path.split(py_file)
+            args.outdir = script_path
+        flash(
+            path_to_python=py_file,
+            path_to_runtime=args.runtime,
+            paths_to_microbits=[args.outdir],
+            minify=args.minify,
+            keepname=True,
+        )  # keepname is always True in py2hex
+
+
 def main(argv=None):
     """
     Entry point for the command line tool 'uflash'.
-
     Will print help text if the optional first argument is "help". Otherwise
     it will ensure the optional first argument ends in ".py" (the source
     Python script).
@@ -483,6 +555,7 @@ def main(argv=None):
                 paths_to_microbits=args.target,
                 path_to_runtime=args.runtime,
                 minify=args.minify,
+                keepname=False,
             )
         except Exception as ex:
             error_message = (

--- a/mu/modes/microbit.py
+++ b/mu/modes/microbit.py
@@ -340,7 +340,9 @@ class MicrobitMode(MicroPythonMode):
         if force_flash:
             logger.info("Flashing new MicroPython runtime onto device")
             self.editor.show_status_message(message, 10)
-            self.set_buttons(flash=False)
+            self.set_buttons(
+                flash=False, repl=False, files=False, plotter=False
+            )
             if user_defined_microbit_path or not port:
                 # The user has provided a path to a location on the
                 # filesystem. In this case save the combined hex/script
@@ -383,11 +385,17 @@ class MicrobitMode(MicroPythonMode):
                         "https://codewith.mu/"
                     )
                     self.view.show_message(message, information)
+                    self.set_buttons(
+                        flash=True, repl=True, files=True, plotter=True
+                    )
                     return
             self.flash_thread.finished.connect(self.flash_finished)
             self.flash_thread.on_flash_fail.connect(self.flash_failed)
             self.flash_thread.start()
         else:
+            self.set_buttons(
+                flash=False, repl=False, files=False, plotter=False
+            )
             try:
                 self.copy_main()
             except IOError as ioex:
@@ -406,12 +414,12 @@ class MicrobitMode(MicroPythonMode):
                 self.flash_thread.start()
             except Exception as ex:
                 self.flash_failed(ex)
+            self.set_buttons(flash=True, repl=True, files=True, plotter=True)
 
     def flash_finished(self):
         """
         Called when the thread used to flash the micro:bit has finished.
         """
-        self.set_buttons(flash=True)
         self.editor.show_status_message(_("Finished flashing."))
         self.flash_thread = None
         if self.python_script:
@@ -419,6 +427,7 @@ class MicrobitMode(MicroPythonMode):
                 self.copy_main()
             except Exception as ex:
                 self.flash_failed(ex)
+        self.set_buttons(flash=True, repl=True, files=True, plotter=True)
 
     def copy_main(self):
         """
@@ -459,7 +468,7 @@ class MicrobitMode(MicroPythonMode):
             " information."
         )
         self.view.show_message(message, information, "Warning")
-        self.set_buttons(flash=True)
+        self.set_buttons(flash=True, repl=True, files=True, plotter=True)
         self.flash_thread = None
 
     def toggle_repl(self, event):

--- a/tests/modes/test_microbit.py
+++ b/tests/modes/test_microbit.py
@@ -866,7 +866,9 @@ def test_flash_script_too_big_no_minify():
     with mock.patch("mu.modes.microbit.can_minify", False):
         mm.flash()
     view.show_message.assert_called_once_with(
-        'Unable to flash "foo"', "Your script is too long!", "Warning"
+        'Unable to flash "foo"',
+        "Your script is too long and code minification is disabled",
+        "Warning",
     )
 
 
@@ -1013,6 +1015,7 @@ def test_flash_minify():
     view = mock.MagicMock()
     script = "#" + ("x" * 8193) + "\n"
     view.current_tab.text = mock.MagicMock(return_value=script)
+    view.current_tab.label = "foo"
     view.show_message = mock.MagicMock()
     editor = mock.MagicMock()
     editor.minify = True
@@ -1027,7 +1030,9 @@ def test_flash_minify():
     with mock.patch("nudatus.mangle", side_effect=ex) as m:
         mm.flash()
         view.show_message.assert_called_once_with(
-            "Problem with script", "Bad [1:0]", "Warning"
+            'Unable to flash "foo"',
+            "Problem minifying script\nBad [1:0]",
+            "Warning",
         )
 
 

--- a/tests/modes/test_microbit.py
+++ b/tests/modes/test_microbit.py
@@ -385,7 +385,7 @@ def test_flash_force_with_unsupported_microbit(microbit_incompatible):
     ):
         view = mock.MagicMock()
         # Empty file to force flashing.
-        view.current_tab.text = mock.MagicMock(return_value="")
+        view.current_tab.text = mock.MagicMock(return_value="foo")
         view.show_message = mock.MagicMock()
         editor = mock.MagicMock()
         editor.microbit_runtime = ""

--- a/tests/modes/test_microbit.py
+++ b/tests/modes/test_microbit.py
@@ -307,7 +307,9 @@ def test_flash_with_attached_device_has_old_firmware(microbit):
         mm.flash()
         assert mm.flash_thread == mock_flasher
         assert editor.show_status_message.call_count == 1
-        mm.set_buttons.assert_called_once_with(flash=False)
+        mm.set_buttons.assert_called_once_with(
+            flash=False, repl=False, files=False, plotter=False
+        )
         mock_flasher_class.assert_called_once_with(["bar"], b"", None)
         mock_flasher.finished.connect.assert_called_once_with(
             mm.flash_finished
@@ -346,7 +348,9 @@ def test_flash_force_with_no_micropython(microbit):
         mm.flash()
         assert mm.flash_thread == mock_flasher
         assert editor.show_status_message.call_count == 1
-        mm.set_buttons.assert_called_once_with(flash=False)
+        mm.set_buttons.assert_called_once_with(
+            flash=False, repl=False, files=False, plotter=False
+        )
         mock_flasher_class.assert_called_once_with(["bar"], b"", "/foo/bar")
         mock_flasher.finished.connect.assert_called_once_with(
             mm.flash_finished
@@ -426,7 +430,9 @@ def test_flash_force_with_attached_device(microbit):
         mm.flash()
         assert mm.flash_thread == mock_flasher
         assert editor.show_status_message.call_count == 1
-        mm.set_buttons.assert_called_once_with(flash=False)
+        mm.set_buttons.assert_called_once_with(
+            flash=False, repl=False, files=False, plotter=False
+        )
         mock_flasher_class.assert_called_once_with(["bar"], b"", "/foo/bar")
         mock_flasher.finished.connect.assert_called_once_with(
             mm.flash_finished
@@ -746,7 +752,9 @@ def test_flash_finished_copy_main():
     mm.set_buttons = mock.MagicMock()
     mm.flash_thread = mock.MagicMock()
     mm.flash_finished()
-    mm.set_buttons.assert_called_once_with(flash=True)
+    mm.set_buttons.assert_called_once_with(
+        flash=True, repl=True, files=True, plotter=True
+    )
     editor.show_status_message.assert_called_once_with("Finished flashing.")
     assert mm.flash_thread is None
     mm.copy_main.assert_called_once_with()
@@ -766,7 +774,9 @@ def test_flash_finished_copy_main_encounters_error():
     mm.set_buttons = mock.MagicMock()
     mm.flash_thread = mock.MagicMock()
     mm.flash_finished()
-    mm.set_buttons.assert_called_once_with(flash=True)
+    mm.set_buttons.assert_called_once_with(
+        flash=True, repl=True, files=True, plotter=True
+    )
     editor.show_status_message.assert_called_once_with("Finished flashing.")
     assert mm.flash_thread is None
     mm.copy_main.assert_called_once_with()
@@ -786,7 +796,9 @@ def test_flash_finished_no_copy():
     mm.set_buttons = mock.MagicMock()
     mm.flash_thread = mock.MagicMock()
     mm.flash_finished()
-    mm.set_buttons.assert_called_once_with(flash=True)
+    mm.set_buttons.assert_called_once_with(
+        flash=True, repl=True, files=True, plotter=True
+    )
     editor.show_status_message.assert_called_once_with("Finished flashing.")
     assert mm.flash_thread is None
     assert mm.copy_main.call_count == 0
@@ -859,7 +871,9 @@ def test_flash_failed():
     mm.flash_thread = mock.MagicMock()
     mm.flash_failed("Boom")
     assert view.show_message.call_count == 1
-    mm.set_buttons.assert_called_once_with(flash=True)
+    mm.set_buttons.assert_called_once_with(
+        flash=True, repl=True, files=True, plotter=True
+    )
     assert mm.flash_thread is None
 
 

--- a/tests/modes/test_microbit.py
+++ b/tests/modes/test_microbit.py
@@ -159,8 +159,6 @@ def test_flash_with_attached_device_has_latest_firmware(microbit):
         "mu.modes.microbit.os.path.exists", return_value=True
     ), mock.patch(
         "mu.modes.microbit.DeviceFlasher", mock_flasher_class
-    ), mock.patch(
-        "mu.modes.microbit.sys.platform", "win32"
     ):
         view = mock.MagicMock()
         view.current_tab.text = mock.MagicMock(return_value="foo")
@@ -177,12 +175,12 @@ def test_flash_with_attached_device_has_latest_firmware(microbit):
         mm.copy_main.assert_called_once_with()
 
 
-def test_flash_device_has_latest_firmware_encounters_serial_problem_windows(
+def test_flash_device_has_latest_firmware_encounters_serial_problem(
     microbit,
 ):
     """
-    If copy_main encounters an IOError on Windows, revert to old-school
-    flashing.
+    If copy_main encounters an IOError (likely on Windows), revert to
+    old-school flashing.
     """
     version_info = {
         "sysname": "microbit",
@@ -204,8 +202,6 @@ def test_flash_device_has_latest_firmware_encounters_serial_problem_windows(
         "mu.modes.microbit.os.path.exists", return_value=True
     ), mock.patch(
         "mu.modes.microbit.DeviceFlasher", mock_flasher_class
-    ), mock.patch(
-        "mu.modes.microbit.sys.platform", "win32"
     ):
         view = mock.MagicMock()
         view.current_tab.text = mock.MagicMock(return_value="foo")
@@ -229,65 +225,6 @@ def test_flash_device_has_latest_firmware_encounters_serial_problem_windows(
             mm.flash_failed
         )
         mock_flasher.start.assert_called_once_with()
-
-
-def test_flash_device_has_latest_firmware_encounters_serial_problem_unix(
-    microbit,
-):
-    """
-    If copy_main encounters an IOError on unix-y, revert to old-school
-    flashing.
-    """
-    version_info = {
-        "sysname": "microbit",
-        "nodename": "microbit",
-        "release": uflash.MICROPYTHON_VERSION,
-        "version": (
-            "micro:bit v0.1.0-b'e10a5ff' on 2018-6-8; MicroPython "
-            "v1.9.2-34-gd64154c73 on 2017-09-01"
-        ),
-        "machine": "micro:bit with nRF51822",
-    }
-    mock_flasher = mock.MagicMock()
-    mock_flasher_class = mock.MagicMock(return_value=mock_flasher)
-    mock_timer = mock.MagicMock()
-    mock_timer_class = mock.MagicMock(return_value=mock_timer)
-    with mock.patch(
-        "mu.modes.microbit.uflash.find_microbit", return_value="bar"
-    ), mock.patch(
-        "mu.modes.microbit.microfs.version", return_value=version_info
-    ), mock.patch(
-        "mu.modes.microbit.os.path.exists", return_value=True
-    ), mock.patch(
-        "mu.modes.microbit.DeviceFlasher", mock_flasher_class
-    ), mock.patch(
-        "mu.modes.microbit.QTimer", mock_timer_class
-    ), mock.patch(
-        "mu.modes.microbit.sys.platform", "linux"
-    ):
-        view = mock.MagicMock()
-        view.current_tab.text = mock.MagicMock(return_value="foo")
-        view.show_message = mock.MagicMock()
-        editor = mock.MagicMock()
-        editor.minify = False
-        editor.microbit_runtime = ""
-        editor.current_device = microbit
-        mm = MicrobitMode(editor, view)
-        mm.flash_failed = mock.MagicMock()
-        error = IOError("bang")
-        mm.copy_main = mock.MagicMock(side_effect=error)
-        mm.set_buttons = mock.MagicMock()
-        mm.flash()
-        mm.copy_main.assert_called_once_with()
-        mock_flasher_class.assert_called_once_with(["bar"], b"foo", None)
-        mock_flasher.on_flash_fail.connect.assert_called_once_with(
-            mm.flash_failed
-        )
-        mock_flasher.start.assert_called_once_with()
-        assert mm.flash_timer == mock_timer
-        mock_timer.timeout.connect.assert_called_once_with(mm.flash_finished)
-        mock_timer.setSingleShot.assert_called_once_with(True)
-        mock_timer.start.assert_called_once_with(10000)
 
 
 def test_flash_with_attached_device_has_latest_firmware_encounters_problem(
@@ -316,8 +253,6 @@ def test_flash_with_attached_device_has_latest_firmware_encounters_problem(
         "mu.modes.microbit.os.path.exists", return_value=True
     ), mock.patch(
         "mu.modes.microbit.DeviceFlasher", mock_flasher_class
-    ), mock.patch(
-        "mu.modes.microbit.sys.platform", "win32"
     ):
         view = mock.MagicMock()
         view.current_tab.text = mock.MagicMock(return_value="foo")
@@ -358,8 +293,6 @@ def test_flash_with_attached_device_has_old_firmware(microbit):
         "mu.modes.microbit.os.path.exists", return_value=True
     ), mock.patch(
         "mu.modes.microbit.DeviceFlasher", mock_flasher_class
-    ), mock.patch(
-        "mu.modes.microbit.sys.platform", "win32"
     ):
         view = mock.MagicMock()
         view.current_tab.text = mock.MagicMock(return_value="foo")
@@ -400,8 +333,6 @@ def test_flash_force_with_no_micropython(microbit):
         "mu.modes.microbit.os.path.exists", return_value=True
     ), mock.patch(
         "mu.modes.microbit.DeviceFlasher", mock_flasher_class
-    ), mock.patch(
-        "mu.modes.microbit.sys.platform", "win32"
     ):
         view = mock.MagicMock()
         view.current_tab.text = mock.MagicMock(return_value="foo")
@@ -442,8 +373,6 @@ def test_flash_force_with_unsupported_microbit(microbit_incompatible):
         "mu.modes.microbit.os.path.exists", return_value=True
     ), mock.patch(
         "mu.modes.microbit.DeviceFlasher", mock_flasher_class
-    ), mock.patch(
-        "mu.modes.microbit.sys.platform", "win32"
     ):
         view = mock.MagicMock()
         # Empty file to force flashing.
@@ -459,10 +388,10 @@ def test_flash_force_with_unsupported_microbit(microbit_incompatible):
         assert view.show_message.call_count == 1
 
 
-def test_flash_force_with_attached_device_as_windows(microbit):
+def test_flash_force_with_attached_device(microbit):
     """
     Ensure the expected calls are made to DeviceFlasher and a helpful status
-    message is enacted as if on Windows.
+    message is enacted.
     """
     version_info = {
         "sysname": "microbit",
@@ -484,8 +413,6 @@ def test_flash_force_with_attached_device_as_windows(microbit):
         "mu.modes.microbit.os.path.exists", return_value=True
     ), mock.patch(
         "mu.modes.microbit.DeviceFlasher", mock_flasher_class
-    ), mock.patch(
-        "mu.modes.microbit.sys.platform", "win32"
     ):
         view = mock.MagicMock()
         view.current_tab.text = mock.MagicMock(return_value="foo")
@@ -510,64 +437,6 @@ def test_flash_force_with_attached_device_as_windows(microbit):
         mock_flasher.start.assert_called_once_with()
 
 
-def test_flash_forced_with_attached_device_as_not_windows(microbit_v1_5):
-    """
-    Ensure the expected calls are made to DeviceFlasher and a helpful status
-    message is enacted as if not on Windows.
-    """
-    version_info = {
-        "sysname": "microbit",
-        "nodename": "microbit",
-        "release": "1.0",
-        "version": (
-            "micro:bit v0.0.9-b'e10a5ff' on 2018-6-8; MicroPython "
-            "v1.9.2-34-gd64154c73 on 2017-09-01"
-        ),
-        "machine": "micro:bit with nRF51822",
-    }
-    mock_timer = mock.MagicMock()
-    mock_timer_class = mock.MagicMock(return_value=mock_timer)
-    mock_flasher = mock.MagicMock()
-    mock_flasher_class = mock.MagicMock(return_value=mock_flasher)
-    with mock.patch(
-        "mu.modes.microbit.uflash.find_microbit", return_value="bar"
-    ), mock.patch(
-        "mu.modes.microbit.microfs.version", return_value=version_info
-    ), mock.patch(
-        "mu.modes.microbit.os.path.exists", return_value=True
-    ), mock.patch(
-        "mu.modes.microbit.DeviceFlasher", mock_flasher_class
-    ), mock.patch(
-        "mu.modes.microbit.sys.platform", "linux"
-    ), mock.patch(
-        "mu.modes.microbit.QTimer", mock_timer_class
-    ):
-        view = mock.MagicMock()
-        view.current_tab.text = mock.MagicMock(return_value="foo")
-        view.show_message = mock.MagicMock()
-        editor = mock.MagicMock()
-        editor.minify = False
-        editor.microbit_runtime = ""
-        editor.current_device = microbit_v1_5
-        mm = MicrobitMode(editor, view)
-        mm.set_buttons = mock.MagicMock()
-        mm.copy_main = mock.MagicMock()
-        mm.flash()
-        assert mm.flash_timer == mock_timer
-        assert editor.show_status_message.call_count == 1
-        mm.set_buttons.assert_called_once_with(flash=False)
-        mock_flasher_class.assert_called_once_with(["bar"], b"", None)
-        assert mock_flasher.finished.connect.call_count == 0
-        mock_timer.timeout.connect.assert_called_once_with(mm.flash_finished)
-        mock_timer.setSingleShot.assert_called_once_with(True)
-        mock_timer.start.assert_called_once_with(10000)
-        mock_flasher.on_flash_fail.connect.assert_called_once_with(
-            mm.flash_failed
-        )
-        mock_flasher.start.assert_called_once_with()
-        assert mm.python_script == b"foo"
-
-
 def test_flash_with_attached_device_and_custom_runtime(microbit_v1_5):
     """
     Ensure the custom runtime is passed into the DeviceFlasher thread.
@@ -576,11 +445,7 @@ def test_flash_with_attached_device_and_custom_runtime(microbit_v1_5):
     mock_flasher_class = mock.MagicMock(return_value=mock_flasher)
     with mock.patch(
         "mu.modes.base.BaseMode.workspace_dir", return_value=TEST_ROOT
-    ), mock.patch(
-        "mu.modes.microbit.DeviceFlasher", mock_flasher_class
-    ), mock.patch(
-        "mu.modes.microbit.sys.platform", "win32"
-    ):
+    ), mock.patch("mu.modes.microbit.DeviceFlasher", mock_flasher_class):
         view = mock.MagicMock()
         view.current_tab.text = mock.MagicMock(return_value="foo")
         view.show_message = mock.MagicMock()
@@ -613,8 +478,6 @@ def test_flash_with_attached_known_device_and_forced(microbit_v1_5):
         ),
         "machine": "micro:bit with nRF51822",
     }
-    mock_timer = mock.MagicMock()
-    mock_timer_class = mock.MagicMock(return_value=mock_timer)
     mock_flasher = mock.MagicMock()
     mock_flasher_class = mock.MagicMock(return_value=mock_flasher)
     with mock.patch(
@@ -625,10 +488,6 @@ def test_flash_with_attached_known_device_and_forced(microbit_v1_5):
         "mu.modes.microbit.os.path.exists", return_value=True
     ), mock.patch(
         "mu.modes.microbit.DeviceFlasher", mock_flasher_class
-    ), mock.patch(
-        "mu.modes.microbit.sys.platform", "linux"
-    ), mock.patch(
-        "mu.modes.microbit.QTimer", mock_timer_class
     ):
         view = mock.MagicMock()
         # Trigger force flash with an empty file.
@@ -659,8 +518,6 @@ def test_force_flash_no_serial_connection():
         "mu.logic.os.path.exists", return_value=True
     ), mock.patch(
         "mu.modes.microbit.DeviceFlasher", mock_flasher_class
-    ), mock.patch(
-        "mu.modes.microbit.sys.platform", "win32"
     ):
         view = mock.MagicMock()
         view.current_tab.text = mock.MagicMock(return_value="foo")
@@ -703,8 +560,6 @@ def test_force_flash_empty_script(microbit_v1_5):
         "mu.logic.os.path.exists", return_value=True
     ), mock.patch(
         "mu.modes.microbit.DeviceFlasher", mock_flasher_class
-    ), mock.patch(
-        "mu.modes.microbit.sys.platform", "win32"
     ):
         view = mock.MagicMock()
         view.current_tab.text = mock.MagicMock(return_value="   ")
@@ -747,8 +602,6 @@ def test_force_flash_user_specified_device_path():
         "mu.logic.os.path.exists", return_value=True
     ), mock.patch(
         "mu.modes.microbit.DeviceFlasher", mock_flasher_class
-    ), mock.patch(
-        "mu.modes.microbit.sys.platform", "win32"
     ):
         view = mock.MagicMock()
         view.get_microbit_path = mock.MagicMock(return_value="bar")
@@ -892,12 +745,10 @@ def test_flash_finished_copy_main():
     mm.copy_main = mock.MagicMock()
     mm.set_buttons = mock.MagicMock()
     mm.flash_thread = mock.MagicMock()
-    mm.flash_timer = mock.MagicMock()
     mm.flash_finished()
     mm.set_buttons.assert_called_once_with(flash=True)
     editor.show_status_message.assert_called_once_with("Finished flashing.")
     assert mm.flash_thread is None
-    assert mm.flash_timer is None
     mm.copy_main.assert_called_once_with()
 
 
@@ -914,12 +765,10 @@ def test_flash_finished_copy_main_encounters_error():
     mm.copy_main = mock.MagicMock(side_effect=error)
     mm.set_buttons = mock.MagicMock()
     mm.flash_thread = mock.MagicMock()
-    mm.flash_timer = mock.MagicMock()
     mm.flash_finished()
     mm.set_buttons.assert_called_once_with(flash=True)
     editor.show_status_message.assert_called_once_with("Finished flashing.")
     assert mm.flash_thread is None
-    assert mm.flash_timer is None
     mm.copy_main.assert_called_once_with()
     mm.flash_failed.assert_called_once_with(error)
 
@@ -936,12 +785,10 @@ def test_flash_finished_no_copy():
     mm.copy_main = mock.MagicMock()
     mm.set_buttons = mock.MagicMock()
     mm.flash_thread = mock.MagicMock()
-    mm.flash_timer = mock.MagicMock()
     mm.flash_finished()
     mm.set_buttons.assert_called_once_with(flash=True)
     editor.show_status_message.assert_called_once_with("Finished flashing.")
     assert mm.flash_thread is None
-    assert mm.flash_timer is None
     assert mm.copy_main.call_count == 0
 
 
@@ -1009,15 +856,11 @@ def test_flash_failed():
     editor = mock.MagicMock()
     mm = MicrobitMode(editor, view)
     mm.set_buttons = mock.MagicMock()
-    mock_timer = mock.MagicMock()
-    mm.flash_timer = mock_timer
     mm.flash_thread = mock.MagicMock()
     mm.flash_failed("Boom")
     assert view.show_message.call_count == 1
     mm.set_buttons.assert_called_once_with(flash=True)
     assert mm.flash_thread is None
-    assert mm.flash_timer is None
-    mock_timer.stop.assert_called_once_with()
 
 
 def test_flash_minify(microbit_v1_5):


### PR DESCRIPTION
The flash method in the micro:bit mode is too long (over 250 lines) with a lot of different paths.
Before we do any V2 work it would be quite beneficial to refactor it to make it more readable, without changing the behaviour (unless we fix bugs).

~~This PR is not yet finished,~~ and will quite likely touch every single line of the method.
The best way to review it is to **go commit by commit**, which I will try to make as atomic as possible and include info in the commit message to help with the review as well.