### PR TITLE
Address virtualenv issues on Debian

### DIFF
--- a/mu/virtual_environment.py
+++ b/mu/virtual_environment.py
@@ -334,6 +334,27 @@ class VirtualEnvironment(object):
         else:
             return self.process.run_blocking(self.interpreter, args)
 
+    def _directory_is_venv(self):
+        """Determine whether a directory appears to be an existing venv
+
+        There appears to be no canonical way to achieve this. Often the
+        presence of a pyvenv.cfg file is enough, but this isn't always there.
+        Specifically, on debian it's not when created by virtualenv. So we
+        fall back to finding an executable python command where we expect
+        """
+        if os.path.isfile(os.path.join(self.path, "pyvenv.cfg")):
+            return True
+
+        #
+        # On windows os.access X_OK is close to meaningless, but it will
+        # succeed for executable files (and everything else). On Posix it
+        # does distinguish executable files
+        #
+        if os.access(self.interpreter, os.X_OK):
+            return True
+
+        return False
+
     def ensure(self):
         """Ensure that a virtual environment exists, creating it if needed"""
         if not os.path.exists(self.path):
@@ -343,17 +364,12 @@ class VirtualEnvironment(object):
             message = "%s exists but is not a directory" % self.path
             logger.error(message)
             raise VirtualEnvironmentError(message)
-
-        #
-        # There doesn't seem to be a canonical way of checking whether
-        # a directory is a virtual environment
-        #
-        elif not os.path.isfile(os.path.join(self.path, "pyvenv.cfg")):
+        elif not self._directory_is_venv():
             message = "Directory %s exists but is not a venv" % self.path
             logger.error(message)
             raise VirtualEnvironmentError(message)
         else:
-            logger.debug("Directory %s already exists", self.path)
+            logger.debug("Found existing virtual environment at %s", self.path)
 
         self.ensure_interpreter()
         self.ensure_pip()
@@ -387,7 +403,15 @@ class VirtualEnvironment(object):
 
         env = dict(os.environ)
         subprocess.run(
-            [sys.executable, "-m", "virtualenv", "-q", self.path],
+            [
+                sys.executable,
+                "-m",
+                "virtualenv",
+                "-p",
+                sys.executable,
+                "-q",
+                self.path,
+            ],
             check=True,
             env=env,
         )

--- a/tests/modes/test_base.py
+++ b/tests/modes/test_base.py
@@ -196,7 +196,7 @@ def test_base_mode_write_csv(tmp_path):
     """When the plotter is removed the resulting csv should represent
     the data -- an should not not include interspersed blank lines
     """
-    csv_filepath = tmp_path / "plotter.csv"
+    csv_filepath = str(tmp_path / "plotter.csv")
     editor = mock.MagicMock()
     view = mock.MagicMock()
     view.plotter_pane.raw_data = [[1, 2, 3], [4, 5, 6]]

--- a/tests/virtual_environment/test_pip.py
+++ b/tests/virtual_environment/test_pip.py
@@ -75,11 +75,6 @@ def test_pip_run_with_kwargs():
         assert output_command == expected_command
         assert set(output_args) == set(expected_args)
 
-
-#
-# pip install
-#
-
 def pip_install_testing(label, command, package_or_packages, input_switches={}, expected_switches=[]):
     pip_executable = "pip-" + rstring() + ".exe"
     pip = mu.virtual_environment.Pip(pip_executable)
@@ -91,9 +86,12 @@ def pip_install_testing(label, command, package_or_packages, input_switches={}, 
         expected_args.append(package_or_packages)
     if expected_switches:
         expected_args.extend(expected_switches)
+    if command == "uninstall":
+        expected_args.append("--yes")
 
     with patch.object(pip.process, "run_blocking") as mock_run:
-        pip.install(package_or_packages, **input_switches)
+        function = getattr(pip, command)
+        function(package_or_packages, **input_switches)
         args, _ = mock_run.call_args
         output_command, output_args = args
         #
@@ -103,12 +101,15 @@ def pip_install_testing(label, command, package_or_packages, input_switches={}, 
         assert output_command == expected_command
         assert set(output_args) == set(expected_args)
 
+#
+# pip install
+#
+
 def test_pip_install_single_package():
     """Ensure that installing a single package results in:
     "pip install <package>"
     """
     pip_install_testing("test_pip_install_single_package", "install", rstring())
-
 
 def test_pip_install_several_packages():
     """Ensure that installing several package results in
@@ -117,13 +118,11 @@ def test_pip_install_several_packages():
     package_names = [rstring() for _ in range(random.randint(1, 5))]
     pip_install_testing("test_pip_install_several_packages", "install", package_names)
 
-
 def test_pip_install_single_package_with_flag():
     """Ensure that installing a single package with upgrade=True
     "pip install --upgrade <package>"
     """
     pip_install_testing("test_pip_install_single_package_with_flag", "install", rstring(), {"switch":True}, ["--switch"])
-
 
 def test_pip_install_several_packages_with_flag():
     """Ensure that installing a single package with switch=True
@@ -131,7 +130,6 @@ def test_pip_install_several_packages_with_flag():
     """
     package_names = [rstring() for _ in range(random.randint(1, 5))]
     pip_install_testing("test_pip_install_several_packages_with_flag", "install", rstring(), {"switch":True}, ["--switch"])
-
 
 def test_pip_install_single_package_with_flag_value():
     """Ensure that installing a single package with timeout=30
@@ -146,108 +144,36 @@ def test_pip_install_single_package_with_flag_value():
 
 
 def test_pip_uninstall_single_package():
-    """Ensure that installing a single package results in:
+    """Ensure that uninstalling a single package results in:
     "pip uninstall <package>"
     """
-    pip_executable = "pip-" + rstring() + ".exe"
-    package_name = rstring()
-    pip = mu.virtual_environment.Pip(pip_executable)
-    with patch.object(pip.process, "run_blocking") as mock_run:
-        pip.uninstall(package_name)
-        expected_args = (
-            pip_executable,
-            [
-                "uninstall",
-                "--disable-pip-version-check",
-                "--yes",
-                package_name,
-            ],
-        )
-        args, _ = mock_run.call_args
-        assert args == expected_args
-
+    pip_install_testing("test_pip_uninstall_single_package", "uninstall", rstring())
 
 def test_pip_uninstall_several_packages():
-    """Ensure that installing several package results in
+    """Ensure that uninstalling several package results in
     "pip uninstall <packageA> <packageB>"
     """
-    pip_executable = "pip-" + rstring() + ".exe"
     package_names = [rstring() for _ in range(random.randint(1, 5))]
-    pip = mu.virtual_environment.Pip(pip_executable)
-    with patch.object(pip.process, "run_blocking") as mock_run:
-        pip.uninstall(package_names)
-        expected_args = (
-            pip_executable,
-            ["uninstall", "--disable-pip-version-check", "--yes"]
-            + package_names,
-        )
-        args, _ = mock_run.call_args
-        assert args == expected_args
-
+    pip_install_testing("test_pip_uninstall_several_packages", "uninstall", package_names)
 
 def test_pip_uninstall_single_package_with_flag():
-    """Ensure that installing a single package with upgrade=True
+    """Ensure that uninstalling a single package with upgrade=True
     "pip uninstall --upgrade <package>"
     """
-    pip_executable = "pip-" + rstring() + ".exe"
-    package_name = rstring()
-    pip = mu.virtual_environment.Pip(pip_executable)
-    with patch.object(pip.process, "run_blocking") as mock_run:
-        pip.uninstall(package_name, switch=True)
-        expected_args = (
-            pip_executable,
-            [
-                "uninstall",
-                "--disable-pip-version-check",
-                "--yes",
-                "--switch",
-                package_name,
-            ],
-        )
-        args, _ = mock_run.call_args
-        assert args == expected_args
-
+    pip_install_testing("test_pip_uninstall_single_package_with_flag", "uninstall", rstring(), {"switch":True}, ["--switch"])
 
 def test_pip_uninstall_several_packages_with_flag():
-    """Ensure that installing a single package with switch=True
+    """Ensure that uninstalling a single package with switch=True
     "pip uninstall --upgrade <package>"
     """
-    pip_executable = "pip-" + rstring() + ".exe"
     package_names = [rstring() for _ in range(random.randint(1, 5))]
-    pip = mu.virtual_environment.Pip(pip_executable)
-    with patch.object(pip.process, "run_blocking") as mock_run:
-        pip.uninstall(package_names, switch=True)
-        expected_args = (
-            pip_executable,
-            ["uninstall", "--disable-pip-version-check", "--yes", "--switch"]
-            + package_names,
-        )
-        args, _ = mock_run.call_args
-        assert args == expected_args
-
+    pip_install_testing("test_pip_uninstall_several_packages_with_flag", "uninstall", rstring(), {"switch":True}, ["--switch"])
 
 def test_pip_uninstall_single_package_with_flag_value():
-    """Ensure that installing a single package with timeout=30
+    """Ensure that uninstalling a single package with timeout=30
     "pip uninstall --timeout 30 <package>"
     """
-    pip_executable = "pip-" + rstring() + ".exe"
-    package_name = rstring()
-    pip = mu.virtual_environment.Pip(pip_executable)
-    with patch.object(pip.process, "run_blocking") as mock_run:
-        pip.uninstall(package_name, switch=30)
-        expected_args = (
-            pip_executable,
-            [
-                "uninstall",
-                "--disable-pip-version-check",
-                "--yes",
-                "--switch",
-                "30",
-                package_name,
-            ],
-        )
-        args, _ = mock_run.call_args
-        assert args == expected_args
+    pip_install_testing("test_pip_uninstall_single_package_with_flag", "uninstall", rstring(), {"switch":30}, ["--switch", "30"])
 
 
 #

--- a/tests/virtual_environment/test_pip.py
+++ b/tests/virtual_environment/test_pip.py
@@ -64,114 +64,80 @@ def test_pip_run_with_kwargs():
     pip = mu.virtual_environment.Pip(pip_executable)
     with patch.object(pip.process, "run_blocking") as mock_run:
         pip.run(command, **params)
-        expected_args = (
-            pip_executable,
-            [command, "--disable-pip-version-check"] + expected_parameters,
-        )
         args, _ = mock_run.call_args
-        assert args == expected_args
+        #
+        # NB presumably because of non-ordered dicts, Python 3.5 can produce
+        # arguments in a different order.
+        #
+        output_command, output_args = args
+        expected_command = pip_executable
+        expected_args = [command, "--disable-pip-version-check"] + expected_parameters
+        assert output_command == expected_command
+        assert set(output_args) == set(expected_args)
 
 
 #
 # pip install
 #
 
+def pip_install_testing(label, command, package_or_packages, input_switches={}, expected_switches=[]):
+    pip_executable = "pip-" + rstring() + ".exe"
+    pip = mu.virtual_environment.Pip(pip_executable)
+    expected_command = pip_executable
+    expected_args = [command, "--disable-pip-version-check"]
+    if isinstance(package_or_packages, list):
+        expected_args.extend(package_or_packages)
+    else:
+        expected_args.append(package_or_packages)
+    if expected_switches:
+        expected_args.extend(expected_switches)
+
+    with patch.object(pip.process, "run_blocking") as mock_run:
+        pip.install(package_or_packages, **input_switches)
+        args, _ = mock_run.call_args
+        output_command, output_args = args
+        #
+        # NB presumably because of non-ordered dicts, Python 3.5 can produce
+        # arguments in a different order.
+        #
+        assert output_command == expected_command
+        assert set(output_args) == set(expected_args)
 
 def test_pip_install_single_package():
     """Ensure that installing a single package results in:
     "pip install <package>"
     """
-    pip_executable = "pip-" + rstring() + ".exe"
-    package_name = rstring()
-    pip = mu.virtual_environment.Pip(pip_executable)
-    with patch.object(pip.process, "run_blocking") as mock_run:
-        pip.install(package_name)
-        expected_args = (
-            pip_executable,
-            ["install", "--disable-pip-version-check", package_name],
-        )
-        args, _ = mock_run.call_args
-        assert args == expected_args
+    pip_install_testing("test_pip_install_single_package", "install", rstring())
 
 
 def test_pip_install_several_packages():
     """Ensure that installing several package results in
     "pip install <packageA> <packageB>"
     """
-    pip_executable = "pip-" + rstring() + ".exe"
     package_names = [rstring() for _ in range(random.randint(1, 5))]
-    pip = mu.virtual_environment.Pip(pip_executable)
-    with patch.object(pip.process, "run_blocking") as mock_run:
-        pip.install(package_names)
-        expected_args = (
-            pip_executable,
-            ["install", "--disable-pip-version-check"] + package_names,
-        )
-        args, _ = mock_run.call_args
-        assert args == expected_args
+    pip_install_testing("test_pip_install_several_packages", "install", package_names)
 
 
 def test_pip_install_single_package_with_flag():
     """Ensure that installing a single package with upgrade=True
     "pip install --upgrade <package>"
     """
-    pip_executable = "pip-" + rstring() + ".exe"
-    package_name = rstring()
-    pip = mu.virtual_environment.Pip(pip_executable)
-    with patch.object(pip.process, "run_blocking") as mock_run:
-        pip.install(package_name, switch=True)
-        expected_args = (
-            pip_executable,
-            [
-                "install",
-                "--disable-pip-version-check",
-                "--switch",
-                package_name,
-            ],
-        )
-        args, _ = mock_run.call_args
-        assert args == expected_args
+    pip_install_testing("test_pip_install_single_package_with_flag", "install", rstring(), {"switch":True}, ["--switch"])
 
 
 def test_pip_install_several_packages_with_flag():
     """Ensure that installing a single package with switch=True
     "pip install --upgrade <package>"
     """
-    pip_executable = "pip-" + rstring() + ".exe"
     package_names = [rstring() for _ in range(random.randint(1, 5))]
-    pip = mu.virtual_environment.Pip(pip_executable)
-    with patch.object(pip.process, "run_blocking") as mock_run:
-        pip.install(package_names, switch=True)
-        expected_args = (
-            pip_executable,
-            ["install", "--disable-pip-version-check", "--switch"]
-            + package_names,
-        )
-        args, _ = mock_run.call_args
-        assert args == expected_args
+    pip_install_testing("test_pip_install_several_packages_with_flag", "install", rstring(), {"switch":True}, ["--switch"])
 
 
 def test_pip_install_single_package_with_flag_value():
     """Ensure that installing a single package with timeout=30
     "pip install --timeout 30 <package>"
     """
-    pip_executable = "pip-" + rstring() + ".exe"
-    package_name = rstring()
-    pip = mu.virtual_environment.Pip(pip_executable)
-    with patch.object(pip.process, "run_blocking") as mock_run:
-        pip.install(package_name, switch=30)
-        expected_args = (
-            pip_executable,
-            [
-                "install",
-                "--disable-pip-version-check",
-                "--switch",
-                "30",
-                package_name,
-            ],
-        )
-        args, _ = mock_run.call_args
-        assert args == expected_args
+    pip_install_testing("test_pip_install_single_package_with_flag", "install", rstring(), {"switch":30}, ["--switch", "30"])
 
 
 #

--- a/tests/virtual_environment/test_pip.py
+++ b/tests/virtual_environment/test_pip.py
@@ -71,11 +71,21 @@ def test_pip_run_with_kwargs():
         #
         output_command, output_args = args
         expected_command = pip_executable
-        expected_args = [command, "--disable-pip-version-check"] + expected_parameters
+        expected_args = [
+            command,
+            "--disable-pip-version-check",
+        ] + expected_parameters
         assert output_command == expected_command
         assert set(output_args) == set(expected_args)
 
-def pip_install_testing(label, command, package_or_packages, input_switches={}, expected_switches=[]):
+
+def pip_install_testing(
+    label,
+    command,
+    package_or_packages,
+    input_switches={},
+    expected_switches=[],
+):
     pip_executable = "pip-" + rstring() + ".exe"
     pip = mu.virtual_environment.Pip(pip_executable)
     expected_command = pip_executable
@@ -101,41 +111,69 @@ def pip_install_testing(label, command, package_or_packages, input_switches={}, 
         assert output_command == expected_command
         assert set(output_args) == set(expected_args)
 
+
 #
 # pip install
 #
+
 
 def test_pip_install_single_package():
     """Ensure that installing a single package results in:
     "pip install <package>"
     """
-    pip_install_testing("test_pip_install_single_package", "install", rstring())
+    pip_install_testing(
+        "test_pip_install_single_package", "install", rstring()
+    )
+
 
 def test_pip_install_several_packages():
     """Ensure that installing several package results in
     "pip install <packageA> <packageB>"
     """
     package_names = [rstring() for _ in range(random.randint(1, 5))]
-    pip_install_testing("test_pip_install_several_packages", "install", package_names)
+    pip_install_testing(
+        "test_pip_install_several_packages", "install", package_names
+    )
+
 
 def test_pip_install_single_package_with_flag():
     """Ensure that installing a single package with upgrade=True
     "pip install --upgrade <package>"
     """
-    pip_install_testing("test_pip_install_single_package_with_flag", "install", rstring(), {"switch":True}, ["--switch"])
+    pip_install_testing(
+        "test_pip_install_single_package_with_flag",
+        "install",
+        rstring(),
+        {"switch": True},
+        ["--switch"],
+    )
+
 
 def test_pip_install_several_packages_with_flag():
     """Ensure that installing a single package with switch=True
     "pip install --upgrade <package>"
     """
     package_names = [rstring() for _ in range(random.randint(1, 5))]
-    pip_install_testing("test_pip_install_several_packages_with_flag", "install", rstring(), {"switch":True}, ["--switch"])
+    pip_install_testing(
+        "test_pip_install_several_packages_with_flag",
+        "install",
+        package_names,
+        {"switch": True},
+        ["--switch"],
+    )
+
 
 def test_pip_install_single_package_with_flag_value():
     """Ensure that installing a single package with timeout=30
     "pip install --timeout 30 <package>"
     """
-    pip_install_testing("test_pip_install_single_package_with_flag", "install", rstring(), {"switch":30}, ["--switch", "30"])
+    pip_install_testing(
+        "test_pip_install_single_package_with_flag",
+        "install",
+        rstring(),
+        {"switch": 30},
+        ["--switch", "30"],
+    )
 
 
 #
@@ -147,33 +185,59 @@ def test_pip_uninstall_single_package():
     """Ensure that uninstalling a single package results in:
     "pip uninstall <package>"
     """
-    pip_install_testing("test_pip_uninstall_single_package", "uninstall", rstring())
+    pip_install_testing(
+        "test_pip_uninstall_single_package", "uninstall", rstring()
+    )
+
 
 def test_pip_uninstall_several_packages():
     """Ensure that uninstalling several package results in
     "pip uninstall <packageA> <packageB>"
     """
     package_names = [rstring() for _ in range(random.randint(1, 5))]
-    pip_install_testing("test_pip_uninstall_several_packages", "uninstall", package_names)
+    pip_install_testing(
+        "test_pip_uninstall_several_packages", "uninstall", package_names
+    )
+
 
 def test_pip_uninstall_single_package_with_flag():
     """Ensure that uninstalling a single package with upgrade=True
     "pip uninstall --upgrade <package>"
     """
-    pip_install_testing("test_pip_uninstall_single_package_with_flag", "uninstall", rstring(), {"switch":True}, ["--switch"])
+    pip_install_testing(
+        "test_pip_uninstall_single_package_with_flag",
+        "uninstall",
+        rstring(),
+        {"switch": True},
+        ["--switch"],
+    )
+
 
 def test_pip_uninstall_several_packages_with_flag():
     """Ensure that uninstalling a single package with switch=True
     "pip uninstall --upgrade <package>"
     """
     package_names = [rstring() for _ in range(random.randint(1, 5))]
-    pip_install_testing("test_pip_uninstall_several_packages_with_flag", "uninstall", rstring(), {"switch":True}, ["--switch"])
+    pip_install_testing(
+        "test_pip_uninstall_several_packages_with_flag",
+        "uninstall",
+        package_names,
+        {"switch": True},
+        ["--switch"],
+    )
+
 
 def test_pip_uninstall_single_package_with_flag_value():
     """Ensure that uninstalling a single package with timeout=30
     "pip uninstall --timeout 30 <package>"
     """
-    pip_install_testing("test_pip_uninstall_single_package_with_flag", "uninstall", rstring(), {"switch":30}, ["--switch", "30"])
+    pip_install_testing(
+        "test_pip_uninstall_single_package_with_flag",
+        "uninstall",
+        rstring(),
+        {"switch": 30},
+        ["--switch", "30"],
+    )
 
 
 #

--- a/tests/virtual_environment/test_virtual_environment.py
+++ b/tests/virtual_environment/test_virtual_environment.py
@@ -88,7 +88,7 @@ def baseline_packages(tmp_path):
     with mock.patch.object(
         mu.virtual_environment.VirtualEnvironment,
         "BASELINE_PACKAGES_FILEPATH",
-        baseline_filepath
+        baseline_filepath,
     ):
         yield baseline_filepath, packages
 
@@ -99,7 +99,7 @@ def test_wheels(tmp_path):
     os.mkdir(wheels_dirpath)
     shutil.copyfile(
         os.path.join(HERE, "wheels", WHEEL_FILENAME),
-        os.path.join(wheels_dirpath, WHEEL_FILENAME)
+        os.path.join(wheels_dirpath, WHEEL_FILENAME),
     )
     with mock.patch.object(
         mu.virtual_environment, "wheels_dirpath", wheels_dirpath
@@ -114,8 +114,8 @@ def test_create_virtual_environment_on_disk(venv_dirpath, test_wheels):
     venv = mu.virtual_environment.VirtualEnvironment(venv_dirpath)
     venv.create()
     venv_site_packages = venv.run_python(
-            "-c", "import sysconfig; print(sysconfig.get_path('purelib'))"
-        ).strip()
+        "-c", "import sysconfig; print(sysconfig.get_path('purelib'))"
+    ).strip()
 
     #
     # Having a series of unrelated asserts is generally frowned upon
@@ -151,7 +151,8 @@ def test_create_virtual_environment_on_disk(venv_dirpath, test_wheels):
     bin = "scripts" if sys.platform == "win32" else "bin"
     bin_extension = ".exe" if sys.platform == "win32" else ""
     assert os.path.samefile(
-        venv.interpreter, os.path.join(venv_dirpath, bin, "python" + bin_extension)
+        venv.interpreter,
+        os.path.join(venv_dirpath, bin, "python" + bin_extension),
     )
 
     #

--- a/tests/virtual_environment/test_virtual_environment.py
+++ b/tests/virtual_environment/test_virtual_environment.py
@@ -351,6 +351,8 @@ def test_venv_folder_already_exists(venv):
 
 def test_venv_folder_already_exists_not_venv(venv):
     """When venv_folder does exist not as a venv ensure we raise an error"""
+    assert not os.path.isfile(os.path.join(venv.path, "pyvenv.cfg"))
+    assert not os.path.isfile(venv.interpreter)
     with pytest.raises(mu.virtual_environment.VirtualEnvironmentError):
         venv.ensure()
 

--- a/tests/virtual_environment/test_virtual_environment.py
+++ b/tests/virtual_environment/test_virtual_environment.py
@@ -133,7 +133,7 @@ def test_create_virtual_environment_on_disk(venv_dirpath, test_wheels):
     #
     # Check that we've created a virtual environment on disk
     #
-    assert (venv_dirpath / "pyvenv.cfg").is_file()
+    assert venv._directory_is_venv()
 
     #
     # Check that we have an installed version of pip


### PR DESCRIPTION
Address issues raised by @carlosperate in https://github.com/mu-editor/mu/pull/1210#issuecomment-751905774 and following:

* Use the `-p` switch to specify the current `sys.executable` when creating the virtualenv
* Use the presence of a python executable to detect whether a directory is a virtual env even if a pyvenv.cfg doesn't exist