### PR TITLE
Tests: Skip test_Window_remember_plotter_position if QtChart not available.

### DIFF
--- a/tests/interface/test_main.py
+++ b/tests/interface/test_main.py
@@ -12,7 +12,7 @@ from tests.test_app import DumSig
 import mu.interface.main
 import mu.interface.themes
 import mu.interface.editor
-from mu.interface.panes import PlotterPane
+from mu.interface.panes import CHARTS, PlotterPane
 import sys
 
 
@@ -937,6 +937,7 @@ def test_Window_add_plotter():
     w.addDockWidget.assert_called_once_with(Qt.BottomDockWidgetArea, mock_dock)
 
 
+@pytest.mark.skipif(not CHARTS, reason="QtChart unavailable")
 def test_Window_remember_plotter_position():
     """
     Check that opening plotter, changing the area it's docked to, then closing


### PR DESCRIPTION
This was an easier fix than I though, this should make all the TravisCI checks green again.
I thought I saw some issues related to the venvs a while ago, but was likely fixed with some of the other changes in that area.
In the end the only thing left standing was a test on the plotter pane that didn't have a "skip" for platforms without QtCharts (Arm Debian with python 3.5)

Fixes https://github.com/mu-editor/mu/issues/1373.