### PR TITLE
venv: Add macOS Python 3.8 pygame custom wheel for app signing workaround

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.7'
+          python-version: '3.8'
       - name: Display Python info
         run: |
           python -c "import sys; print(sys.version)"

--- a/mu/wheels/__init__.py
+++ b/mu/wheels/__init__.py
@@ -5,6 +5,7 @@ import os
 import sys
 import glob
 import logging
+import platform
 import subprocess
 
 logger = logging.getLogger(__name__)
@@ -20,6 +21,16 @@ mode_packages = [
     ("qtconsole", "qtconsole==4.7.4"),
     ("nudatus", "nudatus>=0.0.3"),
 ]
+# Temporary app signing workaround https://github.com/mu-editor/mu/issues/1290
+if sys.version_info[:2] == (3, 8) and platform.system() == "Darwin":
+    mode_packages.insert(
+        0,
+        (
+            "pygame",
+            "https://github.com/mu-editor/pygame/releases/download/2.0.1/"
+            "pygame-2.0.1-cp38-cp38-macosx_10_9_intel.whl",
+        ),
+    )
 WHEELS_DIRPATH = os.path.dirname(__file__)
 
 

--- a/mu/wheels/__init__.py
+++ b/mu/wheels/__init__.py
@@ -13,25 +13,35 @@ logger = logging.getLogger(__name__)
 mode_packages = [
     (
         "pgzero",
-        "git+https://github.com/ntoll/pgzero.git@"
-        "5bcfff44fb50a30f9c0194c76099786d9e31d906",
+        "git+https://github.com/mu-editor/pgzero.git@mu-wheel",
     ),
     ("Flask", "flask==1.1.2"),
     ("pyserial", "pyserial==3.4"),
     ("qtconsole", "qtconsole==4.7.4"),
     ("nudatus", "nudatus>=0.0.3"),
 ]
-# Temporary app signing workaround https://github.com/mu-editor/mu/issues/1290
+WHEELS_DIRPATH = os.path.dirname(__file__)
+
+# TODO: Temp app signing workaround https://github.com/mu-editor/mu/issues/1290
 if sys.version_info[:2] == (3, 8) and platform.system() == "Darwin":
-    mode_packages.insert(
-        0,
+    mode_packages = [
         (
             "pygame",
             "https://github.com/mu-editor/pygame/releases/download/2.0.1/"
             "pygame-2.0.1-cp38-cp38-macosx_10_9_intel.whl",
         ),
-    )
-WHEELS_DIRPATH = os.path.dirname(__file__)
+        (
+            "numpy",
+            "numpy==1.20.1",
+        ),
+        (
+            "pgzero",
+            "https://github.com/mu-editor/pgzero/releases/download/mu-wheel/"
+            "pgzero-1.2-py3-none-any.whl",
+            "--no-index",
+            "--find-links=" + WHEELS_DIRPATH,
+        ),
+    ] + mode_packages[1:]
 
 
 def download(dirpath=WHEELS_DIRPATH):
@@ -41,17 +51,27 @@ def download(dirpath=WHEELS_DIRPATH):
     logger.debug("dirpath: %s", dirpath)
 
     #
-    # Clear the directory of any existing wheels (this is especially
-    # important because there may have been wheels left over from a
-    # test with a different Python version)
+    # Clear the directory of any existing wheels and source distributions
+    # (this is especially important because there may have been wheels
+    # left over from a test with a different Python version)
     #
-    for wheel_filepath in glob.glob(os.path.join(dirpath, "*.whl")):
-        logger.debug("Removing %s", wheel_filepath)
-        os.remove(wheel_filepath)
+    rm_files = (
+        glob.glob(os.path.join(dirpath, "*.whl"))
+        + glob.glob(os.path.join(dirpath, "*.gz"))
+        + glob.glob(os.path.join(dirpath, "*.zip"))
+    )
+    for rm_filepath in rm_files:
+        logger.debug("Removing %s", rm_filepath)
+        os.remove(rm_filepath)
 
     logger.debug("mode_packages: %s", mode_packages)
-    for name, pip_identifier in mode_packages:
-        logger.info("Running pip download for %s / %s", name, pip_identifier)
+    for name, pip_identifier, *extra_flags in mode_packages:
+        logger.info(
+            "Running pip download for %s / %s / %s",
+            name,
+            pip_identifier,
+            extra_flags,
+        )
         process = subprocess.run(
             [
                 sys.executable,
@@ -61,7 +81,8 @@ def download(dirpath=WHEELS_DIRPATH):
                 "--destination-directory",
                 dirpath,
                 pip_identifier,
-            ],
+            ]
+            + extra_flags,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             check=True,


### PR DESCRIPTION
More info: https://github.com/mu-editor/mu/issues/1290

Adding this in mu.wheels since it is a lot easier to detect the specific OS and Python version than somewhere else like the Makefile or the CI scripts.
This will use a custom wheel hosted in https://github.com/mu-editor/pygame/releases/tag/2.0.1 

Also updates the CI built executables to use Python 3.8.