### PR TITLE
Revert "Space in username  (#1390)"

### DIFF
--- a/mu/virtual_environment.py
+++ b/mu/virtual_environment.py
@@ -521,11 +521,10 @@ class VirtualEnvironment(object):
         #
         process = subprocess.run(
             [
-                os.path.basename(self.interpreter),
+                self.interpreter,
                 "-c",
                 'import sys; print("%s%s" % sys.version_info[:2])',
             ],
-            cwd=os.path.abspath(os.path.dirname(self.interpreter)),
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             check=True,


### PR DESCRIPTION
This reverts commit 07da232891ce2c9202b749b25b6f408ada2d8b29.

In reaction to #1413 which shows that, for the installed version on a Mac at least, the venv interpreter version check finds the wrong interpreter.