### PR TITLE
Update bug report template to make log collapsible

### DIFF
--- a/.github/ISSUE_TEMPLATE/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE/ISSUE_TEMPLATE.md
@@ -15,9 +15,16 @@ If you are reporting a bug, we would like to know:
 * Technical details like the version of Mu you're using, your OS version and
   other aspects of the context in which Mu was running. 
 
-Please remember to attach a **copy of the full log files for Mu**. You can get
+<!-- Please remember to add a **copy of the full log files for Mu** below. You can get
 the logs by clicking on the cog icon in the bottom right of the editor window.
 Click on the logs and use CTRL-A to select all, then CTRL-C to copy and CTRL-V
-to paste the contents into the issue.
+to paste the contents into the issue. -->
+
+<details>
+  <summary> Mu Log Files </summary>
+  <pre>
+  Replace me with your logs...
+  </pre>
+</details
 
 Thank you for contributing to Mu! :-)


### PR DESCRIPTION
The log file can get quite long. I edited the issue template to have the reporter put the log file in a `<details>` tag, which makes it collapsible.

Example of the details tag in action below:

<details>
<summary>Summary of hidden content</summary>
Hidden text
</details>

Here's how it's used:
```html
<details>
<summary>Summary of hidden content</summary>
Hidden text
</details>
```