### PR TITLE
Mock out venvs

### DIFF
--- a/mu/virtual_environment.py
+++ b/mu/virtual_environment.py
@@ -385,7 +385,11 @@ class VirtualEnvironment(object):
                 self.relocate(new_dirpath)
                 self.create()
             else:
-                break
+                return
+
+        raise VirtualEnvironmentError(
+            "Unable to create a working virtual environment"
+        )
 
     def ensure(self):
         """Ensure that virtual environment exists and is in a good state"""

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -18,6 +18,7 @@ from mu.debugger.config import DEBUGGER_PORT
 from mu.interface.themes import NIGHT_STYLE, DAY_STYLE, CONTRAST_STYLE
 from mu.logic import LOG_FILE, LOG_DIR, ENCODING
 from mu import mu_debug
+from mu.virtual_environment import VirtualEnvironment as VE
 from PyQt5.QtCore import Qt
 
 
@@ -148,7 +149,9 @@ def test_run():
         "sys.argv", ["mu"]
     ), mock.patch(
         "sys.exit"
-    ) as ex:
+    ) as ex, mock.patch.object(
+        VE, "ensure_and_create"
+    ) as mock_ensure_and_create:
         run()
         assert set_log.call_count == 1
         # foo.call_count is instantiating the class
@@ -165,6 +168,7 @@ def test_run():
         assert win.call_count == 1
         assert len(win.mock_calls) == 6
         assert ex.call_count == 1
+        assert mock_ensure_and_create.call_count == 1
         window.load_theme.emit("day")
         qa.assert_has_calls([mock.call().setStyleSheet(DAY_STYLE)])
         window.load_theme.emit("night")
@@ -213,6 +217,8 @@ def test_close_splash_screen():
         "mu.app.QApplication"
     ), mock.patch("sys.exit"), mock.patch("mu.app.Editor"), mock.patch(
         "mu.app.AnimatedSplash", return_value=splash
+    ), mock.patch.object(
+        VE, "ensure_and_create"
     ):
         run()
         assert splash.finish.call_count == 1

--- a/tests/virtual_environment/test_virtual_environment.py
+++ b/tests/virtual_environment/test_virtual_environment.py
@@ -31,6 +31,7 @@ import mu.virtual_environment
 import mu.wheels
 
 VE = mu.virtual_environment.VirtualEnvironment
+VEError = mu.virtual_environment.VirtualEnvironmentError
 PIP = mu.virtual_environment.Pip
 
 HERE = os.path.dirname(__file__)
@@ -189,7 +190,7 @@ def test_download_wheels_if_not_present(venv, test_wheels):
         # Ignore the exception which will arise from not actually
         # downloading any wheels!
         #
-        except mu.virtual_environment.VirtualEnvironmentError:
+        except VEError:
             pass
 
     assert mock_download.called
@@ -312,9 +313,7 @@ def test_venv_is_singleton():
 
 def _ensure_venv(results):
     def _inner_ensure_venv(self, results=results):
-        print("_inner_ensure_venv called with", results)
         result = results.pop()
-        print("Using result", result)
         if isinstance(result, Exception):
             raise result
         else:
@@ -329,7 +328,7 @@ def test_venv_folder_created(venv):
     with mock.patch.object(VE, "create") as mock_create, mock.patch.object(
         VE,
         "ensure",
-        _ensure_venv([True, mu.virtual_environment.VirtualEnvironmentError()]),
+        _ensure_venv([True, VEError()]),
     ):
         venv.ensure_and_create()
 
@@ -341,7 +340,7 @@ def test_venv_second_try(venv):
     with mock.patch.object(VE, "create") as mock_create, mock.patch.object(
         VE,
         "ensure",
-        _ensure_venv([True, mu.virtual_environment.VirtualEnvironmentError()]),
+        _ensure_venv([True, VEError()]),
     ):
         venv.ensure_and_create()
 
@@ -350,12 +349,12 @@ def test_venv_second_try(venv):
 
 def test_venv_fails_after_three_tries(venv):
     """If the venv fails to ensure after three tries we raise an exception"""
-    with mock.patch.object(VE, "create") as mock_create, mock.patch.object(
+    with mock.patch.object(VE, "create"), mock.patch.object(
         VE,
         "ensure",
-        _ensure_venv([mu.virtual_environment.VirtualEnvironmentError(), mu.virtual_environment.VirtualEnvironmentError(), mu.virtual_environment.VirtualEnvironmentError()]),
+        _ensure_venv([VEError(), VEError(), VEError()]),
     ):
-        with pytest.raises(mu.virtual_environment.VirtualEnvironmentError):
+        with pytest.raises(VEError):
             venv.ensure_and_create()
 
 
@@ -377,7 +376,7 @@ def test_venv_folder_already_exists(venv):
 def test_venv_folder_does_not_exist(venv):
     """When venv_folder does exist not at all we raise an error"""
     os.rmdir(venv.path)
-    with pytest.raises(mu.virtual_environment.VirtualEnvironmentError):
+    with pytest.raises(VEError):
         venv.ensure_path()
 
 
@@ -385,7 +384,7 @@ def test_venv_folder_already_exists_not_venv(venv):
     """When venv_folder does exist not as a venv ensure we raise an error"""
     assert not os.path.isfile(os.path.join(venv.path, "pyvenv.cfg"))
     assert not os.path.isfile(venv.interpreter)
-    with pytest.raises(mu.virtual_environment.VirtualEnvironmentError):
+    with pytest.raises(VEError):
         venv.ensure_path()
 
 
@@ -396,7 +395,7 @@ def test_venv_folder_already_exists_not_directory(venv_dirpath):
     os.rmdir(venv_dirpath)
     open(venv_dirpath, "w").close()
     venv = mu.virtual_environment.VirtualEnvironment(venv_dirpath)
-    with pytest.raises(mu.virtual_environment.VirtualEnvironmentError):
+    with pytest.raises(VEError):
         venv.ensure_path()
 
 
@@ -407,9 +406,7 @@ def test_ensure_interpreter(venv):
     """When venv exists but has no interpreter ensure we raise an exception"""
     assert not os.path.isfile(venv.interpreter)
 
-    with pytest.raises(
-        mu.virtual_environment.VirtualEnvironmentError, match="Interpreter"
-    ):
+    with pytest.raises(VEError, match="[Ii]nterpreter"):
         venv.ensure_interpreter()
 
 
@@ -418,9 +415,7 @@ def test_ensure_interpreter_version(venv):
     mocked_process = mock.MagicMock()
     mocked_process.stdout = b"x.y"
     with mock.patch.object(subprocess, "run", return_value=mocked_process):
-        with pytest.raises(
-            mu.virtual_environment.VirtualEnvironmentError, match="interpreter"
-        ):
+        with pytest.raises(VEError, match="[Ii]nterpreter"):
             venv.ensure_interpreter_version()
 
 
@@ -439,9 +434,7 @@ def test_ensure_pip(venv):
     """When venv exists but has no interpreter ensure we raise an exception"""
     assert not os.path.isfile(venv.interpreter)
 
-    with pytest.raises(
-        mu.virtual_environment.VirtualEnvironmentError, match="Pip"
-    ):
+    with pytest.raises(VEError, match="Pip"):
         venv.ensure_pip()
 
 


### PR DESCRIPTION
Ensure that no venvs are created in the standard location during testing
Also make sure that if we fail to create a valid venv after three tries we fail noisily