### PR TITLE
Venv settings not saved

### DIFF
--- a/mu/modes/base.py
+++ b/mu/modes/base.py
@@ -54,15 +54,18 @@ def get_default_workspace():
     settings file to be used to set a custom path.
     """
     workspace_dir = os.path.join(config.HOME_DIRECTORY, config.WORKSPACE_NAME)
-
     settings_workspace = settings.settings.get("workspace")
-    if settings_workspace and os.path.isdir(settings_workspace):
-        workspace_dir = settings_workspace
-    else:
-        logger.error(
-            "Workspace value in the settings file is not a valid"
-            "directory: {}".format(settings_workspace)
-        )
+
+    if settings_workspace:
+        if os.path.isdir(settings_workspace):
+            logger.info("Using workspace {} from settings file".format(settings_workspace))
+            workspace_dir = settings_workspace
+        else:
+            logger.warn(
+                "Workspace {} in the settings file is not a valid "
+                "directory; using default {}".format(settings_workspace, workspace_dir)
+            )
+
     return workspace_dir
 
 

--- a/mu/modes/base.py
+++ b/mu/modes/base.py
@@ -58,12 +58,18 @@ def get_default_workspace():
 
     if settings_workspace:
         if os.path.isdir(settings_workspace):
-            logger.info("Using workspace {} from settings file".format(settings_workspace))
+            logger.info(
+                "Using workspace {} from settings file".format(
+                    settings_workspace
+                )
+            )
             workspace_dir = settings_workspace
         else:
             logger.warn(
                 "Workspace {} in the settings file is not a valid "
-                "directory; using default {}".format(settings_workspace, workspace_dir)
+                "directory; using default {}".format(
+                    settings_workspace, workspace_dir
+                )
             )
 
     return workspace_dir

--- a/mu/settings.py
+++ b/mu/settings.py
@@ -242,7 +242,7 @@ class SettingsBase(object):
 class UserSettings(SettingsBase):
 
     DEFAULTS = {
-        "workspace" : os.path.join(config.HOME_DIRECTORY, config.WORKSPACE_NAME)
+        "workspace": os.path.join(config.HOME_DIRECTORY, config.WORKSPACE_NAME)
     }
     autosave = False
     filestem = "settings"

--- a/mu/settings.py
+++ b/mu/settings.py
@@ -241,7 +241,9 @@ class SettingsBase(object):
 
 class UserSettings(SettingsBase):
 
-    DEFAULTS = {}
+    DEFAULTS = {
+        "workspace" : os.path.join(config.HOME_DIRECTORY, config.WORKSPACE_NAME)
+    }
     autosave = False
     filestem = "settings"
 

--- a/mu/settings.py
+++ b/mu/settings.py
@@ -258,7 +258,7 @@ class SessionSettings(SettingsBase):
 class VirtualEnvironmentSettings(SettingsBase):
 
     DEFAULTS = {"baseline_packages": [], "dirpath": config.VENV_DIR}
-    autosave = False
+    autosave = True
     filestem = "venv"
 
 

--- a/mu/virtual_environment.py
+++ b/mu/virtual_environment.py
@@ -311,6 +311,7 @@ class VirtualEnvironment(object):
         logger.debug(
             "Virtual environment set up %s at %s", self.name, self.path
         )
+        self.settings['dirpath'] = self.path
 
     def run_python(self, *args, slots=Process.Slots()):
         """Run the referenced Python interpreter with the passed in args

--- a/mu/virtual_environment.py
+++ b/mu/virtual_environment.py
@@ -311,7 +311,7 @@ class VirtualEnvironment(object):
         logger.debug(
             "Virtual environment set up %s at %s", self.name, self.path
         )
-        self.settings['dirpath'] = self.path
+        self.settings["dirpath"] = self.path
 
     def run_python(self, *args, slots=Process.Slots()):
         """Run the referenced Python interpreter with the passed in args

--- a/tests/modes/test_base.py
+++ b/tests/modes/test_base.py
@@ -71,6 +71,7 @@ def test_base_mode_workspace_not_present():
         mu.config.HOME_DIRECTORY, mu.config.WORKSPACE_NAME
     )
     mocked_settings = mu.settings.UserSettings()
+    del mocked_settings["workspace"]
     assert "workspace" not in mocked_settings
     with mock.patch.object(mu.settings, "settings", mocked_settings):
         editor = mock.MagicMock()
@@ -95,7 +96,7 @@ def test_base_mode_workspace_invalid_value():
         view = mock.MagicMock()
         bm = BaseMode(editor, view)
         assert bm.workspace_dir() == default_workspace
-        assert logger.error.call_count == 1
+        assert logger.warn.call_count == 1
 
 
 def test_base_mode_workspace_invalid_json(tmp_path):


### PR DESCRIPTION
It appears that we were not saving the baseline packages when creating the venv! It's possible I've missed something, because I can't see how this would ever have worked. But here's a PR which fixes it... if it's really a problem