### PR TITLE
Apply night/contrast themes to Python 3 REPL and REPL for device-modes

### DIFF
--- a/mu/interface/panes.py
+++ b/mu/interface/panes.py
@@ -57,8 +57,8 @@ from PyQt5.QtGui import (
 )
 from qtconsole.rich_jupyter_widget import RichJupyterWidget
 from ..i18n import language_code
-from mu.interface.themes import Font
-from mu.interface.themes import DEFAULT_FONT_SIZE
+from mu.interface.themes import Font, DEFAULT_FONT_SIZE
+from mu.interface.themes import DAY_STYLE, NIGHT_STYLE, CONTRAST_STYLE
 
 
 logger = logging.getLogger(__name__)
@@ -124,11 +124,14 @@ class JupyterREPLPane(RichJupyterWidget):
         Sets the theme / look for the REPL pane.
         """
         if theme == "contrast":
-            self.set_default_style(colors="nocolor")
+            self.style_sheet = CONTRAST_STYLE
+            self.syntax_style = "bw"
         elif theme == "night":
-            self.set_default_style(colors="nocolor")
+            self.style_sheet = NIGHT_STYLE
+            self.syntax_style = "monokai"
         else:
-            self.set_default_style()
+            self.style_sheet = DAY_STYLE
+            self.syntax_style = "default"
 
     def setFocus(self):
         """

--- a/mu/resources/css/contrast.css
+++ b/mu/resources/css/contrast.css
@@ -38,8 +38,8 @@ QListWidget, QTreeView, QTreeView::branch {
 }
 
 QTextEdit, QPlainTextEdit, QLineEdit {
-    background-color: white;
-    color: black;
+    background-color: black;
+    color: white;
     border: 2px solid white;
 }
 

--- a/tests/interface/test_panes.py
+++ b/tests/interface/test_panes.py
@@ -17,6 +17,7 @@ import mu
 import mu.interface.panes
 from mu import i18n
 from mu.interface.panes import CHARTS
+from mu.interface.themes import DAY_STYLE, NIGHT_STYLE, CONTRAST_STYLE
 
 
 def test_PANE_ZOOM_SIZES():
@@ -1420,9 +1421,9 @@ def test_JupyterREPLPane_set_theme_day():
     Make sure the theme is correctly set for day.
     """
     jw = mu.interface.panes.JupyterREPLPane()
-    jw.set_default_style = mock.MagicMock()
     jw.set_theme("day")
-    jw.set_default_style.assert_called_once_with()
+    assert jw.style_sheet == DAY_STYLE
+    assert jw.syntax_style == "default"
 
 
 def test_JupyterREPLPane_set_theme_night():
@@ -1430,9 +1431,9 @@ def test_JupyterREPLPane_set_theme_night():
     Make sure the theme is correctly set for night.
     """
     jw = mu.interface.panes.JupyterREPLPane()
-    jw.set_default_style = mock.MagicMock()
     jw.set_theme("night")
-    jw.set_default_style.assert_called_once_with(colors="nocolor")
+    assert jw.style_sheet == NIGHT_STYLE
+    assert jw.syntax_style == "monokai"
 
 
 def test_JupyterREPLPane_set_theme_contrast():
@@ -1440,9 +1441,9 @@ def test_JupyterREPLPane_set_theme_contrast():
     Make sure the theme is correctly set for high contrast.
     """
     jw = mu.interface.panes.JupyterREPLPane()
-    jw.set_default_style = mock.MagicMock()
     jw.set_theme("contrast")
-    jw.set_default_style.assert_called_once_with(colors="nocolor")
+    assert jw.style_sheet == CONTRAST_STYLE
+    assert jw.syntax_style == "bw"
 
 
 def test_JupyterREPLPane_setFocus():


### PR DESCRIPTION
As mentioned in #970, the REPL pane was not following theme changes, this PR fixes that part of the issue. There's still other problems left in #970, so it's not a complete fix for the issue.