### PR TITLE
Using pup to package under macOS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,7 @@ jobs:
         if: runner.os == 'macOS'
         run: |
           make macos
-          mv macOS/mu-editor.app upload/
+          mv dist/*.dmg upload/
       - name: Upload Mu installer
         uses: actions/upload-artifact@v1
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,7 @@ jobs:
           pip config list
           pip freeze
       - name: Install Mu dependencies
+        if: runner.os == 'Windows'
         run: |
           pip install .[dev]
           pip list

--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,7 @@ macos:
 	./venv-pup/bin/pip install pup
 	# HACK
 	# 1. Use a custom dmgbuild to address `hdiutil detach` timeouts.
-	./venv-pup/bin/pip uninstall dmgbuild
+	./venv-pup/bin/pip uninstall -y dmgbuild
 	./venv-pup/bin/pip install git+https://github.com/tmontes/dmgbuild.git@mu-pup-ci-hack
 	# Run pup with an "active venv"-like PATH...
 	# ...for pup 1.0.0a7 to find the dmgbuild command.

--- a/Makefile
+++ b/Makefile
@@ -122,6 +122,10 @@ macos:
 	# 1. Not really needed.
 	# 2. Previously active venv would be "gone" on venv-pup deactivation.
 	./venv-pup/bin/pip install pup
+	# HACK
+	# 1. Use a custom dmgbuild to address `hdiutil detach` timeouts.
+	./venv-pup/bin/pip uninstall dmgbuild
+	./venv-pup/bin/pip install git+https://github.com/tmontes/dmgbuild.git@mu-pup-ci-hack
 	# Run pup with an "active venv"-like PATH...
 	# ...for pup 1.0.0a7 to find the dmgbuild command.
 	PATH="${PWD}/venv-pup/bin:${PATH}" ./venv-pup/bin/pup package --launch-module=mu --nice-name="Mu Editor" --icon-path=./package/icons/mac_icon.icns --license-path=./LICENSE .

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,6 @@ clean:
 	rm -rf lib
 	rm -rf pynsist_pkgs
 	rm -rf pynsist_tkinter*
-	rm -rf macOS
 	rm -rf *.mp4
 	rm -rf .git/avatar/*
 	find . \( -name '*.py[co]' -o -name dropin.cache \) -delete

--- a/Makefile
+++ b/Makefile
@@ -125,7 +125,7 @@ macos:
 	./venv-pup/bin/pip install pup
 	# Run pup with a venv-like activated PATH:
 	# - As of 1.0.0a7 it's required for it to find the dmgbuild command.
-	PATH=$PWD/venv-pup/bin:$PATH ./venv-pup/bin/pup package --launch-module=mu --nice-name="Mu Editor" --icon-path=./package/icons/mac_icon.icns --license-path=./LICENSE .
+	PATH="${PWD}/venv-pup/bin:${PATH}" ./venv-pup/bin/pup package --launch-module=mu --nice-name="Mu Editor" --icon-path=./package/icons/mac_icon.icns --license-path=./LICENSE .
 	rm -r venv-pup
 
 video: clean

--- a/Makefile
+++ b/Makefile
@@ -116,9 +116,12 @@ win64: check
 	@echo "\nBuilding 64bit Windows installer."
 	python win_installer.py 64 setup.py
 
-macos: check
+macos:
 	@echo "\nPackaging Mu into a macOS native application."
-	python setup.py macos --support-pkg=https://github.com/mu-editor/mu_portable_python_macos/releases/download/0.0.6/python3-reduced.tar.gz
+	python -m venv venv-pup
+	./venv-pup/bin/pip install pup
+	./venv-pup/bin/pup package --launch-module=mu --nice-name="Mu Editor" --icon-path=./package/icons/mac_icon.icns --license-path=./LICENSE .
+	rm -r venv-pup
 
 video: clean
 	@echo "\nFetching contributor avatars."

--- a/Makefile
+++ b/Makefile
@@ -121,14 +121,12 @@ macos:
 	# Don't activate venv-pup because:
 	# 1. Not really needed.
 	# 2. Previously active venv would be "gone" on venv-pup deactivation.
-	./venv-pup/bin/pip install pup
+	./venv-pup/bin/pip install git+https://github.com/mu-editor/pup
 	# HACK
 	# 1. Use a custom dmgbuild to address `hdiutil detach` timeouts.
 	./venv-pup/bin/pip uninstall -y dmgbuild
 	./venv-pup/bin/pip install git+https://github.com/tmontes/dmgbuild.git@mu-pup-ci-hack
-	# Run pup with an "active venv"-like PATH...
-	# ...for pup 1.0.0a7 to find the dmgbuild command.
-	PATH="${PWD}/venv-pup/bin:${PATH}" ./venv-pup/bin/pup package --launch-module=mu --nice-name="Mu Editor" --icon-path=./package/icons/mac_icon.icns --license-path=./LICENSE .
+	./venv-pup/bin/pup package --launch-module=mu --nice-name="Mu Editor" --icon-path=./package/icons/mac_icon.icns --license-path=./LICENSE .
 	rm -r venv-pup
 	ls -la ./build/pup/
 	ls -la ./dist/

--- a/Makefile
+++ b/Makefile
@@ -121,7 +121,7 @@ macos:
 	# Don't activate venv-pup because:
 	# 1. Not really needed.
 	# 2. Previously active venv would be "gone" on venv-pup deactivation.
-	./venv-pup/bin/pip install git+https://github.com/mu-editor/pup
+	./venv-pup/bin/pip install pup
 	# HACK
 	# 1. Use a custom dmgbuild to address `hdiutil detach` timeouts.
 	./venv-pup/bin/pip uninstall -y dmgbuild

--- a/Makefile
+++ b/Makefile
@@ -119,8 +119,13 @@ win64: check
 macos:
 	@echo "\nPackaging Mu into a macOS native application."
 	python -m venv venv-pup
+	# Let's not activate venv-pup:
+	# - It's not really needed.
+	# - Any previously active venv would be lost on deactivation.
 	./venv-pup/bin/pip install pup
-	./venv-pup/bin/pup package --launch-module=mu --nice-name="Mu Editor" --icon-path=./package/icons/mac_icon.icns --license-path=./LICENSE .
+	# Run pup with a venv-like activated PATH:
+	# - As of 1.0.0a7 it's required for it to find the dmgbuild command.
+	PATH=$PWD/venv-pup/bin:$PATH ./venv-pup/bin/pup package --launch-module=mu --nice-name="Mu Editor" --icon-path=./package/icons/mac_icon.icns --license-path=./LICENSE .
 	rm -r venv-pup
 
 video: clean

--- a/Makefile
+++ b/Makefile
@@ -118,14 +118,16 @@ win64: check
 macos:
 	@echo "\nPackaging Mu into a macOS native application."
 	python -m venv venv-pup
-	# Let's not activate venv-pup:
-	# - It's not really needed.
-	# - Any previously active venv would be lost on deactivation.
+	# Don't activate venv-pup because:
+	# 1. Not really needed.
+	# 2. Previously active venv would be "gone" on venv-pup deactivation.
 	./venv-pup/bin/pip install pup
-	# Run pup with a venv-like activated PATH:
-	# - As of 1.0.0a7 it's required for it to find the dmgbuild command.
+	# Run pup with an "active venv"-like PATH...
+	# ...for pup 1.0.0a7 to find the dmgbuild command.
 	PATH="${PWD}/venv-pup/bin:${PATH}" ./venv-pup/bin/pup package --launch-module=mu --nice-name="Mu Editor" --icon-path=./package/icons/mac_icon.icns --license-path=./LICENSE .
 	rm -r venv-pup
+	ls -la ./build/pup/
+	ls -la ./dist/
 
 video: clean
 	@echo "\nFetching contributor avatars."

--- a/setup.py
+++ b/setup.py
@@ -145,8 +145,4 @@ setup(
         "Topic :: Text Editors :: Integrated Development Environments (IDE)",
     ],
     entry_points={"console_scripts": ["mu-editor = mu.app:run"]},
-    options={  # Briefcase packaging options for OSX
-        "app": {"formal_name": "mu-editor", "bundle": "mu.codewith.editor"},
-        "macos": {"icon": "package/icons/mac_icon"},
-    },
 )

--- a/setup.py
+++ b/setup.py
@@ -72,8 +72,6 @@ extras_require = {
         "nudatus",
     ],
     "docs": [
-        "docutils >= 0.12, < 0.16",  # adding docutils requirement to avoid
-        # conflict between sphinx and briefcase
         "sphinx",
     ],
     "package": [
@@ -83,12 +81,6 @@ extras_require = {
         # Windows native packaging (see win_installer.py).
         'requests==2.23.0;platform_system == "Windows"',
         'yarg==0.1.9;platform_system == "Windows"',
-        # Temporarily pin boto3 (briefcase dependency) to fix urllib3  version
-        # conflicts, it can be removed after the dependencies have been updated
-        # https://github.com/mu-editor/mu/issues/1155
-        "boto3==1.15.18",
-        # macOS native packaging (see Makefile)
-        'briefcase==0.2.9;platform_system == "Darwin"',
     ],
     "utils": ["scrapy", "beautifulsoup4", "requests"],
 }


### PR DESCRIPTION
NOTES:

* As agreed last Monday, here is the first take at this.
* As of now, macOS packaged Mu is not able to run `turtle`/`tkinter` things, see:
  * https://github.com/mu-editor/pup/issues/122
  * https://github.com/indygreg/python-build-standalone/issues/68
* Not being 100% familiar with the recently merged venv branch:
  * I experienced a few odd behaviors resulting from running "in dev mode" vs "packaged".
  * Did not investigate in full but they went away once I removed any previously existing Mu venv.
  * Currently packaged macOS Mu **does not bundle** venv needed wheels -- shouldn't it?

IMPORTANT:

* I disabled the `check` dependency for the `macos` target:
  * Two tests were failing on my system.
  * I really wanted to see how this goes on CI. :-)
