### PR TITLE
Make check and tidy use the same maximum line lenght. Fixes #1146.

### DIFF
--- a/mu/config.py
+++ b/mu/config.py
@@ -10,3 +10,6 @@ VENV_NAME = "mu_venv"
 
 # The directory containing default virtual environment.
 VENV_DIR = os.path.join(DATA_DIR, VENV_NAME)
+
+# Maximum line length for using both in Check and Tidy
+MAX_LINE_LENGTH = 88

--- a/mu/logic.py
+++ b/mu/logic.py
@@ -42,7 +42,7 @@ from . import __version__
 from . import i18n
 from .resources import path
 from .debugger.utils import is_breakpoint_line
-from .config import DATA_DIR, VENV_DIR
+from .config import DATA_DIR, VENV_DIR, MAX_LINE_LENGTH
 from .virtual_environment import venv
 
 # The user's home directory.
@@ -53,8 +53,6 @@ WORKSPACE_NAME = "mu_code"
 LOG_DIR = appdirs.user_log_dir(appname="mu", appauthor="python")
 # The path to the log file for the application.
 LOG_FILE = os.path.join(LOG_DIR, "mu.log")
-# Maximum line length for using both in Check and Tidy
-MAX_LINE_LENGTH = 88
 # Regex to match pycodestyle (PEP8) output.
 STYLE_REGEX = re.compile(r".*:(\d+):(\d+):\s+(.*)")
 # Regex to match flake8 output.

--- a/mu/logic.py
+++ b/mu/logic.py
@@ -53,6 +53,8 @@ WORKSPACE_NAME = "mu_code"
 LOG_DIR = appdirs.user_log_dir(appname="mu", appauthor="python")
 # The path to the log file for the application.
 LOG_FILE = os.path.join(LOG_DIR, "mu.log")
+# Maximum line length for using both in Check and Tidy
+MAX_LINE_LENGTH = 88
 # Regex to match pycodestyle (PEP8) output.
 STYLE_REGEX = re.compile(r".*:(\d+):(\d+):\s+(.*)")
 # Regex to match flake8 output.
@@ -481,7 +483,11 @@ def check_pycodestyle(code, config_file=False):
         "W391",
         "W503",
     )
-    style = StyleGuide(parse_argv=False, config_file=config_file)
+    style = StyleGuide(
+        parse_argv=False,
+        config_file=config_file,
+        max_line_length=MAX_LINE_LENGTH,
+    )
 
     # StyleGuide() returns pycodestyle module's own ignore list. That list may
     # be a default list or a custom list provided by the user
@@ -1805,7 +1811,9 @@ class Editor(QObject):
             source_code = tab.text()
             logger.info("Tidy code.")
             logger.info(source_code)
-            filemode = FileMode(target_versions=PY36_VERSIONS, line_length=88)
+            filemode = FileMode(
+                target_versions=PY36_VERSIONS, line_length=MAX_LINE_LENGTH
+            )
             tidy_code = format_str(source_code, mode=filemode)
             # The following bypasses tab.setText which resets the undo history.
             # Doing it this way means the user can use CTRL-Z to undo the

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -3620,6 +3620,7 @@ def test_tidy_code_invalid_python():
     assert mock_view.show_message.call_count == 1
 
 
+@pytest.mark.skipif(sys.version_info < (3, 6), reason="Requires Python3.6")
 def test_check_tidy_check_line_too_long():
     """
     Check we detect, then correct, lines longer than MAX_LINE_LENGTH.
@@ -3657,6 +3658,7 @@ def test_check_tidy_check_line_too_long():
     )
 
 
+@pytest.mark.skipif(sys.version_info < (3, 6), reason="Requires Python3.6")
 def test_check_tidy_check_short_line():
     """
     Check that Cidy and Check leave a short line as-is and respect


### PR DESCRIPTION
Add another constant to logic.py and use it to configure maximum line lengths for both black and pycodestyle, attempting to fix #1146. This is a clear candidate for going into conf.py and settings in the future. Might be a little test-heavy.

Open to and welcoming any suggestions, criticisms, alternative designs and requests.