### PR TITLE
Find using plain text instead of regex

### DIFF
--- a/mu/interface/main.py
+++ b/mu/interface/main.py
@@ -1174,7 +1174,7 @@ class Window(QMainWindow):
         if global_replace:
             counter = 0
             found = self.current_tab.findFirst(
-                target_text, True, True, False, False, line=0, index=0
+                target_text, False, True, False, False, line=0, index=0
             )
             if found:
                 counter += 1
@@ -1185,7 +1185,7 @@ class Window(QMainWindow):
             return counter
         else:
             found = self.current_tab.findFirst(
-                target_text, True, True, False, True
+                target_text, False, True, False, True
             )
             if found:
                 self.current_tab.replace(replace)
@@ -1207,7 +1207,7 @@ class Window(QMainWindow):
                 line, index, _el, _ei = self.current_tab.getSelection()
             return self.current_tab.findFirst(
                 target_text,  # Text to find,
-                True,  # Treat as regular expression
+                False,  # Treat as regular expression
                 True,  # Case sensitive search
                 False,  # Whole word matches only
                 True,  # Wrap search

--- a/tests/interface/test_main.py
+++ b/tests/interface/test_main.py
@@ -1841,7 +1841,7 @@ def test_Window_highlight_text():
     mock_tab.getSelection.return_value = 0, 0, 0, 0
     assert w.highlight_text("foo")
     mock_tab.findFirst.assert_called_once_with(
-        "foo", True, True, False, True, forward=True, index=-1, line=-1
+        "foo", False, True, False, True, forward=True, index=-1, line=-1
     )
 
 

--- a/tests/interface/test_main.py
+++ b/tests/interface/test_main.py
@@ -1828,6 +1828,22 @@ def test_Window_replace_text_global_missing():
     assert w.replace_text("foo", "bar", True) == 0
 
 
+def test_Window_replace_text_highlight_text_correct_selection():
+    """
+    Check that replace_text and highlight_text are actually highlighting text
+    without regex matching.
+    """
+    view = mu.interface.main.Window()
+    text = "ofafefifoof."
+    tab = mu.interface.editor.EditorPane("path", text)
+    with mock.patch("mu.interface.Window.current_tab") as current:
+        current.findFirst = tab.findFirst
+        view.highlight_text("f.")
+        assert tab.selectedText() == "f."
+        assert view.replace_text("of.", "", False)
+        assert tab.selectedText() == "of."
+
+
 def test_Window_highlight_text():
     """
     Given target_text, highlights the first instance via Scintilla's findFirst

--- a/tests/interface/test_main.py
+++ b/tests/interface/test_main.py
@@ -1874,7 +1874,7 @@ def test_Window_highlight_text_backward():
     mock_tab.getSelection.return_value = 0, 0, 0, 0
     assert w.highlight_text("foo", forward=False)
     mock_tab.findFirst.assert_called_once_with(
-        "foo", True, True, False, True, forward=False, index=0, line=0
+        "foo", False, True, False, True, forward=False, index=0, line=0
     )
 
 

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -19,10 +19,8 @@ import uuid
 
 import pytest
 import mu.config
-import mu.interface.editor
 import mu.logic
 import mu.settings
-from mu.interface import Window
 
 from mu.virtual_environment import venv
 from PyQt5.QtWidgets import QMessageBox
@@ -3204,22 +3202,6 @@ def test_find_replace_find_matched():
     ed.show_status_message.assert_called_once_with(
         'Highlighting matches for "foo".'
     )
-
-
-def test_find_replace_find_correct_selection():
-    """
-    If the user just supplies a find target and it is matched in the code then
-    the expected status message should be shown.
-    """
-    view = Window()
-    text = "ofafefifoof."
-    tab = mu.interface.editor.EditorPane("path", text)
-    with mock.patch("mu.interface.Window.current_tab") as current:
-        current.findFirst = tab.findFirst
-        view.highlight_text("f.")
-        assert tab.selectedText() == "f."
-        assert view.replace_text("of.", "", False)
-        assert tab.selectedText() == "of."
 
 
 def test_find_again_find_matched():

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -19,8 +19,10 @@ import uuid
 
 import pytest
 import mu.config
+import mu.interface.editor
 import mu.logic
 import mu.settings
+from mu.interface import Window
 
 from mu.virtual_environment import venv
 from PyQt5.QtWidgets import QMessageBox
@@ -3202,6 +3204,22 @@ def test_find_replace_find_matched():
     ed.show_status_message.assert_called_once_with(
         'Highlighting matches for "foo".'
     )
+
+
+def test_find_replace_find_correct_selection():
+    """
+    If the user just supplies a find target and it is matched in the code then
+    the expected status message should be shown.
+    """
+    view = Window()
+    text = "ofafefifoof."
+    tab = mu.interface.editor.EditorPane("path", text)
+    with mock.patch("mu.interface.Window.current_tab") as current:
+        current.findFirst = tab.findFirst
+        view.highlight_text("f.")
+        assert tab.selectedText() == "f."
+        assert view.replace_text("of.", "", False)
+        assert tab.selectedText() == "of."
 
 
 def test_find_again_find_matched():


### PR DESCRIPTION
Fixes #1222 by calling `EditorPane.findFirst` with the regex flag set to `False`.