### PR TITLE
Update GH issue templates with links to GH Discussions.

### DIFF
--- a/.github/ISSUE_TEMPLATE/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE/ISSUE_TEMPLATE.md
@@ -1,3 +1,10 @@
+---
+
+name: New Bug Report
+about: Report a problem with the Mu editor.
+
+---
+
 If you are reporting a bug, we would like to know:
 
 * What you were trying to do,

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Request New Features
+    url: https://github.com/mu-editor/mu/discussions/categories/ideas-new-features
+    about: New features are first discussed here.
+  - name: General discussion
+    url: https://github.com/mu-editor/mu/discussions/
+    about: You can talk about anything else in the Discussions section.
+  - name: Tutorials & Guides
+    url: https://codewith.mu
+    about: Have you checked the Mu website for documentation first?


### PR DESCRIPTION
The proposal would be have the initial discussion for new features in the GH Discussions forum, and once we reach agreement to create a GH issue (or to directly create a PR) that we can then track with milestones, as we are currently doing.

The current template is for reporting bugs, which will still be present, and this PR adds links to the issue creation page that point to the GH Discussion section.

This is done via the entries defined in the `config.yml` file, and right now there are links for a feature request, general discussion, and also a link to the website for people  to check the docs.

Even if the conclusion of a feature request will end up as a GH issue, I would recommend not to have a template, so that it doesn't confuse users, and as a way that all feature requests are done in the new place.