### PR TITLE
Only try to rebuild the specific sdist, not its dependencies

### DIFF
--- a/mu/wheels/__init__.py
+++ b/mu/wheels/__init__.py
@@ -108,6 +108,7 @@ def download(dirpath=WHEELS_DIRPATH):
                     "-m",
                     "pip",
                     "wheel",
+                    "--no-deps",
                     "--wheel-dir",
                     dirpath,
                     filepath,


### PR DESCRIPTION
Fixes #1377 

When we use `pip wheel` to convert an sdist to a wheel on the local machine, it defaults to pulling in the dependencies again. For reasons I haven't entirely understood, this results in an odd effect when one of the sdist projects includes one of the others as a dependency; this is compounded when the sdist has an option to build a binary when Cython is present, or a pure Python package when it isn't

To cut the Gordian Knot we can simply build a wheel from that sdist alone