### PR TITLE
Restore tests with spaces in venv with TravisCI Ubuntu Arm fix

### DIFF
--- a/mu/virtual_environment.py
+++ b/mu/virtual_environment.py
@@ -521,10 +521,11 @@ class VirtualEnvironment(object):
         #
         process = subprocess.run(
             [
-                self.interpreter,
+                os.path.basename(self.interpreter),
                 "-c",
                 'import sys; print("%s%s" % sys.version_info[:2])',
             ],
+            cwd=os.path.abspath(os.path.dirname(self.interpreter)),
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             check=True,

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ install_requires = [
     #
     # Needed for creating the runtime virtual environment
     #
-    "virtualenv",
+    "virtualenv>=16.0.0",
     #
     # Needed for packaging
     #

--- a/tests/virtual_environment/test_virtual_environment.py
+++ b/tests/virtual_environment/test_virtual_environment.py
@@ -43,8 +43,11 @@ WHEEL_FILENAME = "arrr-1.0.2-py3-none-any.whl"
 def venv_name():
     """Use a random venv name each time, at least partly to expose any
     hidden assumptions about the name of the venv directory
+
+    Force the name to have a space in it to expose possible fragilities that way
     """
-    return uuid.uuid1().hex[:4]
+    hex = uuid.uuid1().hex
+    return hex[:2] + " " + hex[2:4]
 
 
 @pytest.fixture
@@ -185,6 +188,11 @@ def test_create_virtual_environment_on_disk(venv_dirpath, test_wheels):
     expected_result = os.path.join(venv_site_packages, "arrr.py")
     result = venv.run_python("-c", "import arrr; print(arrr.__file__)").strip()
     assert os.path.samefile(result, expected_result)
+
+    #
+    # Issue #1372 -- venv creation fails for paths with a space
+    #
+    venv.ensure_interpreter_version()
 
 
 def test_create_virtual_environment_path(patched, venv_dirpath):


### PR DESCRIPTION
Older versions of virtualenv create a pip file (a python file without extension) in the venv bin folder that uses a "normal"
shebang pointing to the python executable inside the venv. Something like
```
#!"/path/to/venv with spaces/bin/python"
```

If the path contains a space the shell shebang parsing can break and stop processing the path after it (even if the space is escaped with `\ `). When this happens it means that `mu.virtualenv` fails trying to call the `venv/bin/pip` executable with a `bad interpreter: No such file or directory` error.

From version 16.* of virtualenv the shebang has been changed to use a format that should work fine with spaces:

```
#!/bin/sh
'''exec' "/path/to/venv with spaces/bin/python3" "$0" "$@"
' '''
```

So this PR adds #1390 again and the min version in setup.py.