### PR TITLE
Fix FLAKE_REGEX to match new flake 'path:lineno:col message' format.

### DIFF
--- a/mu/logic.py
+++ b/mu/logic.py
@@ -56,7 +56,7 @@ LOG_FILE = os.path.join(LOG_DIR, "mu.log")
 # Regex to match pycodestyle (PEP8) output.
 STYLE_REGEX = re.compile(r".*:(\d+):(\d+):\s+(.*)")
 # Regex to match flake8 output.
-FLAKE_REGEX = re.compile(r".*:(\d+):\s+(.*)")
+FLAKE_REGEX = re.compile(r".*:(\d+):(\d+)\s+(.*)")
 # Regex to match false positive flake errors if microbit.* is expanded.
 EXPAND_FALSE_POSITIVE = re.compile(r"^'microbit\.(\w+)' imported but unused$")
 # The text to which "from microbit import \*" should be expanded.
@@ -580,11 +580,11 @@ class MuFlakeCodeReporter:
         """
         matcher = FLAKE_REGEX.match(str(message))
         if matcher:
-            line_no, msg = matcher.groups()
+            line_no, col, msg = matcher.groups()
             self.log.append(
                 {
                     "line_no": int(line_no) - 1,  # Zero based counting in Mu.
-                    "column": 0,
+                    "column": int(col),
                     "message": msg,
                 }
             )

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -690,12 +690,26 @@ def test_MuFlakeCodeReporter_flake_matched():
     message structure.
     """
     r = mu.logic.MuFlakeCodeReporter()
-    err = "foo.py:4: something went wrong"
+    err = "foo.py:4:0 something went wrong"
     r.flake(err)
     assert len(r.log) == 1
     assert r.log[0]["line_no"] == 3
     assert r.log[0]["column"] == 0
     assert r.log[0]["message"] == "something went wrong"
+
+
+def test_MuFlakeCodeReporter_flake_real_output():
+    """
+    Check the reporter handles real output from flake, to catch format
+    change regressions.
+    """
+    check = mu.logic.check
+    reporter = mu.logic.MuFlakeCodeReporter()
+    code = "a = 1\nb = 2\nc\n"
+    check(code, "filename", reporter)
+    assert reporter.log[0]["line_no"] == 2
+    assert reporter.log[0]["message"] == "undefined name 'c'"
+    assert reporter.log[0]["column"] == 1
 
 
 def test_MuFlakeCodeReporter_flake_un_matched():


### PR DESCRIPTION
Mu currently misplaces "undefined name" errors from flake because the message format changed, like in #1161 and #1205.
![before_flake_regex](https://user-images.githubusercontent.com/74280297/103142974-0d0b4280-46ec-11eb-9240-d5030a2ae7c8.png)
![after_flake_regex](https://user-images.githubusercontent.com/74280297/103142975-0da3d900-46ec-11eb-9aba-000b9cbb0bec.png)

