### PR TITLE
Add the location of the user's log file to the URL as a base64 encoded value.

### DIFF
--- a/mu/app.py
+++ b/mu/app.py
@@ -173,6 +173,7 @@ def excepthook(*exc_args):
     """
     logging.error("Unrecoverable error", exc_info=(exc_args))
     try:
+        log_file = base64.standard_b64encode(LOG_FILE.encode("utf-8"))
         error = base64.standard_b64encode(
             "".join(traceback.format_exception(*exc_args)).encode("utf-8")
         )
@@ -185,6 +186,7 @@ def excepthook(*exc_args):
                     "utf-8"
                 )
             ),  # platform
+            "f": log_file,  # location of log file
             "e": error,  # error message
         }
         args = urllib.parse.urlencode(params)


### PR DESCRIPTION
This is used by the new version of the crash handler on the website like this:

![crash_with_logs](https://user-images.githubusercontent.com/37602/112730095-83a42000-8f27-11eb-8426-cb5f5a2814f7.png)

If no log is passed in (i.e. they're using `beta.2`) then it looks like this:

![crash_no_log](https://user-images.githubusercontent.com/37602/112730107-974f8680-8f27-11eb-99fb-609c9a3c282f.png)
