### PR TITLE
Prevent creation of multiple venvs during testing

### DIFF
--- a/mu/app.py
+++ b/mu/app.py
@@ -67,8 +67,8 @@ class AnimatedSplash(QSplashScreen):
         """
         Ensure signals are connected and start the animation.
         """
-        self.number_of_log_lines = 3
-        # To hold only the number_of_log_lines of logs to display.
+        self.log_lines = 3
+        # To hold only number of log_lines of logs to display.
         self.log = []
         self.animation = animation
         self.animation.frameChanged.connect(self.set_frame)
@@ -88,12 +88,16 @@ class AnimatedSplash(QSplashScreen):
 
     def draw_log(self, text):
         """
-        Draw the log entries onto the splash screen.
+        Draw the log entries onto the splash screen. Will only display the last
+        self.log_lines number of log entries. The logs will be displayed at the
+        bottom of the splash screen, justified left.
         """
         self.log.append(text)
-        self.log = self.log[-self.number_of_log_lines:]
+        self.log = self.log[-self.log_lines :]
         if self.log:
-            self.showMessage("\n".join(self.log), Qt.AlignBottom | Qt.AlignLeft)
+            self.showMessage(
+                "\n".join(self.log), Qt.AlignBottom | Qt.AlignLeft
+            )
 
 
 class StartupWorker(QObject):

--- a/mu/app.py
+++ b/mu/app.py
@@ -59,16 +59,23 @@ from . import settings
 
 class AnimatedSplash(QSplashScreen):
     """
-    An animated splash screen for gifs.
+    An animated splash screen for gifs. Includes a text area for logging
+    output.
     """
 
     def __init__(self, animation, parent=None):
         """
         Ensure signals are connected and start the animation.
         """
-        super().__init__()
+        self.number_of_log_lines = 3
+        # To hold only the number_of_log_lines of logs to display.
+        self.log = []
         self.animation = animation
         self.animation.frameChanged.connect(self.set_frame)
+        super().__init__(
+            self.animation.currentPixmap(), Qt.WindowStaysOnTopHint
+        )
+        self.setEnabled(False)
         self.animation.start()
 
     def set_frame(self):
@@ -78,6 +85,15 @@ class AnimatedSplash(QSplashScreen):
         pixmap = self.animation.currentPixmap()
         self.setPixmap(pixmap)
         self.setMask(pixmap.mask())
+
+    def draw_log(self, text):
+        """
+        Draw the log entries onto the splash screen.
+        """
+        self.log.append(text)
+        self.log = self.log[-self.number_of_log_lines:]
+        if self.log:
+            self.showMessage("\n".join(self.log), Qt.AlignBottom | Qt.AlignLeft)
 
 
 class StartupWorker(QObject):
@@ -89,6 +105,7 @@ class StartupWorker(QObject):
     """
 
     finished = pyqtSignal()
+    display_text = pyqtSignal(str)
 
     def run(self):
         """
@@ -216,6 +233,7 @@ def run():
     thread.started.connect(worker.run)
     worker.finished.connect(thread.quit)
     worker.finished.connect(worker.deleteLater)
+    worker.display_text.connect(splash.draw_log)
     # Stop the blocking event loop when the thread is finished.
     thread.finished.connect(initLoop.quit)
     thread.finished.connect(thread.deleteLater)

--- a/mu/app.py
+++ b/mu/app.py
@@ -67,7 +67,7 @@ class AnimatedSplash(QSplashScreen):
         """
         Ensure signals are connected and start the animation.
         """
-        self.log_lines = 3
+        self.log_lines = 4
         # To hold only number of log_lines of logs to display.
         self.log = []
         self.animation = animation
@@ -118,7 +118,7 @@ class StartupWorker(QObject):
         Blocking and long running tasks for application startup should be
         called from here.
         """
-        venv.ensure_and_create()
+        venv.ensure_and_create(self.display_text)
         self.finished.emit()  # Always called last.
 
 

--- a/mu/app.py
+++ b/mu/app.py
@@ -72,9 +72,11 @@ class AnimatedSplash(QSplashScreen):
         self.log = []
         self.animation = animation
         self.animation.frameChanged.connect(self.set_frame)
+        # Always on top.
         super().__init__(
             self.animation.currentPixmap(), Qt.WindowStaysOnTopHint
         )
+        # Disable clicks.
         self.setEnabled(False)
         self.animation.start()
 

--- a/mu/virtual_environment.py
+++ b/mu/virtual_environment.py
@@ -47,7 +47,7 @@ class SplashLogHandler(logging.NullHandler):
         timestamp = datetime.datetime.fromtimestamp(record.created)
         messages = record.getMessage().splitlines()
         for msg in messages:
-            output = "[{level}]() - {message}".format(level=record.levelname, timestamp=timestamp, message=msg)
+            output = "[{level}]({timestamp}) - {message}".format(level=record.levelname, timestamp=timestamp, message=msg)
             self.emitter.emit(output)
 
     def handle(self, record):

--- a/mu/virtual_environment.py
+++ b/mu/virtual_environment.py
@@ -47,7 +47,9 @@ class SplashLogHandler(logging.NullHandler):
         timestamp = datetime.datetime.fromtimestamp(record.created)
         messages = record.getMessage().splitlines()
         for msg in messages:
-            output = "[{level}]({timestamp}) - {message}".format(level=record.levelname, timestamp=timestamp, message=msg)
+            output = "[{level}]({timestamp}) - {message}".format(
+                level=record.levelname, timestamp=timestamp, message=msg
+            )
             self.emitter.emit(output)
 
     def handle(self, record):
@@ -405,10 +407,16 @@ class VirtualEnvironment(object):
 
         return False
 
-    def ensure_and_create(self, emitter):
-        splash_handler = SplashLogHandler(emitter)
-        logger.addHandler(splash_handler)
-        logger.info("Added handler")
+    def ensure_and_create(self, emitter=None):
+        """
+        If an emitter is provided, this will be used by a custom log handler
+        to display logging events onto a splash screen.
+        """
+        splash_handler = None
+        if emitter:
+            splash_handler = SplashLogHandler(emitter)
+            logger.addHandler(splash_handler)
+            logger.info("Added handler")
         n_retries = 3
         for n in range(n_retries):
             try:
@@ -422,6 +430,8 @@ class VirtualEnvironment(object):
                 self.create()
             else:
                 break
+        if emitter and splash_handler:
+                logger.removeHandler(splash_handler)
 
     def ensure(self):
         """Ensure that virtual environment exists and is in a good state"""
@@ -432,7 +442,9 @@ class VirtualEnvironment(object):
         self.ensure_key_modules()
 
     def ensure_path(self):
-        """Ensure that the virtual environment path exists and is a valid venv"""
+        """
+        Ensure that the virtual environment path exists and is a valid venv.
+        """
         if not os.path.exists(self.path):
             message = "%s does not exist" % self.path
             logger.error(message)

--- a/mu/virtual_environment.py
+++ b/mu/virtual_environment.py
@@ -416,7 +416,7 @@ class VirtualEnvironment(object):
         if emitter:
             splash_handler = SplashLogHandler(emitter)
             logger.addHandler(splash_handler)
-            logger.info("Added handler")
+            logger.info("Added log handler")
         n_retries = 3
         for n in range(n_retries):
             try:
@@ -431,7 +431,7 @@ class VirtualEnvironment(object):
             else:
                 break
         if emitter and splash_handler:
-                logger.removeHandler(splash_handler)
+            logger.removeHandler(splash_handler)
 
     def ensure(self):
         """Ensure that virtual environment exists and is in a good state"""

--- a/mu/wheels/__init__.py
+++ b/mu/wheels/__init__.py
@@ -22,7 +22,7 @@ mode_packages = [
         "git+https://github.com/mu-editor/pgzero.git@mu-wheel",
     ),
     ("flask", "flask==1.1.2"),
-    ("serial", "pyserial==3.4"),
+    ("serial", "pyserial>=3.0"),
     ("qtconsole", "qtconsole==4.7.4"),
     ("nudatus", "nudatus>=0.0.3"),
     ("esptool", "esptool==3.*"),

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -149,7 +149,9 @@ def test_run():
         "sys.argv", ["mu"]
     ), mock.patch(
         "sys.exit"
-    ) as ex, mock.patch.object(VE, "ensure_and_create") as mock_ensure_and_create:
+    ) as ex, mock.patch.object(
+        VE, "ensure_and_create"
+    ) as mock_ensure_and_create:
         run()
         assert set_log.call_count == 1
         # foo.call_count is instantiating the class
@@ -215,7 +217,9 @@ def test_close_splash_screen():
         "mu.app.QApplication"
     ), mock.patch("sys.exit"), mock.patch("mu.app.Editor"), mock.patch(
         "mu.app.AnimatedSplash", return_value=splash
-    ), mock.patch.object(VE, "ensure_and_create") as mock_ensure_and_create:
+    ), mock.patch.object(
+        VE, "ensure_and_create"
+    ):
         run()
         assert splash.finish.call_count == 1
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -18,6 +18,7 @@ from mu.debugger.config import DEBUGGER_PORT
 from mu.interface.themes import NIGHT_STYLE, DAY_STYLE, CONTRAST_STYLE
 from mu.logic import LOG_FILE, LOG_DIR, ENCODING
 from mu import mu_debug
+from mu.virtual_environment import VirtualEnvironment as VE
 from PyQt5.QtCore import Qt
 
 
@@ -148,7 +149,7 @@ def test_run():
         "sys.argv", ["mu"]
     ), mock.patch(
         "sys.exit"
-    ) as ex:
+    ) as ex, mock.patch.object(VE, "ensure_and_create") as mock_ensure_and_create:
         run()
         assert set_log.call_count == 1
         # foo.call_count is instantiating the class
@@ -165,6 +166,7 @@ def test_run():
         assert win.call_count == 1
         assert len(win.mock_calls) == 6
         assert ex.call_count == 1
+        assert mock_ensure_and_create.call_count == 1
         window.load_theme.emit("day")
         qa.assert_has_calls([mock.call().setStyleSheet(DAY_STYLE)])
         window.load_theme.emit("night")
@@ -213,7 +215,7 @@ def test_close_splash_screen():
         "mu.app.QApplication"
     ), mock.patch("sys.exit"), mock.patch("mu.app.Editor"), mock.patch(
         "mu.app.AnimatedSplash", return_value=splash
-    ):
+    ), mock.patch.object(VE, "ensure_and_create") as mock_ensure_and_create:
         run()
         assert splash.finish.call_count == 1
 

--- a/tests/virtual_environment/test_virtual_environment.py
+++ b/tests/virtual_environment/test_virtual_environment.py
@@ -36,6 +36,7 @@ PIP = mu.virtual_environment.Pip
 HERE = os.path.dirname(__file__)
 WHEEL_FILENAME = "arrr-1.0.2-py3-none-any.whl"
 
+
 @pytest.fixture
 def venv_name():
     """Use a random venv name each time, at least partly to expose any

--- a/tests/virtual_environment/test_virtual_environment.py
+++ b/tests/virtual_environment/test_virtual_environment.py
@@ -36,7 +36,6 @@ PIP = mu.virtual_environment.Pip
 HERE = os.path.dirname(__file__)
 WHEEL_FILENAME = "arrr-1.0.2-py3-none-any.whl"
 
-
 @pytest.fixture
 def venv_name():
     """Use a random venv name each time, at least partly to expose any


### PR DESCRIPTION
Sort out a problem creating venvs (clashing version of pyserial)
Plus ensure that no real venvs are created in Mu's standard data dir