### PR TITLE
Appveyor: Fix current issue by removing the built exe rename

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -46,12 +46,10 @@ install:
   # 64bit
   - cmd: make win64
   - cmd: dir .\dist\
-  - ps: Rename-Item .\dist\mu-editor_64bit.exe mu_$(get-date -f yyyy-MM-dd_HH_mm)_$($env:APPVEYOR_REPO_BRANCH)_$($env:APPVEYOR_REPO_COMMIT.subString(0,7))_64bit.exe
   - cmd: ren dist dist-keep
   # 32bit
   - cmd: make win32
   - cmd: dir .\dist\
-  - ps: Rename-Item .\dist\mu-editor_32bit.exe mu_$(get-date -f yyyy-MM-dd_HH_mm)_$($env:APPVEYOR_REPO_BRANCH)_$($env:APPVEYOR_REPO_COMMIT.subString(0,7))_32bit.exe
   - cmd: move .\dist\*.exe .\dist-keep\
   # Confirm we have both installer executables
   - cmd: dir .\dist-keep\


### PR DESCRIPTION
It just uploads with the default name.
We'll be removing this soon, but in the meantime we can get another green tick on the CI.