### PR TITLE
WiP: Move child process shutdown from modes to PythonProcessPane

### DIFF
--- a/mu/interface/panes.py
+++ b/mu/interface/panes.py
@@ -936,6 +936,18 @@ class PythonProcessPane(QTextEdit):
             self.process.start(interpreter, args)
             self.running = True
 
+    def stop_process(self):
+        if self.process:
+            self.process.terminate()
+            terminated = self.process.waitForFinished(10)
+            if not terminated:
+                self.process.kill()
+                self.process.waitForFinished()
+            self.running = False
+
+    def _del_(self):
+        self.stop_process()
+
     def finished(self, code, status):
         """
         Handle when the child process finishes.

--- a/mu/modes/debugger.py
+++ b/mu/modes/debugger.py
@@ -147,8 +147,7 @@ class DebugMode(BaseMode):
         """
         logger.debug("Stopping debugger.")
         if self.runner:
-            self.runner.process.kill()
-            self.runner.process.waitForFinished()
+            self.runner.stop_process()
             self.runner = None
             self.debugger = None
             self.view.remove_python_runner()

--- a/mu/modes/pygamezero.py
+++ b/mu/modes/pygamezero.py
@@ -162,8 +162,7 @@ class PyGameZeroMode(BaseMode):
         """
         logger.debug("Stopping script.")
         if self.runner:
-            self.runner.process.kill()
-            self.runner.process.waitForFinished()
+            self.runner.stop_process()
             self.runner = None
         self.view.remove_python_runner()
 

--- a/mu/modes/python3.py
+++ b/mu/modes/python3.py
@@ -256,8 +256,7 @@ class PythonMode(BaseMode):
         """
         logger.debug("Stopping script.")
         if self.runner:
-            self.runner.process.kill()
-            self.runner.process.waitForFinished()
+            self.runner.stop_process()
             self.runner = None
         self.view.remove_python_runner()
         self.set_buttons(plotter=True, repl=True)

--- a/mu/modes/web.py
+++ b/mu/modes/web.py
@@ -19,7 +19,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import os
 import logging
 import webbrowser
-import signal
 from mu.modes.base import BaseMode
 from mu.modes.api import PYTHON3_APIS, SHARED_APIS, FLASK_APIS
 from mu.resources import load_icon
@@ -192,16 +191,7 @@ class WebMode(BaseMode):
         """
         logger.debug("Stopping Flask app.")
         if self.runner:
-            try:
-                pid = self.runner.process.processId()
-                os.kill(pid, signal.SIGINT)
-            except Exception as ex:
-                # Couldn't kill child process. Perhaps it's already finished
-                # because it encountered an error. In any case, log this for
-                # debugging purposes.
-                logger.error("Problem stopping local web server.")
-                logger.error(ex)
-            self.runner.process.waitForFinished()
+            self.runner.stop_process()
             self.runner = None
         self.view.remove_python_runner()
 

--- a/tests/interface/test_panes.py
+++ b/tests/interface/test_panes.py
@@ -1682,6 +1682,31 @@ def test_PythonProcessPane_start_process_custom_python_args():
     ppp.process.start.assert_called_once_with(runner, expected_args)
 
 
+def test_PythonProcessPane_stop_process():
+    """
+    Ensure that a process is terminated on PythonProcessPane.stop_process
+    """
+    ppp = mu.interface.panes.PythonProcessPane()
+    ppp.process = mock.MagicMock()
+    ppp.stop_process()
+    ppp.process.terminate.assert_called_once_with()
+    ppp.process.waitForFinished.assert_called_once_with(10)
+
+
+def test_PythonProcessPane_stop_process_with_error():
+    """
+    If killing the child process encounters a problem (perhaps the
+    process is already dead), then log this and tidy up.
+    """
+    ppp = mu.interface.panes.PythonProcessPane()
+    ppp.process = mock.MagicMock()
+    ppp.process.waitForFinished.return_value = False
+    ppp.stop_process()
+    ppp.process.terminate.assert_called_once_with()
+    ppp.process.kill.assert_called_once_with()
+    ppp.process.waitForFinished.call_count == 2
+
+
 def test_PythonProcessPane_finished():
     """
     Check the functionality to handle the process finishing is correct.

--- a/tests/modes/test_debug.py
+++ b/tests/modes/test_debug.py
@@ -118,8 +118,7 @@ def test_debug_stop():
     dm.stop()
     assert dm.runner is None
     assert dm.debugger is None
-    mock_runner.process.kill.assert_called_once_with()
-    mock_runner.process.waitForFinished.assert_called_once_with()
+    mock_runner.stop_process.assert_called_once_with()
     view.remove_python_runner.assert_called_once_with()
     view.remove_debug_inspector.assert_called_once_with()
     editor.change_mode.assert_called_once_with("python")

--- a/tests/modes/test_pygamezero.py
+++ b/tests/modes/test_pygamezero.py
@@ -177,8 +177,7 @@ def test_pgzero_stop_game():
     mock_runner = mock.MagicMock()
     pm.runner = mock_runner
     pm.stop_game()
-    mock_runner.process.kill.assert_called_once_with()
-    mock_runner.process.waitForFinished.assert_called_once_with()
+    mock_runner.stop_process.assert_called_once_with()
     assert pm.runner is None
     view.remove_python_runner.assert_called_once_with()
 

--- a/tests/modes/test_python3.py
+++ b/tests/modes/test_python3.py
@@ -297,8 +297,7 @@ def test_python_stop_script():
     mock_runner = mock.MagicMock()
     pm.runner = mock_runner
     pm.stop_script()
-    mock_runner.process.kill.assert_called_once_with()
-    mock_runner.process.waitForFinished.assert_called_once_with()
+    mock_runner.stop_process.assert_called_once_with()
     assert pm.runner is None
 
 

--- a/tests/modes/test_web.py
+++ b/tests/modes/test_web.py
@@ -3,7 +3,6 @@
 Tests for the flask based web mode.
 """
 import os
-import signal
 from mu.modes.web import WebMode, CODE_TEMPLATE
 from mu.modes.api import PYTHON3_APIS, SHARED_APIS, FLASK_APIS
 from unittest import mock
@@ -161,34 +160,9 @@ def test_stop_server():
     view = mock.MagicMock()
     wm = WebMode(editor, view)
     mock_runner = mock.MagicMock()
-    mock_runner.process.processId.return_value = 666  # ;-)
     wm.runner = mock_runner
-    with mock.patch("os.kill") as mock_kill:
-        wm.stop_server()
-        mock_kill.assert_called_once_with(666, signal.SIGINT)
-    mock_runner.process.waitForFinished.assert_called_once_with()
-    assert wm.runner is None
-    view.remove_python_runner.assert_called_once_with()
-
-
-def test_stop_server_with_error():
-    """
-    If killing the server's child process encounters a problem (perhaps the
-    process is already dead), then log this and tidy up.
-    """
-    editor = mock.MagicMock()
-    view = mock.MagicMock()
-    wm = WebMode(editor, view)
-    mock_runner = mock.MagicMock()
-    mock_runner.process.processId.return_value = 666  # ;-)
-    wm.runner = mock_runner
-    with mock.patch(
-        "os.kill", side_effect=Exception("Bang")
-    ) as mock_kill, mock.patch("mu.modes.web.logger.error") as mock_log:
-        wm.stop_server()
-        mock_kill.assert_called_once_with(666, signal.SIGINT)
-        assert mock_log.call_count == 2
-    mock_runner.process.waitForFinished.assert_called_once_with()
+    wm.stop_server()
+    mock_runner.stop_process.assert_called_once_with()
     assert wm.runner is None
     view.remove_python_runner.assert_called_once_with()
 


### PR DESCRIPTION
This is work in progress and needs to be tested across platforms. The goal is to solve both #1004 and #1236