### PR TITLE
CI: Build Mu with Python 3.8.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.7'
+          python-version: '3.8'
       - name: Display Python info
         run: |
           python -c "import sys; print(sys.version)"


### PR DESCRIPTION
To use the latest compatible Python version in the CI builds. This way it will match the installers that will be created in the next release.