### PR TITLE
WIP: Fix REPL using wrong interpreter, bad PYTHONPATH from envars breaking things

### DIFF
--- a/mu/interface/panes.py
+++ b/mu/interface/panes.py
@@ -862,6 +862,7 @@ class PythonProcessPane(QTextEdit):
         """
         if not envars:  # Envars must be a list if not passed a value.
             envars = []
+        envars = [(name, v) for (name, v) in envars if name != "PYTHONPATH"]
         self.script = ""
         if script_name:
             self.script = os.path.abspath(os.path.normcase(script_name))

--- a/mu/modes/python3.py
+++ b/mu/modes/python3.py
@@ -75,7 +75,8 @@ class KernelRunner(QObject):
             "{}".format(self.envars)
         )
         for k, v in self.envars.items():
-            os.environ[k] = v
+            if k != "PYTHONPATH":
+                os.environ[k] = v
 
         self.repl_kernel_manager = QtKernelManager()
         self.repl_kernel_manager.kernel_name = self.kernel_name

--- a/tests/modes/test_python3.py
+++ b/tests/modes/test_python3.py
@@ -34,7 +34,7 @@ def test_kernel_runner_start_kernel():
     mock_kernel_manager_class = mock.MagicMock()
     mock_kernel_manager_class.return_value = mock_kernel_manager
     with mock.patch("mu.modes.python3.os", mock_os), mock.patch(
-        "mu.modes.python3.QtKernelManager", mock_kernel_manager_class
+        "mu.modes.python3.MuKernelManager", mock_kernel_manager_class
     ), mock.patch("sys.platform", "darwin"):
         kr.start_kernel()
     mock_os.chdir.assert_called_once_with("/a/path/to/mu_code")


### PR DESCRIPTION
This records two tentative fixes for #1239:
* Avoid using any `PYTHONPATH` values from envars ("Python3 Environment" tab), as that is prone to breaking stuff and way more likely if user has more than one Mu version installed.
* Check whether `QtKernelManager` figures out the right interpreter to run the kernel on. If it doesn't, we log the issue and tell it to use `venv.interpreter` instead. Since I couldn't actually reproduce this issue, not sure the value added goes beyond better diagnostics (i.e., kernel might still fail to run).