### PR TITLE
WIP: Make venv setup more robust

### DIFF
--- a/mu/app.py
+++ b/mu/app.py
@@ -95,7 +95,7 @@ class StartupWorker(QObject):
         Blocking and long running tasks for application startup should be
         called from here.
         """
-        venv.ensure()
+        venv.ensure_and_create()
         self.finished.emit()  # Always called last.
 
 

--- a/mu/settings.py
+++ b/mu/settings.py
@@ -257,7 +257,9 @@ class SessionSettings(SettingsBase):
 
 class VirtualEnvironmentSettings(SettingsBase):
 
-    DEFAULTS = {"baseline_packages": [], "dirpath": config.VENV_DIR}
+    DEFAULTS = {
+        "baseline_packages": [],
+    }
     autosave = True
     filestem = "venv"
 

--- a/mu/virtual_environment.py
+++ b/mu/virtual_environment.py
@@ -286,7 +286,7 @@ class VirtualEnvironment(object):
         self.settings = settings.VirtualEnvironmentSettings()
         self.settings.init()
         dirpath_to_use = (
-            dirpath or self.settings["dirpath"] or self._generate_dirpath()
+            dirpath or self.settings.get("dirpath") or self._generate_dirpath()
         )
         logger.info("Using dirpath: %s", dirpath_to_use)
         self.relocate(dirpath_to_use)

--- a/mu/virtual_environment.py
+++ b/mu/virtual_environment.py
@@ -376,7 +376,7 @@ class VirtualEnvironment(object):
         n_retries = 3
         for n in range(n_retries):
             try:
-                logger.debug("Checking venv; attempt #%d", 1 + n_retries)
+                logger.debug("Checking venv; attempt #%d", 1 + n)
                 self.ensure()
             except VirtualEnvironmentError:
                 logger.debug("Venv not present or correct")
@@ -388,7 +388,15 @@ class VirtualEnvironment(object):
                 break
 
     def ensure(self):
-        """Ensure that a virtual environment exists, creating it if needed"""
+        """Ensure that virtual environment exists and is in a good state"""
+        self.ensure_path()
+        self.ensure_interpreter()
+        self.ensure_interpreter_version()
+        self.ensure_pip()
+        self.ensure_key_modules()
+
+    def ensure_path(self):
+        """Ensure that the virtual environment path exists and is a valid venv"""
         if not os.path.exists(self.path):
             message = "%s does not exist" % self.path
             logger.error(message)
@@ -401,13 +409,7 @@ class VirtualEnvironment(object):
             message = "Directory %s exists but is not a venv" % self.path
             logger.error(message)
             raise VirtualEnvironmentError(message)
-        else:
-            logger.debug("Found existing virtual environment at %s", self.path)
-
-        self.ensure_interpreter()
-        self.ensure_interpreter_version()
-        self.ensure_pip()
-        self.ensure_key_modules()
+        logger.info("Virtual Environment found at %s", self.path)
 
     def ensure_interpreter(self):
         """Ensure there is an interpreter of the expected name at the expected
@@ -509,7 +511,8 @@ class VirtualEnvironment(object):
         self.install_jupyter_kernel()
 
     def install_jupyter_kernel(self):
-        logger.info("Installing Jupyter Kernel")
+        kernel_name = '"Python/Mu ({})"'.format(self.name)
+        logger.info("Installing Jupyter Kernel %s", kernel_name)
         return self.run_python(
             "-m",
             "ipykernel",
@@ -518,7 +521,7 @@ class VirtualEnvironment(object):
             "--name",
             self.name,
             "--display-name",
-            '"Python/Mu ({})"'.format(self.name),
+            kernel_name,
         )
 
     def install_baseline_packages(self):

--- a/mu/virtual_environment.py
+++ b/mu/virtual_environment.py
@@ -288,12 +288,31 @@ class VirtualEnvironment(object):
         self._bin_extension = ".exe" if self._is_windows else ""
         self.settings = settings.VirtualEnvironmentSettings()
         self.settings.init()
-        self.relocate(dirpath or self.settings["dirpath"])
+        dirpath_to_use = dirpath or self.settings["dirpath"] or self._generate_dirpath()
+        logger.info("Using dirpath: %s", dirpath_to_use)
+        self.relocate(dirpath_to_use)
 
     def __str__(self):
         return "<%s at %s>" % (self.__class__.__name__, self.path)
 
+    @staticmethod
+    def _generate_dirpath():
+        """Construct a unique virtual environment folder
+
+        To avoid clashing with previously-created virtual environments,
+        construct one which includes the Python version and a timestamp
+        """
+        return "%s-%s-%s" % (
+            config.VENV_DIR,
+            "%s%s" % sys.version_info[:2],
+            time.strftime("%Y%m%d-%H%M%S")
+        )
+
     def relocate(self, dirpath):
+        """Relocate sets up variables for, eg, the expected location and name of
+        the Python and Pip binaries, but doesn't access the file system. That's
+        done by code in or called from `create`
+        """
         self.path = str(dirpath)
         self.name = os.path.basename(self.path)
         self._bin_directory = os.path.join(
@@ -371,9 +390,22 @@ class VirtualEnvironment(object):
             logger.debug("Found existing virtual environment at %s", self.path)
 
         self.ensure_interpreter()
+        print("#1")
+        self.ensure_interpreter_version()
+        print("#2")
         self.ensure_pip()
+        print("#3")
+        self.ensure_key_modules()
+        print("#4")
 
     def ensure_interpreter(self):
+        """Ensure there is an interpreter of the expected name at the expected
+        location, given the platform and naming conventions
+
+        NB if the interpreter is present as a symlink to a system interpreter (likely
+        for a venv) but the link is broken, then os.path.isfile will fail as though
+        the file wasn't there. Which is what we want in these circumstances
+        """
         if os.path.isfile(self.interpreter):
             logger.info("Interpreter found at %s", self.interpreter)
         else:
@@ -382,6 +414,44 @@ class VirtualEnvironment(object):
             )
             logger.error(message)
             raise VirtualEnvironmentError(message)
+
+    def ensure_interpreter_version(self):
+        """Ensure that the venv interpreter matches the version of Python running Mu
+
+        This is necessary because otherwise we'll have mismatched wheels etc.
+        """
+        current_version = "%s%s" % sys.version_info[:2]
+        print("Current version:", current_version)
+        #
+        # Can't use self.run_python as we're not yet within the Qt UI loop
+        #
+        process = subprocess.run([self.interpreter, "-c", 'import sys; print("%s%s" % sys.version_info[:2])'], stdout=subprocess.PIPE, stderr=subprocess.STDOUT, check=True)
+        venv_version = process.stdout.decode("utf-8").strip()
+        print("Venv version:", venv_version)
+        if current_version == venv_version:
+            logger.info("Both interpreters at version %s", current_version)
+        else:
+            message = (
+                "Current interpreter is at version %s; venv interpreter is at version %s" % (current_version, venv_version)
+            )
+            logger.error(message)
+            raise VirtualEnvironmentError(message)
+
+    def ensure_key_modules(self):
+        """Ensure that the venv interpreter is able to load key modules
+        """
+        #
+        # FIXME: import from wheels.mode_packages
+        #
+        modules = ['pygame', 'pgzero', 'flask', 'xxx']
+        for module in modules:
+            logger.debug("Trying to import %s", module)
+            try:
+                process = subprocess.run([self.interpreter, "-c", 'import %s' % module], stdout=subprocess.PIPE, stderr=subprocess.STDOUT, check=True)
+            except subprocess.CalledProcessError:
+                message = "Failed to import %s" % module
+                logger.error(message)
+                raise VirtualEnvironmentError(message)
 
     def ensure_pip(self):
         if os.path.isfile(self.pip.executable):

--- a/mu/wheels/__init__.py
+++ b/mu/wheels/__init__.py
@@ -10,13 +10,19 @@ import subprocess
 
 logger = logging.getLogger(__name__)
 
+#
+# List of base packages to support modes
+# The first element should be the importable name (so "serial" rather than "pyserial")
+# The second element is passed to `pip download|install`
+# Any additional elements are passed to `pip` for specific purposes
+#
 mode_packages = [
     (
         "pgzero",
         "git+https://github.com/mu-editor/pgzero.git@mu-wheel",
     ),
-    ("Flask", "flask==1.1.2"),
-    ("pyserial", "pyserial==3.4"),
+    ("flask", "flask==1.1.2"),
+    ("serial", "pyserial==3.4"),
     ("qtconsole", "qtconsole==4.7.4"),
     ("nudatus", "nudatus>=0.0.3"),
 ]

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -867,15 +867,18 @@ def test_editor_restore_session_existing_runtime():
     ed = mocked_editor(mode)
     with mock.patch("os.path.isfile", return_value=True):
         with mock.patch.object(venv, "relocate") as venv_relocate:
-            with generate_session(
-                theme,
-                mode,
-                file_contents,
-                microbit_runtime="/foo",
-                zoom_level=5,
-                venv_path="foo",
+            with mock.patch.object(venv, "ensure"), mock.patch.object(
+                venv, "create"
             ):
-                ed.restore_session()
+                with generate_session(
+                    theme,
+                    mode,
+                    file_contents,
+                    microbit_runtime="/foo",
+                    zoom_level=5,
+                    venv_path="foo",
+                ):
+                    ed.restore_session()
 
     assert ed.theme == theme
     assert ed._view.add_tab.call_count == len(file_contents)

--- a/tests/virtual_environment/test_virtual_environment.py
+++ b/tests/virtual_environment/test_virtual_environment.py
@@ -313,10 +313,15 @@ def test_venv_is_singleton():
 def test_venv_folder_created(venv):
     """When not existing venv is ensured we create a new one"""
     os.rmdir(venv.path)
-    with mock.patch.object(VE, "create") as mock_create, mock.patch.object(VE, "ensure", side_effect=mu.virtual_environment.VirtualEnvironmentError()) as mock_ensure:
+    with mock.patch.object(VE, "create") as mock_create, mock.patch.object(
+        VE,
+        "ensure",
+        side_effect=mu.virtual_environment.VirtualEnvironmentError(),
+    ):
         venv.ensure_and_create()
 
     assert mock_create.called
+
 
 def _ensure_venv():
     def _inner_ensure_venv(self, tries=[1, 2, 3]):
@@ -326,11 +331,15 @@ def _ensure_venv():
             raise mu.virtual_environment.VirtualEnvironmentError()
         else:
             return
+
     return _inner_ensure_venv
+
 
 def test_venv_second_try(venv):
     """If the creation of a venv fails to produce a valid venv, try again"""
-    with mock.patch.object(VE, "create") as mock_create, mock.patch.object(VE, "ensure", _ensure_venv()) as mock_ensure:
+    with mock.patch.object(VE, "create") as mock_create, mock.patch.object(
+        VE, "ensure", _ensure_venv()
+    ):
         venv.ensure_and_create()
 
     assert mock_create.call_count == 2
@@ -342,7 +351,9 @@ def test_venv_second_try(venv):
 def test_venv_folder_already_exists(venv):
     """When all ensure tests pass, we have an existing venv so don't create it"""
     open(os.path.join(venv.path, "pyvenv.cfg"), "w").close()
-    with mock.patch.object(VE, "ensure") as mock_ensure, mock.patch.object(VE, "create") as mock_create:
+    with mock.patch.object(VE, "ensure") as mock_ensure, mock.patch.object(
+        VE, "create"
+    ) as mock_create:
         venv.ensure_and_create()
 
     assert not mock_create.called
@@ -387,8 +398,9 @@ def test_ensure_interpreter(venv):
     ):
         venv.ensure_interpreter()
 
+
 def test_ensure_interpreter_version(venv):
-    """When venv interpreter exists but is for a different Python version we raise an exception"""
+    """When venv interpreter exists but for a different Py version raise an exception"""
     mocked_process = mock.MagicMock()
     mocked_process.stdout = b"x.y"
     with mock.patch.object(subprocess, "run", return_value=mocked_process):
@@ -397,12 +409,14 @@ def test_ensure_interpreter_version(venv):
         ):
             venv.ensure_interpreter_version()
 
+
 #
 # Ensure Key Modules
 #
 @pytest.mark.skip("Not sure how to test this one yet")
 def test_ensure_key_modules(venv):
     assert False
+
 
 #
 # Ensure Pip


### PR DESCRIPTION
(fixes #1291)

Initial PoC PR to ensure greater robustness around the venv on startup. Key points:

* First checks whether a venv exists and is a good state
* If not, creates a new venv and checks again
* Doesn't loop any further atm: if the second check fails, Mu will bomb out
* Checks include:
    * Does the venv directory exist? Is it a venv?
    * Is there an interpreter and pip exe where expected?
    * Does the interpreter version (x.y) match the Python x.y Mu is running under?
    * Can we import key modules (pgzero, flask, serial)?
