### PR TITLE
Make panes easier to resize (fix for #1298)

### DIFF
--- a/mu/resources/css/contrast.css
+++ b/mu/resources/css/contrast.css
@@ -271,12 +271,14 @@ QDockWidget > QWidget {
     border-bottom: 1px solid #555;   /* Border */
 }
 
-QMainWindow::separator:horizontal {
-    width: 2px;
+QMainWindow::separator:horizontal,
+QMainWindow::separator:vertical {
+    width: 4px;
 }
 
-QMainWindow::separator:vertical {
-    height: 2px;
+QMainWindow::separator:horizontal:hover,
+QMainWindow::separator:vertical:hover {
+    background: white;
 }
 
 QHeaderView::section {

--- a/mu/resources/css/day.css
+++ b/mu/resources/css/day.css
@@ -263,12 +263,14 @@ QDockWidget > QWidget {
     border-bottom: 1px solid #b4b4b4;   /* Border */
 }
 
-QMainWindow::separator:horizontal {
-    width: 2px;
+QMainWindow::separator:horizontal,
+QMainWindow::separator:vertical {
+    width: 4px;
 }
 
-QMainWindow::separator:vertical {
-    height: 2px;
+QMainWindow::separator:horizontal:hover,
+QMainWindow::separator:vertical:hover {
+    background: #d4d4d4;
 }
 
 QHeaderView::section {

--- a/mu/resources/css/night.css
+++ b/mu/resources/css/night.css
@@ -263,12 +263,14 @@ QDockWidget > QWidget {
     border-bottom: 1px solid #6b6b6b;   /* Border */
 }
 
-QMainWindow::separator:horizontal {
-    width: 2px;
+QMainWindow::separator:horizontal,
+QMainWindow::separator:vertical {
+    width: 4px;
 }
 
-QMainWindow::separator:vertical {
-    height: 2px;
+QMainWindow::separator:horizontal:hover,
+QMainWindow::separator:vertical:hover {
+    background: #5c5c5c;
 }
 
 QHeaderView::section {


### PR DESCRIPTION
A fix for #1298, following the idea of @ntoll, where pane-separators are increased in size (from 2px to 4px) and a :hover CSS-rule is added for changing background colors to make the separator easier to see while resizing.
