### PR TITLE
Isolate assets used in the splash screen away from the main program.

### DIFF
--- a/mu/app.py
+++ b/mu/app.py
@@ -289,10 +289,7 @@ def run():
     app.setApplicationVersion(__version__)
     app.setAttribute(Qt.AA_DontShowIconsInMenus)
 
-    # Create the "window" we'll be looking at.
-    editor_window = Window()
-
-    def splash_context(app=app, editor_window=editor_window):
+    def splash_context():
         """
         Function context (to ensure garbage collection) for displaying the
         splash screen.
@@ -300,7 +297,6 @@ def run():
         # Display a friendly "splash" icon.
         splash = AnimatedSplash(load_movie("splash_screen"))
         splash.show()
-        app.processEvents()
 
         # Create a blocking thread upon which to run the StartupWorker and which
         # will process the events for animating the splash screen.
@@ -318,10 +314,13 @@ def run():
         thread.finished.connect(thread.deleteLater)
         thread.start()
         initLoop.exec()  # start processing the pending StartupWorker.
-        splash.finish(editor_window)
+        splash.close()
         splash.deleteLater()
 
     splash_context()
+
+    # Create the "window" we'll be looking at.
+    editor_window = Window()
 
     @editor_window.load_theme.connect
     def load_theme(theme):

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -248,9 +248,9 @@ def test_run():
         assert qa.call_count == 1
         # foo.mock_calls are method calls on the object
         if hasattr(Qt, "AA_EnableHighDpiScaling"):
-            assert len(qa.mock_calls) == 10
-        else:
             assert len(qa.mock_calls) == 9
+        else:
+            assert len(qa.mock_calls) == 8
         assert qsp.call_count == 1
         assert len(qsp.mock_calls) == 4
         assert ed.call_count == 1
@@ -312,7 +312,7 @@ def test_close_splash_screen():
         VE, "ensure_and_create"
     ):
         run()
-        assert splash.finish.call_count == 1
+        assert splash.close.call_count == 1
 
 
 def test_excepthook():


### PR DESCRIPTION
To ensure nothing in the main program is referenced from the splash screen code.