### PR TITLE
Update check_flake regex for handling builtins and add "const" builtin, fixes #788

### DIFF
--- a/mu/logic.py
+++ b/mu/logic.py
@@ -52,6 +52,8 @@ LOG_FILE = os.path.join(LOG_DIR, "mu.log")
 STYLE_REGEX = re.compile(r".*:(\d+):(\d+):\s+(.*)")
 # Regex to match flake8 output.
 FLAKE_REGEX = re.compile(r".*:(\d+):(\d+)\s+(.*)")
+# Regex to match undefined name errors for given builtins
+BUILTINS_REGEX = r"^undefined name '({})'"
 # Regex to match false positive flake errors if microbit.* is expanded.
 EXPAND_FALSE_POSITIVE = re.compile(
     r"^.*'microbit\.(\w+)' imported but unused$"
@@ -368,9 +370,7 @@ def check_flake(filename, code, builtins=None):
     reporter = MuFlakeCodeReporter()
     check(code, filename, reporter)
     if builtins:
-        builtins_regex = re.compile(
-            r"^undefined name '(" + "|".join(builtins) + r")'"
-        )
+        builtins_regex = re.compile(BUILTINS_REGEX.format("|".join(builtins)))
     feedback = {}
     for log in reporter.log:
         if import_all:

--- a/mu/modes/base.py
+++ b/mu/modes/base.py
@@ -370,6 +370,7 @@ class MicroPythonMode(BaseMode):
     force_interrupt = True
     connection = None
     baudrate = 115200
+    builtins = ["const"]
 
     def compatible_board(self, port):
         """

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -497,6 +497,17 @@ def test_check_flake_with_builtins():
         mock_check.assert_called_once_with("some code", "foo.py", mock_r)
 
 
+def test_check_real_flake_output_with_builtins():
+    """
+    Check that passing builtins correctly suppresses undefined name errors
+    using real .check_flake() output.
+    """
+    ok_result = mu.logic.check_flake("foo.py", "print(foo)", builtins=["foo"])
+    assert ok_result == {}
+    bad_result = mu.logic.check_flake("foo.py", "print(bar)", builtins=["foo"])
+    assert len(bad_result) == 1
+
+
 def test_check_pycodestyle_E121():
     """
     Ensure the expected result is generated from the PEP8 style validator.


### PR DESCRIPTION
Fix #788 by adding a "const" builtin to MicroPythonMode. For the fix to work, solve a issue similar to  #1161, as our regexes were missing flake's new output formatting and not matching builtins. Moved the regex to a module constant so it's easier to spot it when fixing other regexes.

Updated existing test and added test using real check_flake output to catch any regressions.