### PR TITLE
Avoid circuitpython permission denied crash, fixes #1237

### DIFF
--- a/mu/logic.py
+++ b/mu/logic.py
@@ -1525,7 +1525,7 @@ class Editor(QObject):
                     "Could not open {} mode workspace directory, "
                     'due to exception "{}".'
                     "Using:\n\n{}\n\n...to store your code instead"
-                ).format(mode, e, workspace_dir)
+                ).format(mode, repr(e), workspace_dir)
             )
         # Reset remembered current path for load/save dialogs.
         self.current_path = ""

--- a/mu/logic.py
+++ b/mu/logic.py
@@ -1103,9 +1103,10 @@ class Editor(QObject):
                 workspace_path = self.modes["python"].workspace_dir()
                 logger.error(
                     (
-                        "Could not open {} mode workspace directory, using:"
+                        "Could not open {} mode workspace directory"
+                        'due to exception "{}". Using:'
                         "\n\n{}\n\n...to store your code instead"
-                    ).format(self.mode, workspace_path)
+                    ).format(self.mode, e, workspace_path)
                 )
             tab = self._view.current_tab
             if tab and tab.path:
@@ -1522,8 +1523,9 @@ class Editor(QObject):
             logger.error(
                 (
                     "Could not open {} mode workspace directory, "
-                    "using:\n\n{}\n\n...to store your code instead"
-                ).format(mode, workspace_dir)
+                    'due to exception "{}".'
+                    "Using:\n\n{}\n\n...to store your code instead"
+                ).format(mode, e, workspace_dir)
             )
         # Reset remembered current path for load/save dialogs.
         self.current_path = ""

--- a/mu/modes/circuitpython.py
+++ b/mu/modes/circuitpython.py
@@ -18,10 +18,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 import os
 import ctypes
+import logging
 from subprocess import check_output
 from mu.modes.base import MicroPythonMode
 from mu.modes.api import ADAFRUIT_APIS, SHARED_APIS
 from mu.interface.panes import CHARTS
+
+
+logger = logging.getLogger(__name__)
 
 
 class CircuitPythonMode(MicroPythonMode):
@@ -139,7 +143,30 @@ class CircuitPythonMode(MicroPythonMode):
                             device_dir = volume.decode("utf-8")
                             break
                 except FileNotFoundError:
-                    next
+                    pass
+                except PermissionError as e:
+                    logger.error(
+                        "Received '{}' running command: {}".format(
+                            repr(e),
+                            mount_command,
+                        )
+                    )
+                    m = _("Permission error running mount command")
+                    info = _(
+                        "The mount command ({}) returned an error: "
+                        "{}. Mu will continue as if a device isn't "
+                        "plugged in."
+                    ).format(e, mount_command)
+                    self.view.show_message(m, info.format(wd))
+                # Avoid crashing Mu, the workspace dir will be set to default
+                except Exception as e:
+                    logger.error(
+                        "Received '{}' running command: {}".format(
+                            repr(e),
+                            mount_command,
+                        )
+                    )
+
         elif os.name == "nt":
             # We're on Windows.
 

--- a/mu/modes/circuitpython.py
+++ b/mu/modes/circuitpython.py
@@ -153,11 +153,11 @@ class CircuitPythonMode(MicroPythonMode):
                     )
                     m = _("Permission error running mount command")
                     info = _(
-                        "The mount command ({}) returned an error: "
+                        'The mount command ("{}") returned an error: '
                         "{}. Mu will continue as if a device isn't "
                         "plugged in."
-                    ).format(e, mount_command)
-                    self.view.show_message(m, info.format(wd))
+                    ).format(mount_command, repr(e))
+                    self.view.show_message(m, info)
                 # Avoid crashing Mu, the workspace dir will be set to default
                 except Exception as e:
                     logger.error(

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -2435,6 +2435,29 @@ def test_change_mode_reset_breakpoints():
     mock_tab.reset_annotations.assert_called_once_with()
 
 
+def test_change_mode_workspace_dir_exception():
+    """
+    Check that any mode.workspace_dir() raising an exception doesn't crash Mu,
+    but uses Python mode's workspace_dir as a default.
+    """
+    ed = mu.logic.Editor(mock.MagicMock())
+    mode = mock.MagicMock()
+    mode.save_timeout = 0
+    mode.workspace_dir = mock.MagicMock(side_effect=ValueError("Some error."))
+    python_mode = mock.MagicMock()
+    ed.modes = {
+        "circuitpython": mode,
+        "python": python_mode,
+        "debug": mock.MagicMock(),
+    }
+    ed.mode = "debug"
+    with mock.patch("mu.logic.logger.error") as mock_error:
+        ed.change_mode("circuitpython")
+        assert mock_error.call_count == 1
+    assert ed.mode == "circuitpython"
+    assert python_mode.workspace_dir.called_once()
+
+
 def test_autosave():
     """
     Ensure the autosave callback does the expected things to the tabs.


### PR DESCRIPTION
We have a report of a Mu crash when trying to use CircuitPython mode in  #1237. The `Editor.change_mode` method calls `CircuitPythonMode.workspace_dir` which can cause a crash if e.g. the mount command raises a `PermissionError` as in that report. It turns out that any exception in any `workspace_dir` implementation would also crash, including the `NotImplementedError` we raise if `os.name` isn't either "nt" or "posix".

The crash is fixed by catching any exceptions in `Editor.change_mode` , logging an error and using the default workspace dir (`self.modes["python"].workspace_dir()` as used in `Editor.setup`).

To improve diagnosing the specific issue if it happens, `CircuitPythonMode.workspace_dir` pops an error message if `PermissionError` happens there.

All other modes seem to delegate `workspace_dir` to `mu.modes.base.get_default_workspace`, which is a safe "load default paths and override if present in settings" function.

Questions: should we use `get_default_workspace` directly in `change_mode` instead of going through `PythonMode`? If so, should `Editor.setup`? `CircuitPythonMode` uses `super().workspace_dir` for a default dir, which ends up the same as every other mode, leave it as is?

