### PR TITLE
Hide admin tabs not relevant for the current mode. Fixes #1125

### DIFF
--- a/mu/interface/dialogs.py
+++ b/mu/interface/dialogs.py
@@ -480,17 +480,18 @@ class AdminDialog(QDialog):
         self.tabs.addTab(self.log_widget, _("Current Log"))
         self.envar_widget = EnvironmentVariablesWidget(self)
         self.envar_widget.setup(settings.get("envars", ""))
+        self.microbit_widget = MicrobitSettingsWidget(self)
+        self.microbit_widget.setup(
+            settings.get("minify", False),
+            settings.get("microbit_runtime", ""),
+        )
+        self.package_widget = PackagesWidget(self)
+        self.package_widget.setup(packages)
         if mode.short_name in ["python", "web", "pygamezero"]:
             self.tabs.addTab(self.envar_widget, _("Python3 Environment"))
         if mode.short_name == "microbit":
-            self.microbit_widget = MicrobitSettingsWidget(self)
-            self.microbit_widget.setup(
-                settings.get("minify", False), settings.get("microbit_runtime", "")
-            )
             self.tabs.addTab(self.microbit_widget, _("BBC micro:bit Settings"))
         if mode.short_name in ["python", "web", "pygamezero"]:
-            self.package_widget = PackagesWidget(self)
-            self.package_widget.setup(packages)
             self.tabs.addTab(self.package_widget, _("Third Party Packages"))
         if mode.short_name == "esp":
             self.esp_widget = ESPFirmwareFlasherWidget(self)

--- a/mu/interface/dialogs.py
+++ b/mu/interface/dialogs.py
@@ -480,20 +480,23 @@ class AdminDialog(QDialog):
         self.tabs.addTab(self.log_widget, _("Current Log"))
         self.envar_widget = EnvironmentVariablesWidget(self)
         self.envar_widget.setup(settings.get("envars", ""))
-        self.tabs.addTab(self.envar_widget, _("Python3 Environment"))
-        self.log_widget.log_text_area.setFocus()
-        self.microbit_widget = MicrobitSettingsWidget(self)
-        self.microbit_widget.setup(
-            settings.get("minify", False), settings.get("microbit_runtime", "")
-        )
-        self.tabs.addTab(self.microbit_widget, _("BBC micro:bit Settings"))
-        self.package_widget = PackagesWidget(self)
-        self.package_widget.setup(packages)
-        self.tabs.addTab(self.package_widget, _("Third Party Packages"))
+        if mode.short_name in ["python", "web", "pygamezero"]:
+            self.tabs.addTab(self.envar_widget, _("Python3 Environment"))
+        if mode.short_name == "microbit":
+            self.microbit_widget = MicrobitSettingsWidget(self)
+            self.microbit_widget.setup(
+                settings.get("minify", False), settings.get("microbit_runtime", "")
+            )
+            self.tabs.addTab(self.microbit_widget, _("BBC micro:bit Settings"))
+        if mode.short_name in ["python", "web", "pygamezero"]:
+            self.package_widget = PackagesWidget(self)
+            self.package_widget.setup(packages)
+            self.tabs.addTab(self.package_widget, _("Third Party Packages"))
         if mode.short_name == "esp":
             self.esp_widget = ESPFirmwareFlasherWidget(self)
             self.esp_widget.setup(mode, device_list)
             self.tabs.addTab(self.esp_widget, _("ESP Firmware flasher"))
+        self.log_widget.log_text_area.setFocus()
 
     def settings(self):
         """

--- a/tests/interface/test_dialogs.py
+++ b/tests/interface/test_dialogs.py
@@ -365,6 +365,60 @@ def test_ESPFirmwareFlasherWidget_firmware_path_changed(
     assert not espff.btnExec.isEnabled()
 
 
+def test_AdminDialog_setup_python_mode():
+    """
+    Ensure the admin dialog is setup properly given the content of a log
+    file and envars.
+    """
+    log = "this is the contents of a log file"
+    settings = {
+        "envars": "name=value",
+        "minify": True,
+        "microbit_runtime": "/foo/bar",
+    }
+    packages = "foo\nbar\nbaz\n"
+    mock_window = QWidget()
+    mode = mock.MagicMock()
+    mode.short_name = "python"
+    mode.name = "Python 3"
+    modes = mock.MagicMock()
+    device_list = mu.logic.DeviceList(modes)
+    ad = mu.interface.dialogs.AdminDialog(mock_window)
+    ad.setup(log, settings, packages, mode, device_list)
+    assert ad.log_widget.log_text_area.toPlainText() == log
+    s = ad.settings()
+    assert s["packages"] == packages
+    del s["packages"]
+    assert s == settings
+
+
+def test_AdminDialog_setup_microbit_mode():
+    """
+    Ensure the admin dialog is setup properly given the content of a log
+    file and envars.
+    """
+    log = "this is the contents of a log file"
+    settings = {
+        "envars": "name=value",
+        "minify": True,
+        "microbit_runtime": "/foo/bar",
+    }
+    packages = "foo\nbar\nbaz\n"
+    mock_window = QWidget()
+    mode = mock.MagicMock()
+    mode.short_name = "microbit"
+    mode.name = "BBC micro:bit"
+    modes = mock.MagicMock()
+    device_list = mu.logic.DeviceList(modes)
+    ad = mu.interface.dialogs.AdminDialog(mock_window)
+    ad.setup(log, settings, packages, mode, device_list)
+    assert ad.log_widget.log_text_area.toPlainText() == log
+    s = ad.settings()
+    assert s["packages"] == packages
+    del s["packages"]
+    assert s == settings
+
+
 def test_AdminDialog_setup():
     """
     Ensure the admin dialog is setup properly given the content of a log


### PR DESCRIPTION
Suggested fix for #1125. This hides the administration tabs not related to the current mode, making it harder for users to things like trying to use the "Third Party Packages" tab to install packages on microbit/other MicroPython devices (I've seen that one a lot, even by professional developers teaching at our code club...)