### PR TITLE
Make margins around debugger-marker follow zoom-levels

### DIFF
--- a/mu/interface/editor.py
+++ b/mu/interface/editor.py
@@ -283,6 +283,7 @@ class EditorPane(QsciScintilla):
             "xxl": 16,
             "xxxl": 48,
         }
+        self.zoomTo(sizes[size])
         margins = {
             "xs": 30,
             "s": 35,
@@ -292,8 +293,11 @@ class EditorPane(QsciScintilla):
             "xxl": 75,
             "xxxl": 85,
         }
-        self.zoomTo(sizes[size])
+        # Make the margin left of line numbers follow zoom level
         self.setMarginWidth(0, margins[size])
+        # Make margins around debugger-marker follow zoom level
+        self.setMarginWidth(1, margins[size] * 0.25)
+        self.setMarginWidth(4, margins[size] * 0.1)
 
     @property
     def label(self):

--- a/tests/interface/test_editor.py
+++ b/tests/interface/test_editor.py
@@ -266,7 +266,8 @@ def test_EditorPane_set_zoom():
     ep.setMarginWidth = mock.MagicMock()
     ep.set_zoom("xl")
     ep.zoomTo.assert_called_once_with(8)
-    ep.setMarginWidth.assert_called_once_with(0, 60)
+    ep.setMarginWidth.assert_any_call(0, 60)
+    ep.setMarginWidth.call_count = 3
 
 
 def test_EditorPane_label():


### PR DESCRIPTION
Follow up on #1310 to fix #238