### PR TITLE
Ensure modes terminate the threads they use for flashing/file system operations before Mu quits

### DIFF
--- a/mu/modes/esp.py
+++ b/mu/modes/esp.py
@@ -38,6 +38,8 @@ class ESPMode(MicroPythonMode):
     description = _("Write MicroPython on ESP8266/ESP32 boards.")
     icon = "esp"
     fs = None
+    file_manager = None
+    file_manager_thread = None
 
     # The below list defines the supported devices, however, many
     # devices are using the exact same FTDI USB-interface, with vendor
@@ -268,6 +270,11 @@ class ESPMode(MicroPythonMode):
         """
         self.view.remove_filesystem()
         self.file_manager = None
+        if self.file_manager_thread:
+            self.file_manager_thread.quit()
+            if not self.file_manager_thread.wait(1):
+                self.file_manager_thread.terminate()
+                self.file_manager_thread.wait()
         self.file_manager_thread = None
         self.fs = None
 
@@ -295,3 +302,10 @@ class ESPMode(MicroPythonMode):
         if self.fs:
             self.remove_fs()
             self.add_fs()
+
+    def stop(self):
+        """
+        Destructor: Make sure any file manager threads are closed if necessary
+        """
+        super().stop()
+        self.remove_fs()

--- a/mu/modes/microbit.py
+++ b/mu/modes/microbit.py
@@ -113,6 +113,8 @@ class MicrobitMode(MicroPythonMode):
     description = _("Write MicroPython for the BBC micro:bit.")
     icon = "microbit"
     fs = None  #: Reference to filesystem navigator.
+    file_manager = None
+    file_manager_thread = None
     flash_thread = None
     file_extensions = ["hex"]
 
@@ -610,6 +612,11 @@ class MicrobitMode(MicroPythonMode):
         """
         self.view.remove_filesystem()
         self.file_manager = None
+        if self.file_manager_thread:
+            self.file_manager_thread.quit()
+            if not self.file_manager_thread.wait(1):
+                self.file_manager_thread.terminate()
+                self.file_manager_thread.wait()
         self.file_manager_thread = None
         self.fs = None
 
@@ -655,3 +662,18 @@ class MicrobitMode(MicroPythonMode):
         if self.fs:
             self.remove_fs()
             self.add_fs()
+
+    def stop(self):
+        """
+        Destructor: Make sure any file manager and flasher threads are
+        closed if necessary
+        """
+        super().stop()
+        # Remove FS closes the file manager thread
+        self.remove_fs()
+        # Close flashing thread
+        if self.flash_thread:
+            self.flash_thread.quit()
+            if not self.flash_thread.wait(1):
+                self.flash_thread.terminate()
+                self.flash_thread.wait()

--- a/tests/modes/test_microbit.py
+++ b/tests/modes/test_microbit.py
@@ -1044,18 +1044,49 @@ def test_add_fs_no_device():
     assert view.show_message.call_count == 1
 
 
-def test_remove_fs():
+@mock.patch("mu.modes.microbit.FileManager")
+def test_remove_fs(fm):
     """
-    Removing the file system results in the expected state.
+    Removing the file system shuts down the file manager thread and
+    results in the expected state.
+
     """
     view = mock.MagicMock()
-    view.remove_repl = mock.MagicMock()
     editor = mock.MagicMock()
     mm = MicrobitMode(editor, view)
-    mm.fs = True
-    mm.remove_fs()
-    assert view.remove_filesystem.call_count == 1
-    assert mm.fs is None
+
+    mock_qthread = mock.MagicMock()
+    mock_qthread_class = mock.MagicMock(return_value=mock_qthread)
+
+    with mock.patch("mu.modes.microbit.QThread", mock_qthread_class):
+        mm.add_fs()
+        mm.remove_fs()
+        mock_qthread.quit.assert_called_once_with()
+        assert mm.view.remove_filesystem.call_count == 1
+        assert mm.fs is None
+        assert mm.file_manager is None
+        assert mm.file_manager_thread is None
+
+
+@mock.patch("mu.modes.microbit.FileManager")
+def test_remove_fs_terminates_thread(fm):
+    """
+    If the file manager thread doesn't quit by itself, we will terminate it
+    """
+    view = mock.MagicMock()
+    editor = mock.MagicMock()
+    mm = MicrobitMode(editor, view)
+
+    mock_qthread = mock.MagicMock()
+    mock_qthread_class = mock.MagicMock(return_value=mock_qthread)
+    mock_qthread.wait = mock.MagicMock(return_value=False)
+
+    with mock.patch("mu.modes.microbit.QThread", mock_qthread_class):
+        mm.add_fs()
+        mm.remove_fs()
+        mock_qthread.quit.assert_called_once_with()
+        mock_qthread.terminate.assert_called_once_with()
+        mock_qthread.wait.call_count == 2
 
 
 def test_toggle_files_on():
@@ -1373,3 +1404,46 @@ def test_device_changed(microbit):
     mm.device_changed(microbit)
     mm.remove_fs.assert_called_once_with()
     mm.add_fs.assert_called_once_with()
+
+
+def test_stop(microbit):
+    """
+    Check that invoking stop remove the file system pane and thus
+    shutsdown the file manager thread
+    """
+    view = mock.MagicMock()
+    editor = mock.MagicMock()
+    mm = MicrobitMode(editor, view)
+    mm.remove_fs = mock.MagicMock()
+
+    mock_flash_thread = mock.MagicMock()
+    with mock.patch(
+        "mu.modes.microbit.DeviceFlasher", return_value=mock_flash_thread
+    ):
+        mm.flash_attached("pass", "/path/to/microbit/mount/")
+        mm.stop()
+        mock_flash_thread.quit.assert_called_once_with()
+
+    mm.remove_fs.assert_called_once_with()
+
+
+def test_stop_terminates_thread(microbit):
+    """
+    Check that invoking stop remove the file system pane and thus
+    shutsdown the file manager thread
+    """
+    view = mock.MagicMock()
+    editor = mock.MagicMock()
+    mm = MicrobitMode(editor, view)
+    mm.remove_fs = mock.MagicMock()
+
+    mock_flash_thread = mock.MagicMock()
+    mock_flash_thread.wait = mock.MagicMock(return_value=False)
+    with mock.patch(
+        "mu.modes.microbit.DeviceFlasher", return_value=mock_flash_thread
+    ):
+        mm.flash_attached("pass", "/path/to/microbit/mount/")
+        mm.stop()
+        mock_flash_thread.quit.assert_called_once_with()
+        mock_flash_thread.terminate.assert_called_once_with()
+        mock_flash_thread.wait.call_count == 2


### PR DESCRIPTION
This is a fix for issue #1321, where both micro:bit and ESP-mode didn't properly close the threads that they opened.