### PR TITLE
venv: Add installed packages to log in single entry.

### DIFF
--- a/mu/virtual_environment.py
+++ b/mu/virtual_environment.py
@@ -518,9 +518,9 @@ class VirtualEnvironment(object):
         ]
         user_packages = []
         for package, version in self.pip.installed():
-            logger.info(package)
             if package not in baseline_packages:
                 user_packages.append(package)
+        logger.info(user_packages)
 
         return baseline_packages, user_packages
 


### PR DESCRIPTION
Tiny PR to make the log a bit less vertically long. It makes checking the log a bit easier when debugging.

With this change it shows:
```
2021-01-31 19:30:15,957 - mu.virtual_environment:523(installed_packages) INFO: ['appnope', 'backcall', 'click', 'decorator', 'Flask', 'ipykernel', 'ipython', 'ipython-genutils', 'itsdangerous', 'jedi', 'Jinja2', 'jupyter-client', 'jupyter-core', 'MarkupSafe', 'nudatus', 'numpy', 'parso', 'pexpect', 'pgzero', 'pickleshare', 'pip', 'prompt-toolkit', 'ptyprocess', 'pygame', 'Pygments', 'pyserial', 'python-dateutil', 'pyzmq', 'qtconsole', 'QtPy', 'setuptools', 'six', 'tornado', 'traitlets', 'wcwidth', 'Werkzeug', 'wheel']
```

Instead of:
```
2021-01-31 18:50:38,898 - mu.virtual_environment:521(installed_packages) INFO: appnope
2021-01-31 18:50:38,898 - mu.virtual_environment:521(installed_packages) INFO: backcall
2021-01-31 18:50:38,898 - mu.virtual_environment:521(installed_packages) INFO: click
2021-01-31 18:50:38,898 - mu.virtual_environment:521(installed_packages) INFO: decorator
2021-01-31 18:50:38,898 - mu.virtual_environment:521(installed_packages) INFO: Flask
2021-01-31 18:50:38,898 - mu.virtual_environment:521(installed_packages) INFO: ipykernel
2021-01-31 18:50:38,898 - mu.virtual_environment:521(installed_packages) INFO: ipython
2021-01-31 18:50:38,898 - mu.virtual_environment:521(installed_packages) INFO: ipython-genutils
2021-01-31 18:50:38,898 - mu.virtual_environment:521(installed_packages) INFO: itsdangerous
2021-01-31 18:50:38,899 - mu.virtual_environment:521(installed_packages) INFO: jedi
2021-01-31 18:50:38,899 - mu.virtual_environment:521(installed_packages) INFO: Jinja2
2021-01-31 18:50:38,899 - mu.virtual_environment:521(installed_packages) INFO: jupyter-client
2021-01-31 18:50:38,899 - mu.virtual_environment:521(installed_packages) INFO: jupyter-core
2021-01-31 18:50:38,899 - mu.virtual_environment:521(installed_packages) INFO: MarkupSafe
2021-01-31 18:50:38,899 - mu.virtual_environment:521(installed_packages) INFO: nudatus
2021-01-31 18:50:38,899 - mu.virtual_environment:521(installed_packages) INFO: numpy
2021-01-31 18:50:38,899 - mu.virtual_environment:521(installed_packages) INFO: parso
2021-01-31 18:50:38,899 - mu.virtual_environment:521(installed_packages) INFO: pexpect
2021-01-31 18:50:38,899 - mu.virtual_environment:521(installed_packages) INFO: pgzero
2021-01-31 18:50:38,899 - mu.virtual_environment:521(installed_packages) INFO: pickleshare
2021-01-31 18:50:38,899 - mu.virtual_environment:521(installed_packages) INFO: pip
2021-01-31 18:50:38,899 - mu.virtual_environment:521(installed_packages) INFO: prompt-toolkit
2021-01-31 18:50:38,899 - mu.virtual_environment:521(installed_packages) INFO: ptyprocess
2021-01-31 18:50:38,899 - mu.virtual_environment:521(installed_packages) INFO: pygame
2021-01-31 18:50:38,899 - mu.virtual_environment:521(installed_packages) INFO: Pygments
2021-01-31 18:50:38,899 - mu.virtual_environment:521(installed_packages) INFO: pyserial
2021-01-31 18:50:38,899 - mu.virtual_environment:521(installed_packages) INFO: python-dateutil
2021-01-31 18:50:38,899 - mu.virtual_environment:521(installed_packages) INFO: pyzmq
2021-01-31 18:50:38,899 - mu.virtual_environment:521(installed_packages) INFO: qtconsole
2021-01-31 18:50:38,899 - mu.virtual_environment:521(installed_packages) INFO: QtPy
2021-01-31 18:50:38,899 - mu.virtual_environment:521(installed_packages) INFO: setuptools
2021-01-31 18:50:38,900 - mu.virtual_environment:521(installed_packages) INFO: six
2021-01-31 18:50:38,900 - mu.virtual_environment:521(installed_packages) INFO: tornado
2021-01-31 18:50:38,900 - mu.virtual_environment:521(installed_packages) INFO: traitlets
2021-01-31 18:50:38,900 - mu.virtual_environment:521(installed_packages) INFO: wcwidth
2021-01-31 18:50:38,900 - mu.virtual_environment:521(installed_packages) INFO: Werkzeug
2021-01-31 18:50:38,900 - mu.virtual_environment:521(installed_packages) INFO: wheel
```

