### PR TITLE
Remember UI pane positions for session

### DIFF
--- a/mu/interface/main.py
+++ b/mu/interface/main.py
@@ -319,6 +319,12 @@ class Window(QMainWindow):
 
     def __init__(self, parent=None):
         super().__init__(parent)
+        # Record pane area to allow reopening where user put it in a session
+        self._fs_area = 0
+        self._inspector_area = 0
+        self._plotter_area = 0
+        self._repl_area = 0
+        self._runner_area = 0
 
     def wheelEvent(self, event):
         """
@@ -591,7 +597,8 @@ class Window(QMainWindow):
             | Qt.LeftDockWidgetArea
             | Qt.RightDockWidgetArea
         )
-        self.addDockWidget(Qt.BottomDockWidgetArea, self.repl)
+        area = self._repl_area or Qt.BottomDockWidgetArea
+        self.addDockWidget(area, self.repl)
         self.connect_zoom(self.repl_pane)
         self.repl_pane.set_theme(self.theme)
         self.repl_pane.setFocus()
@@ -609,7 +616,8 @@ class Window(QMainWindow):
             | Qt.LeftDockWidgetArea
             | Qt.RightDockWidgetArea
         )
-        self.addDockWidget(Qt.BottomDockWidgetArea, self.plotter)
+        area = self._plotter_area or Qt.BottomDockWidgetArea
+        self.addDockWidget(area, self.plotter)
         self.plotter_pane.set_theme(self.theme)
         self.plotter_pane.setFocus()
 
@@ -659,7 +667,8 @@ class Window(QMainWindow):
             | Qt.LeftDockWidgetArea
             | Qt.RightDockWidgetArea
         )
-        self.addDockWidget(Qt.BottomDockWidgetArea, self.runner)
+        area = self._runner_area or Qt.BottomDockWidgetArea
+        self.addDockWidget(area, self.runner)
         logger.info(
             "About to start_process: %r, %r, %r, %r, %r, %r, %r, %r",
             interpreter,
@@ -702,7 +711,8 @@ class Window(QMainWindow):
             | Qt.LeftDockWidgetArea
             | Qt.RightDockWidgetArea
         )
-        self.addDockWidget(Qt.RightDockWidgetArea, self.inspector)
+        area = self._inspector_area or Qt.RightDockWidgetArea
+        self.addDockWidget(area, self.inspector)
         self.connect_zoom(self.debug_inspector)
 
     def update_debug_inspector(self, locals_dict):
@@ -769,6 +779,7 @@ class Window(QMainWindow):
         Removes the file system pane from the application.
         """
         if hasattr(self, "fs") and self.fs:
+            self._fs_area = self.dockWidgetArea(self.fs)
             self.fs_pane = None
             self.fs.setParent(None)
             self.fs.deleteLater()
@@ -779,6 +790,7 @@ class Window(QMainWindow):
         Removes the REPL pane from the application.
         """
         if self.repl:
+            self._repl_area = self.dockWidgetArea(self.repl)
             self.repl_pane = None
             self.repl.setParent(None)
             self.repl.deleteLater()
@@ -789,6 +801,7 @@ class Window(QMainWindow):
         Removes the plotter pane from the application.
         """
         if self.plotter:
+            self._plotter_area = self.dockWidgetArea(self.plotter)
             self.plotter_pane = None
             self.plotter.setParent(None)
             self.plotter.deleteLater()
@@ -799,6 +812,7 @@ class Window(QMainWindow):
         Removes the runner pane from the application.
         """
         if hasattr(self, "runner") and self.runner:
+            self._runner_area = self.dockWidgetArea(self.runner)
             self.process_runner = None
             self.runner.setParent(None)
             self.runner.deleteLater()
@@ -809,6 +823,7 @@ class Window(QMainWindow):
         Removes the debug inspector pane from the application.
         """
         if hasattr(self, "inspector") and self.inspector:
+            self._inspector_area = self.dockWidgetArea(self.inspector)
             self.debug_inspector = None
             self.debug_model = None
             self.inspector.setParent(None)

--- a/mu/interface/main.py
+++ b/mu/interface/main.py
@@ -320,6 +320,7 @@ class Window(QMainWindow):
     def __init__(self, parent=None):
         super().__init__(parent)
         # Record pane area to allow reopening where user put it in a session
+        self._debugger_area = 0
         self._inspector_area = 0
         self._plotter_area = 0
         self._repl_area = 0
@@ -666,7 +667,11 @@ class Window(QMainWindow):
             | Qt.LeftDockWidgetArea
             | Qt.RightDockWidgetArea
         )
-        area = self._runner_area or Qt.BottomDockWidgetArea
+        self.process_runner.debugger = debugger
+        if debugger:
+            area = self._debugger_area or Qt.BottomDockWidgetArea
+        else:
+            area = self._runner_area or Qt.BottomDockWidgetArea
         self.addDockWidget(area, self.runner)
         logger.info(
             "About to start_process: %r, %r, %r, %r, %r, %r, %r, %r",
@@ -810,7 +815,10 @@ class Window(QMainWindow):
         Removes the runner pane from the application.
         """
         if hasattr(self, "runner") and self.runner:
-            self._runner_area = self.dockWidgetArea(self.runner)
+            if self.process_runner.debugger:
+                self._debugger_area = self.dockWidgetArea(self.runner)
+            else:
+                self._runner_area = self.dockWidgetArea(self.runner)
             self.process_runner = None
             self.runner.setParent(None)
             self.runner.deleteLater()

--- a/mu/interface/main.py
+++ b/mu/interface/main.py
@@ -320,7 +320,6 @@ class Window(QMainWindow):
     def __init__(self, parent=None):
         super().__init__(parent)
         # Record pane area to allow reopening where user put it in a session
-        self._fs_area = 0
         self._inspector_area = 0
         self._plotter_area = 0
         self._repl_area = 0
@@ -779,7 +778,6 @@ class Window(QMainWindow):
         Removes the file system pane from the application.
         """
         if hasattr(self, "fs") and self.fs:
-            self._fs_area = self.dockWidgetArea(self.fs)
             self.fs_pane = None
             self.fs.setParent(None)
             self.fs.deleteLater()

--- a/tests/interface/test_main.py
+++ b/tests/interface/test_main.py
@@ -1125,6 +1125,7 @@ def test_Window_remove_python_runner():
     mock_runner.setParent = mock.MagicMock(return_value=None)
     mock_runner.deleteLater = mock.MagicMock(return_value=None)
     w.runner = mock_runner
+    w.process_runner = mock.MagicMock()
     w.dockWidgetArea = mock.MagicMock()
     w.remove_python_runner()
     mock_runner.setParent.assert_called_once_with(None)

--- a/tests/interface/test_main.py
+++ b/tests/interface/test_main.py
@@ -1078,7 +1078,6 @@ def test_Window_remove_filesystem():
     w.remove_filesystem()
     mock_fs.setParent.assert_called_once_with(None)
     mock_fs.deleteLater.assert_called_once_with()
-    w.dockWidgetArea.assert_called_once()
     assert w.fs is None
 
 

--- a/tests/interface/test_main.py
+++ b/tests/interface/test_main.py
@@ -12,6 +12,7 @@ from tests.test_app import DumSig
 import mu.interface.main
 import mu.interface.themes
 import mu.interface.editor
+from mu.interface.panes import PlotterPane
 import sys
 
 
@@ -936,6 +937,29 @@ def test_Window_add_plotter():
     w.addDockWidget.assert_called_once_with(Qt.BottomDockWidgetArea, mock_dock)
 
 
+def test_Window_remember_plotter_position():
+    """
+    Check that opening plotter, changing the area it's docked to, then closing
+    it makes the next plotter open at the same area.
+    """
+    w = mu.interface.main.Window()
+    w.theme = mock.MagicMock()
+    pane = PlotterPane()
+    w.add_plotter(pane, "Test Plotter")
+    dock_area = w.dockWidgetArea(w.plotter)
+    assert dock_area == 8  # Bottom
+    w.removeDockWidget(w.plotter)
+    w.addDockWidget(Qt.LeftDockWidgetArea, w.plotter)
+    dock_area = w.dockWidgetArea(w.plotter)
+    assert dock_area == 1  # Left
+    w.remove_plotter()
+    assert w.plotter is None
+    pane2 = PlotterPane()
+    w.add_plotter(pane2, "Test Plotter 2")
+    dock_area = w.dockWidgetArea(w.plotter)
+    assert dock_area == 1  # Reopened on left
+
+
 def test_Window_add_python3_runner():
     """
     Ensure a Python 3 runner (to capture stdin/out/err) is displayed correctly.
@@ -1050,9 +1074,11 @@ def test_Window_remove_filesystem():
     mock_fs.setParent = mock.MagicMock(return_value=None)
     mock_fs.deleteLater = mock.MagicMock(return_value=None)
     w.fs = mock_fs
+    w.dockWidgetArea = mock.MagicMock()
     w.remove_filesystem()
     mock_fs.setParent.assert_called_once_with(None)
     mock_fs.deleteLater.assert_called_once_with()
+    w.dockWidgetArea.assert_called_once()
     assert w.fs is None
 
 
@@ -1065,9 +1091,11 @@ def test_Window_remove_repl():
     mock_repl.setParent = mock.MagicMock(return_value=None)
     mock_repl.deleteLater = mock.MagicMock(return_value=None)
     w.repl = mock_repl
+    w.dockWidgetArea = mock.MagicMock()
     w.remove_repl()
     mock_repl.setParent.assert_called_once_with(None)
     mock_repl.deleteLater.assert_called_once_with()
+    w.dockWidgetArea.assert_called_once()
     assert w.repl is None
 
 
@@ -1079,10 +1107,12 @@ def test_Window_remove_plotter():
     mock_plotter = mock.MagicMock()
     mock_plotter.setParent = mock.MagicMock(return_value=None)
     mock_plotter.deleteLater = mock.MagicMock(return_value=None)
+    w.dockWidgetArea = mock.MagicMock()
     w.plotter = mock_plotter
     w.remove_plotter()
     mock_plotter.setParent.assert_called_once_with(None)
     mock_plotter.deleteLater.assert_called_once_with()
+    w.dockWidgetArea.assert_called_once()
     assert w.plotter is None
 
 
@@ -1096,9 +1126,11 @@ def test_Window_remove_python_runner():
     mock_runner.setParent = mock.MagicMock(return_value=None)
     mock_runner.deleteLater = mock.MagicMock(return_value=None)
     w.runner = mock_runner
+    w.dockWidgetArea = mock.MagicMock()
     w.remove_python_runner()
     mock_runner.setParent.assert_called_once_with(None)
     mock_runner.deleteLater.assert_called_once_with()
+    w.dockWidgetArea.assert_called_once()
     assert w.process_runner is None
     assert w.runner is None
 
@@ -1115,12 +1147,14 @@ def test_Window_remove_debug_inspector():
     w.inspector = mock_inspector
     w.debug_inspector = mock_debug_inspector
     w.debug_model = mock_model
+    w.dockWidgetArea = mock.MagicMock()
     w.remove_debug_inspector()
     assert w.debug_inspector is None
     assert w.debug_model is None
     assert w.inspector is None
     mock_inspector.setParent.assert_called_once_with(None)
     mock_inspector.deleteLater.assert_called_once_with()
+    w.dockWidgetArea.assert_called_once()
 
 
 def test_Window_set_theme():


### PR DESCRIPTION
Add simple support for reopening the UI panes (inspector, plotter, repl, runner) in the same dock area (bottom, left, right) they were previously moved to, as discussed in #1122.

As can be seen below, a given pane's position isn't stable in each of these areas. As cannot be seen below (sorry!) both the debugger inspector and debugger runner remember the areas they belong to, and moving a debugger runner doesn't change normal runner's recorded area.

As of right now REPLs, plotters and non-debugger runners clobber the positions of equivalent panes in other modes.

The filesystem pane isn't currently movable, but can easily be added if we decide to change that.

![remember_panes2](https://user-images.githubusercontent.com/74280297/106104877-cad98480-6121-11eb-9631-c2a90f660ec0.gif)
