### PR TITLE
Ignore whitespace and blank line checks for pycodestyle

### DIFF
--- a/mu/logic.py
+++ b/mu/logic.py
@@ -469,11 +469,8 @@ def check_pycodestyle(code, config_file=False):
         "E121",
         "E123",
         "E126",
-        "E226",
-        "E203",
-        "E302",
-        "E305",
-        "E24",
+        "E2",
+        "E3",
         "E704",
         "W291",
         "W292",
@@ -515,8 +512,6 @@ def check_pycodestyle(code, config_file=False):
             line_no, col, msg = matcher.groups()
             line_no = int(line_no) - 1
             code, description = msg.split(" ", 1)
-            if code == "E303":
-                description += _(" above this line")
             if line_no not in style_feedback:
                 style_feedback[line_no] = []
             style_feedback[line_no].append(

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -620,13 +620,27 @@ def test_check_pycodestyle():
     """
     Ensure the expected result if generated from the PEP8 style validator.
     """
-    code = "import foo\n\n\n\n\n\ndef bar():\n    pass\n"  # Generate E303
+    code = "import foo; print(foo.__file__)"  # Generate E702
     result = mu.logic.check_pycodestyle(code)
     assert len(result) == 1
-    assert result[6][0]["line_no"] == 6
-    assert result[6][0]["column"] == 0
-    assert " above this line" in result[6][0]["message"]
-    assert result[6][0]["code"] == "E303"
+    assert result[0][0]["line_no"] == 0
+    assert result[0][0]["column"] == 10
+    assert " on one line (semicolon)" in result[0][0]["message"]
+    assert result[0][0]["code"] == "E702"
+
+
+def test_check_pycodestyle_no_whitespace_newlines():
+    """
+    Ensure the PEP8 style validator doesn't flag whitespace or newline
+    issues.
+    """
+    code = (
+        "def bar  (   ) :#Comment\n    1  +  2\n    3+4\n    5\t-\t6\n"
+        "@bar\n\ndef baz(a = 7):\n\n\n    b= 8\tif\t9 else(10)\n"
+        "    return \tb"
+    )
+    result = mu.logic.check_pycodestyle(code)
+    assert len(result) == 0
 
 
 def test_check_pycodestyle_with_non_ascii():


### PR DESCRIPTION
Disable checks for all [whitespace (E2) and blank line (E3) errors](https://pycodestyle.pycqa.org/en/latest/intro.html#error-codes) for the Check button, to avoid spamming the users with low-reward error messages. Should fix #977 and #917, also addressing #655 as in leaving tabs to be solved by the Tidy button.

We might also want to ignore most indentation checks, there are a lot of low value ones (like indentation in a comment is not a multiple of four), some that might help improving style (like misalignment of continuation lines and their braces), and at least two that seem worth keeping (because they flag and provide context to IndentationError , which prevents Tidy from running):

* E112: expected an indented block
* E113: unexpected indentation

These helpful indentation checks often get de-emphasized by "not multiple of four" errors in the same message box.


Unpatched result for very badly mis-spaced code (also used for a new test added):
![unpatched_ignore_whitespace](https://user-images.githubusercontent.com/74280297/102944666-36cd2b00-449a-11eb-80f1-c2d090788c8e.jpg)

Patched result for the same very badly mis-spaced code:
![patched_ignore_whitespace](https://user-images.githubusercontent.com/74280297/102944660-359bfe00-449a-11eb-9c2c-c5269c2ba217.jpg)