### PR TITLE
CI: Add GH Action workflow to run tests on Arm.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,3 +45,41 @@ jobs:
       - name: Run tests
         if: runner.os != 'Linux'
         run: python make.py check
+
+  build-arm:
+    runs-on: ubuntu-latest
+    name: Test Py 3.7 - arm-debian-buster
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up QEMU
+        id: qemu
+        uses: docker/setup-qemu-action@v1
+        with:
+          image: tonistiigi/binfmt:latest
+          platforms: 'linux/arm64,linux/arm/v7,linux/arm/v6'
+      - name: Check Debian image info
+        uses: docker://multiarch/debian-debootstrap:armhf-buster
+        with:
+          args: /bin/bash -c "uname -a && cat /etc/os-release"
+      - name: Install dependencies and run tests
+        uses: docker://multiarch/debian-debootstrap:armhf-buster
+        with:
+          args: >
+            bash -c "
+              apt-get update &&
+              apt-get install -y python3 python3-pip python3-virtualenv &&
+              apt-get install -y python3-pyqt5 python3-pyqt5.qsci python3-pyqt5.qtserialport python3-pyqt5.qtsvg python3-pyqt5.qtchart &&
+              apt-get install -y libxmlsec1-dev libxml2 libxml2-dev libxkbcommon-x11-0 libatlas-base-dev xvfb &&
+              python3 -m virtualenv venv --python=python3 --system-site-packages &&
+              source venv/bin/activate &&
+              python -c \"import platform, struct, sys; print(platform.machine(), struct.calcsize('P') * 8, sys.version)\" &&
+              python -m pip --version &&
+              python -m pip config set global.extra-index-url https://www.piwheels.org/simple &&
+              python -m pip config list &&
+              python -m pip list &&
+              python -m pip install .[dev] &&
+              python -m pip list &&
+              QT_QPA_PLATFORM=\"offscreen\" &&
+              xvfb-run python make.py check &&
+              echo 'Finished successfully! :)'
+            "


### PR DESCRIPTION
Moving away from Travis, the main thing left over there are the tests running in the Arm platform as done in https://github.com/mu-editor/mu/pull/1104.

This GH Actions workflow job uses docker with a QEMU backend to emulate armv7 and run a Debian Buster container.