### PR TITLE
Add esptool as dependency to simplify user experience in ESP-mode (fixes #1279)

### DIFF
--- a/mu/interface/dialogs.py
+++ b/mu/interface/dialogs.py
@@ -241,18 +241,6 @@ class ESPFirmwareFlasherWidget(QWidget):
         widget_layout = QVBoxLayout()
         self.setLayout(widget_layout)
 
-        # Check whether esptool is installed, show error if not
-        if not self.esptool_is_installed():
-            error_msg = _(
-                "The ESP Firmware flasher requires the esptool' "
-                "package to be installed.\n"
-                "Select \"Third Party Packages\", add 'esptool' "
-                "and click 'OK'"
-            )
-            error_label = QLabel(error_msg)
-            widget_layout.addWidget(error_label)
-            return
-
         # Instructions
         grp_instructions = QGroupBox(
             _("How to flash MicroPython to your device")

--- a/mu/wheels/__init__.py
+++ b/mu/wheels/__init__.py
@@ -19,6 +19,7 @@ mode_packages = [
     ("pyserial", "pyserial==3.4"),
     ("qtconsole", "qtconsole==4.7.4"),
     ("nudatus", "nudatus>=0.0.3"),
+    ("esptool", "esptool"),
 ]
 WHEELS_DIRPATH = os.path.dirname(__file__)
 

--- a/mu/wheels/__init__.py
+++ b/mu/wheels/__init__.py
@@ -19,7 +19,7 @@ mode_packages = [
     ("pyserial", "pyserial==3.4"),
     ("qtconsole", "qtconsole==4.7.4"),
     ("nudatus", "nudatus>=0.0.3"),
-    ("esptool", "esptool"),
+    ("esptool", "esptool==3.*"),
 ]
 WHEELS_DIRPATH = os.path.dirname(__file__)
 

--- a/setup.py
+++ b/setup.py
@@ -54,10 +54,6 @@ install_requires = [
     # Needed for packaging
     #
     "wheel",
-    #
-    # Needed for ESP-mode
-    #
-    "esptool",
 ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,10 @@ install_requires = [
     # Needed for packaging
     #
     "wheel",
+    #
+    # Needed for ESP-mode
+    #
+    "esptool",
 ]
 
 


### PR DESCRIPTION
I hope it is enough to just add the 'esptool' dependency in `setup.py`, please check that I'm not missing something