### PR TITLE
Reduce baudrate when flashing firmware to make it more stable

### DIFF
--- a/mu/interface/dialogs.py
+++ b/mu/interface/dialogs.py
@@ -343,6 +343,7 @@ class ESPFirmwareFlasherWidget(QWidget):
             self.txtFolder.setText(filename)
 
     def update_firmware(self):
+        baudrate = 115200
 
         if self.mode.repl:
             self.mode.toggle_repl(None)
@@ -362,22 +363,24 @@ class ESPFirmwareFlasherWidget(QWidget):
 
         if self.device_type.currentText() == "ESP32":
             write_command = (
-                '"{}" "{}" --chip esp32 --port {} --baud 460800 '
+                '"{}" "{}" --chip esp32 --port {} --baud {} '
                 'write_flash -z 0x1000 "{}"'
             ).format(
                 venv.interpreter,
                 esptool,
                 device.port,
+                baudrate,
                 self.txtFolder.text(),
             )
         else:
             write_command = (
-                '"{}" "{}" --chip esp8266 --port {} --baud 460800 '
+                '"{}" "{}" --chip esp8266 --port {} --baud {} '
                 'write_flash --flash_size=detect 0 "{}"'
             ).format(
                 venv.interpreter,
                 esptool,
                 device.port,
+                baudrate,
                 self.txtFolder.text(),
             )
 


### PR DESCRIPTION
Currently when flashing firmware with our built-in ESP firmware flasher, we use a  medium/high baudrate (460800), which makes it possible to go wrong in some cases. We don't provide the user with the option to try a lower baudrate, in the case it doesn't work.

I'm not sure if we should add a dropdown widget for selecting baudrate, so for now I just think we should lower the baudrate to 115200, where it's most likely to work, and then users will have to wait for the slower process to complete, without the ability to speed it up.