### PR TITLE
Pip fail2

### DIFF
--- a/mu/app.py
+++ b/mu/app.py
@@ -224,7 +224,7 @@ def setup_logging():
     log = logging.getLogger()
     log.setLevel(logging.DEBUG)
     log.addHandler(handler)
-    # ~ log.addHandler(stdout_handler)
+    log.addHandler(stdout_handler)
     sys.excepthook = excepthook
 
 

--- a/mu/app.py
+++ b/mu/app.py
@@ -122,7 +122,7 @@ class AnimatedSplash(QSplashScreen):
         lines = text.split("\n")
         lines.append(
             "This screen will close in a few seconds. "
-            + "Then a crash report tool will open in your browser."
+            "Then a crash report tool will open in your browser."
         )
         lines = lines[-12:]
         self.draw_text("\n".join(lines))
@@ -224,7 +224,7 @@ def setup_logging():
     log = logging.getLogger()
     log.setLevel(logging.DEBUG)
     log.addHandler(handler)
-    log.addHandler(stdout_handler)
+    # log.addHandler(stdout_handler)
     sys.excepthook = excepthook
 
 

--- a/mu/virtual_environment.py
+++ b/mu/virtual_environment.py
@@ -159,7 +159,7 @@ class Process(QObject):
         partial = functools.partial(self.process.start, command, args)
         logger.debug("partial: %r", partial)
         QTimer.singleShot(
-            100,
+            1,
             partial,
         )
 

--- a/mu/virtual_environment.py
+++ b/mu/virtual_environment.py
@@ -110,35 +110,18 @@ class Process(QObject):
 
     def _set_up_run(self, **envvars):
         """Run the process with the command and args"""
-        logger.debug("_set_up_run#0 with envvars %s", envvars)
         self.process = QProcess()
-        logger.debug("_set_up_run#1")
         environment = QProcessEnvironment(self.environment)
-        logger.debug("_set_up_run#2")
         for k, v in envvars.items():
             environment.insert(k, v)
-        logger.debug("_set_up_run#3")
         self.process.setProcessEnvironment(environment)
-        logger.debug("_set_up_run#4")
         self.process.setProcessChannelMode(QProcess.MergedChannels)
-        logger.debug("_set_up_run#5")
 
     def run_blocking(self, command, args, wait_for_s=30.0, **envvars):
-        logger.debug(
-            "run_blocking#0 with command %s, args %s, wait_for %s, envvars %s",
-            command,
-            args,
-            wait_for_s,
-            envvars,
-        )
         self._set_up_run(**envvars)
-        logger.debug("run_blocking#1")
         self.process.start(command, args)
-        logger.debug("run_blocking#2")
         self.wait(wait_for_s=wait_for_s)
-        logger.debug("run_blocking#3")
         output = self.data()
-        logger.debug("run_blocking#4")
         return output
 
     def run(self, command, args, **envvars):
@@ -153,7 +136,6 @@ class Process(QObject):
         self.process.started.connect(self._started)
         self.process.finished.connect(self._finished)
         partial = functools.partial(self.process.start, command, args)
-        logger.debug("partial: %r", partial)
         QTimer.singleShot(
             1,
             partial,
@@ -222,20 +204,11 @@ class Pip(object):
         params.extend(args)
 
         if slots.output is None:
-            logger.debug(
-                "About to run blocking: %s, %s, %s",
-                self.executable,
-                params,
-                wait_for_s,
-            )
             result = self.process.run_blocking(
                 self.executable, params, wait_for_s=wait_for_s
             )
             return result
         else:
-            logger.debug(
-                "About to run unblocking: %s, %s", self.executable, params
-            )
             if slots.started:
                 self.process.started.connect(slots.started)
             self.process.output.connect(slots.output)
@@ -253,7 +226,6 @@ class Pip(object):
         Any kwargs are passed as command-line switches. A value of None
         indicates a switch without a value (eg --upgrade)
         """
-        logger.debug("About to pip install: %r", packages)
         if isinstance(packages, str):
             return self.run(
                 "install", packages, wait_for_s=180.0, slots=slots, **kwargs
@@ -273,7 +245,6 @@ class Pip(object):
         Any kwargs are passed as command-line switches. A value of None
         indicates a switch without a value (eg --upgrade)
         """
-        logger.debug("About to pip uninstall: %r", packages)
         if isinstance(packages, str):
             return self.run(
                 "uninstall",
@@ -419,7 +390,6 @@ class VirtualEnvironment(object):
         headless and the process will be run synchronously and output collected
         will be returned when the process is complete
         """
-        logger.debug("run_python with args %s and slots %s", args, slots)
         if slots.output:
             if slots.started:
                 self.process.started.connect(slots.started)
@@ -470,17 +440,13 @@ class VirtualEnvironment(object):
                     "Checking virtual environment; attempt #%d.", 1 + n
                 )
                 self.ensure()
-                logger.debug("ensure_and_create#1")
             except VirtualEnvironmentError:
-                logger.debug("Virtual environment not present or correct.")
                 new_dirpath = self._generate_dirpath()
                 logger.debug(
                     "Creating new virtual environment at %s.", new_dirpath
                 )
                 self.relocate(new_dirpath)
-                logger.debug("ensure_and_create#2a")
                 self.create()
-                logger.debug("ensure_and_create#2b")
             else:
                 logger.info("Virtual environment already exists.")
                 return
@@ -498,17 +464,11 @@ class VirtualEnvironment(object):
         """
         Ensure that virtual environment exists and is in a good state.
         """
-        logger.debug("ensure#1")
         self.ensure_path()
-        logger.debug("ensure#2")
         self.ensure_interpreter()
-        logger.debug("ensure#3")
         self.ensure_interpreter_version()
-        logger.debug("ensure#4")
         self.ensure_pip()
-        logger.debug("ensure#5")
         self.ensure_key_modules()
-        logger.debug("ensure#6")
 
     def ensure_path(self):
         """
@@ -715,7 +675,6 @@ class VirtualEnvironment(object):
         Install user defined packages.
         """
         logger.info("Installing user packages: %s", ", ".join(packages))
-        logger.debug("Slots: %s", slots)
         self.reset_pip()
         self.pip.install(
             packages,
@@ -728,7 +687,6 @@ class VirtualEnvironment(object):
         Remove user defined packages.
         """
         logger.info("Removing user packages: %s", ", ".join(packages))
-        logger.debug("Slots: %s", slots)
         self.reset_pip()
         self.pip.uninstall(
             packages,

--- a/tests/virtual_environment/test_virtual_environment.py
+++ b/tests/virtual_environment/test_virtual_environment.py
@@ -494,3 +494,26 @@ def test_run_python_nonblocking(venv):
         venv.run_python(*args, slots=venv.Slots(output=lambda x: x))
 
     mocked_start.assert_called_with(command, args)
+
+
+def test_reset_pip(venv, pipped):
+    """Ensure that we're using a new Pip object for every invocation"""
+    n_tries = random.randint(1, 5)
+    for i in range(n_tries):
+        venv.reset_pip()
+    assert pipped.call_count == n_tries
+
+
+def test_reset_pip_used(venv_dirpath):
+    with mock.patch("mu.virtual_environment.Pip") as mock_pip:
+        mock_pip.installed.return_value = []
+        venv = mu.virtual_environment.VirtualEnvironment(venv_dirpath)
+        with mock.patch.object(venv, "reset_pip") as mocked_reset:
+            venv.relocate(".")
+            venv.install_baseline_packages()
+            venv.register_baseline_packages()
+            venv.install_user_packages([])
+            venv.remove_user_packages([])
+            venv.installed_packages()
+
+    assert mocked_reset.call_count == 6


### PR DESCRIPTION
Force the `Pip` object to recreate its internal QProcess object on every run. This sidesteps the issue where it's first invoked as part of a worker thread during the Splash screen, causing every later invocation to run cross-thread