### PR TITLE
CI: Increase pip install timeout

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
         run: |
           pip install .[dev]
           pip list
-        timeout-minutes: 5
+        timeout-minutes: 10
       - name: Run tests
         if: runner.os == 'Linux'
         run: xvfb-run make check


### PR DESCRIPTION
It's not uncommon for this step to sometimes take longer, as shown in: 
https://github.com/mu-editor/mu/runs/2170455523?check_suite_focus=true

So let's increase now, rather than keep tracking it.