### PR TITLE
Fix crash when Files pane has empty lists and right click menu is used

### DIFF
--- a/mu/interface/panes.py
+++ b/mu/interface/panes.py
@@ -534,12 +534,15 @@ class MicroPythonDeviceFileList(MuFileList):
         self.list_files.emit()
 
     def contextMenuEvent(self, event):
+        menu_current_item = self.currentItem()
+        if menu_current_item is None:
+            return
         menu = QMenu(self)
         delete_action = menu.addAction(_("Delete (cannot be undone)"))
         action = menu.exec_(self.mapToGlobal(event.pos()))
         if action == delete_action:
             self.disable.emit()
-            microbit_filename = self.currentItem().text()
+            microbit_filename = menu_current_item.text()
             logger.info("Deleting {}".format(microbit_filename))
             msg = _("Deleting '{}' from micro:bit.").format(microbit_filename)
             logger.info(msg)
@@ -603,10 +606,13 @@ class LocalFileList(MuFileList):
         self.list_files.emit()
 
     def contextMenuEvent(self, event):
-        menu = QMenu(self)
-        local_filename = self.currentItem().text()
+        menu_current_item = self.currentItem()
+        if menu_current_item is None:
+            return
+        local_filename = menu_current_item.text()
         # Get the file extension
         ext = os.path.splitext(local_filename)[1].lower()
+        menu = QMenu(self)
         open_internal_action = None
         # Mu micro:bit mode only handles .py & .hex
         if ext == ".py" or ext == ".hex":

--- a/mu/interface/panes.py
+++ b/mu/interface/panes.py
@@ -520,7 +520,7 @@ class MicroPythonDeviceFileList(MuFileList):
                 local_filename = os.path.join(
                     self.home, source.currentItem().text()
                 )
-                msg = _("Copying '{}' to micro:bit.").format(local_filename)
+                msg = _("Copying '{}' to device.").format(local_filename)
                 logger.info(msg)
                 self.set_message.emit(msg)
                 self.put.emit(local_filename)
@@ -529,7 +529,7 @@ class MicroPythonDeviceFileList(MuFileList):
         """
         Fired when the put event is completed for the given filename.
         """
-        msg = _("'{}' successfully copied to micro:bit.").format(microbit_file)
+        msg = _("'{}' successfully copied to device.").format(microbit_file)
         self.set_message.emit(msg)
         self.list_files.emit()
 
@@ -544,7 +544,7 @@ class MicroPythonDeviceFileList(MuFileList):
             self.disable.emit()
             microbit_filename = menu_current_item.text()
             logger.info("Deleting {}".format(microbit_filename))
-            msg = _("Deleting '{}' from micro:bit.").format(microbit_filename)
+            msg = _("Deleting '{}' from device.").format(microbit_filename)
             logger.info(msg)
             self.set_message.emit(msg)
             self.delete.emit(microbit_filename)
@@ -553,9 +553,7 @@ class MicroPythonDeviceFileList(MuFileList):
         """
         Fired when the delete event is completed for the given filename.
         """
-        msg = _("'{}' successfully deleted from micro:bit.").format(
-            microbit_file
-        )
+        msg = _("'{}' successfully deleted from device.").format(microbit_file)
         self.set_message.emit(msg)
         self.list_files.emit()
 
@@ -589,7 +587,7 @@ class LocalFileList(MuFileList):
                 microbit_filename = source.currentItem().text()
                 local_filename = os.path.join(self.home, microbit_filename)
                 msg = _(
-                    "Getting '{}' from micro:bit. " "Copying to '{}'."
+                    "Getting '{}' from device. " "Copying to '{}'."
                 ).format(microbit_filename, local_filename)
                 logger.info(msg)
                 self.set_message.emit(msg)
@@ -600,7 +598,7 @@ class LocalFileList(MuFileList):
         Fired when the get event is completed for the given filename.
         """
         msg = _(
-            "Successfully copied '{}' " "from the micro:bit to your computer."
+            "Successfully copied '{}' " "from the device to your computer."
         ).format(microbit_file)
         self.set_message.emit(msg)
         self.list_files.emit()

--- a/tests/interface/test_panes.py
+++ b/tests/interface/test_panes.py
@@ -2,8 +2,8 @@
 """
 Tests for the user interface elements of Mu.
 """
-from PyQt5.QtWidgets import QMessageBox, QLabel
-from PyQt5.QtCore import Qt, QEvent, QPointF
+from PyQt5.QtWidgets import QMessageBox, QLabel, QMenu
+from PyQt5.QtCore import Qt, QEvent, QPointF, QUrl
 from PyQt5.QtGui import QTextCursor, QMouseEvent
 from collections import deque
 from unittest import mock
@@ -998,9 +998,12 @@ def test_MicroPythonDeviceFileList_on_put():
     mfs = mu.interface.panes.MicroPythonDeviceFileList("homepath")
     mfs.set_message = mock.MagicMock()
     mfs.list_files = mock.MagicMock()
+
     mfs.on_put("my_file.py")
-    msg = "'my_file.py' successfully copied to micro:bit."
-    mfs.set_message.emit.assert_called_once_with(msg)
+
+    mfs.set_message.emit.assert_called_once_with(
+        "'my_file.py' successfully copied to micro:bit."
+    )
     mfs.list_files.emit.assert_called_once_with()
 
 
@@ -1029,6 +1032,23 @@ def test_MicroPythonDeviceFileList_contextMenuEvent():
     mfs.delete.emit.assert_called_once_with("foo.py")
 
 
+def test_MicroPythonDeviceFileList_contextMenuEvent_empty_list():
+    """
+    Ensure that there is no menu displayed (and menu action processed) when
+    there is not files in the MicroPython device and the list is right-clicked.
+    """
+    mock_menu = mock.MagicMock()
+    mfs = mu.interface.panes.MicroPythonDeviceFileList("homepath")
+    mfs.currentItem = mock.MagicMock(return_value=None)
+    mock_event = mock.MagicMock()
+
+    with mock.patch("mu.interface.panes.QMenu", return_value=mock_menu):
+        mfs.contextMenuEvent(mock_event)
+
+    assert not mock_menu.called
+    assert not mock_event.called
+
+
 def test_MicroPythonFileList_on_delete():
     """
     On delete should emit a message and list_files signal.
@@ -1036,9 +1056,12 @@ def test_MicroPythonFileList_on_delete():
     mfs = mu.interface.panes.MicroPythonDeviceFileList("homepath")
     mfs.set_message = mock.MagicMock()
     mfs.list_files = mock.MagicMock()
+
     mfs.on_delete("my_file.py")
-    msg = "'my_file.py' successfully deleted from micro:bit."
-    mfs.set_message.emit.assert_called_once_with(msg)
+
+    mfs.set_message.emit.assert_called_once_with(
+        "'my_file.py' successfully deleted from micro:bit."
+    )
     mfs.list_files.emit.assert_called_once_with()
 
 
@@ -1094,28 +1117,26 @@ def test_LocalFileList_on_get():
     lfs = mu.interface.panes.LocalFileList("homepath")
     lfs.set_message = mock.MagicMock()
     lfs.list_files = mock.MagicMock()
+
     lfs.on_get("my_file.py")
-    msg = (
-        "Successfully copied 'my_file.py' from the micro:bit "
-        "to your computer."
+
+    lfs.set_message.emit.assert_called_once_with(
+        "Successfully copied 'my_file.py' from the micro:bit to your computer."
     )
-    lfs.set_message.emit.assert_called_once_with(msg)
     lfs.list_files.emit.assert_called_once_with()
 
 
 def test_LocalFileList_contextMenuEvent():
     """
-    Ensure that the menu displayed when a local file is
-    right-clicked works as expected when activated.
+    Ensure the menu displayed when a local .py file is right-clicked works as
+    expected when activated and signals are sent for "Open in Mu" entry.
     """
-    mock_menu = mock.MagicMock()
+    mock_menu = mock.create_autospec(QMenu, instance=True)
     mock_action_first = mock.MagicMock()
-    mock_action_second = mock.MagicMock()
-    mock_action_third = mock.MagicMock()
     mock_menu.addAction.side_effect = [
-        mock_action_first,
-        mock_action_second,
-        mock_action_third,
+        mock_action_first,  # "Open in Mu"
+        mock.MagicMock(),  # "Write to main.py on device"
+        mock.MagicMock(),  # "Open"
     ]
     mock_menu.exec_.return_value = mock_action_first
     mfs = mu.interface.panes.LocalFileList("homepath")
@@ -1128,20 +1149,61 @@ def test_LocalFileList_contextMenuEvent():
     mfs.set_message = mock.MagicMock()
     mfs.mapToGlobal = mock.MagicMock()
     mock_event = mock.MagicMock()
-    with mock.patch("mu.interface.panes.QMenu", return_value=mock_menu):
+
+    with mock.patch(
+        "mu.interface.panes.QMenu", return_value=mock_menu, autospec=True
+    ):
         mfs.contextMenuEvent(mock_event)
+
     assert mfs.set_message.emit.call_count == 0
+    assert mock_menu.addAction.call_count == 3
     mock_open.assert_called_once_with(os.path.join("homepath", "foo.py"))
+
+
+def test_LocalFileList_contextMenuEvent_hex():
+    """
+    Ensure the menu displayed when a local .hex file is right-clicked works as
+    expected when activated and signals are sent for "Open" entry.
+    """
+    mock_menu = mock.create_autospec(QMenu, instance=True)
+    mock_action_second = mock.MagicMock()
+    mock_menu.addAction.side_effect = [
+        mock.MagicMock(),  # "Open in Mu"
+        mock_action_second,  # "Open"
+    ]
+    mock_menu.exec_.return_value = mock_action_second
+    mfs = mu.interface.panes.LocalFileList("homepath")
+    mock_current = mock.MagicMock()
+    mock_current.text.return_value = "foo.hex"
+    mfs.currentItem = mock.MagicMock(return_value=mock_current)
+    mfs.set_message = mock.MagicMock()
+    mfs.mapToGlobal = mock.MagicMock()
+    mock_event = mock.MagicMock()
+
+    with mock.patch(
+        "mu.interface.panes.QMenu", return_value=mock_menu
+    ), mock.patch(
+        "mu.interface.panes.QDesktopServices", autospec=True
+    ) as mock_QDesktopServices:
+        mfs.contextMenuEvent(mock_event)
+
+    assert mfs.set_message.emit.call_count == 1
+    assert mock_menu.addAction.call_count == 2
+    mock_QDesktopServices.openUrl.assert_called_once_with(
+        QUrl.fromLocalFile(
+            os.path.abspath(os.path.join("homepath", "foo.hex"))
+        )
+    )
 
 
 def test_LocalFileList_contextMenuEvent_external():
     """
-    Ensure that the menu displayed when a local file is
-    right-clicked works as expected when activated.
+    Ensure the menu displayed when a local file with a non py/hex extension
+    is right-clicked works as expected when the "Open" option is clicked.
     """
-    mock_menu = mock.MagicMock()
+    mock_menu = mock.create_autospec(QMenu, instance=True)
     mock_action = mock.MagicMock()
-    mock_menu.addAction.side_effect = [mock_action, mock.MagicMock()]
+    mock_menu.addAction.side_effect = [mock_action, mock.MagicMock()]  # "Open"
     mock_menu.exec_.return_value = mock_action
     mfs = mu.interface.panes.LocalFileList("homepath")
     mock_open = mock.MagicMock()
@@ -1153,10 +1215,22 @@ def test_LocalFileList_contextMenuEvent_external():
     mfs.set_message = mock.MagicMock()
     mfs.mapToGlobal = mock.MagicMock()
     mock_event = mock.MagicMock()
-    with mock.patch("mu.interface.panes.QMenu", return_value=mock_menu):
+
+    with mock.patch(
+        "mu.interface.panes.QMenu", return_value=mock_menu
+    ), mock.patch(
+        "mu.interface.panes.QDesktopServices", autospec=True
+    ) as mock_QDesktopServices:
         mfs.contextMenuEvent(mock_event)
+
     assert mfs.set_message.emit.call_count == 1
+    assert mock_menu.addAction.call_count == 1
     assert mock_open.call_count == 0
+    mock_QDesktopServices.openUrl.assert_called_once_with(
+        QUrl.fromLocalFile(
+            os.path.abspath(os.path.join("homepath", "foo.qwerty"))
+        )
+    )
 
 
 def test_LocalFileList_contextMenuEvent_write_to_mainpy():
@@ -1183,12 +1257,33 @@ def test_LocalFileList_contextMenuEvent_write_to_mainpy():
     mfs.set_message = mock.MagicMock()
     mfs.mapToGlobal = mock.MagicMock()
     mock_event = mock.MagicMock()
+
     with mock.patch("mu.interface.panes.QMenu", return_value=mock_menu):
         mfs.contextMenuEvent(mock_event)
+
     assert mfs.set_message.emit.call_count == 0
     mfs.put.emit.assert_called_once_with(
         os.path.join("homepath", "foo.py"), "main.py"
     )
+
+
+def test_LocalFileList_contextMenuEvent_empty_list():
+    """
+    Ensure that there is no menu displayed with a right-clicked if the local
+    file list is empty.
+    """
+    mock_menu = mock.MagicMock()
+    mock_menu.exec_.return_value = mock.MagicMock()
+    mfs = mu.interface.panes.LocalFileList("homepath")
+    mfs.currentItem = mock.MagicMock(return_value=None)
+    mock_event = mock.MagicMock()
+
+    with mock.patch("mu.interface.panes.QMenu", return_value=mock_menu):
+        mfs.contextMenuEvent(mock_event)
+
+    assert not mock_menu.called
+    assert not mock_event.called
+    assert mock_menu.addAction.call_count == 0
 
 
 def test_FileSystemPane_init():

--- a/tests/interface/test_panes.py
+++ b/tests/interface/test_panes.py
@@ -1002,14 +1002,14 @@ def test_MicroPythonDeviceFileList_on_put():
     mfs.on_put("my_file.py")
 
     mfs.set_message.emit.assert_called_once_with(
-        "'my_file.py' successfully copied to micro:bit."
+        "'my_file.py' successfully copied to device."
     )
     mfs.list_files.emit.assert_called_once_with()
 
 
 def test_MicroPythonDeviceFileList_contextMenuEvent():
     """
-    Ensure that the menu displayed when a file on the micro:bit is
+    Ensure that the menu displayed when a file on the MicroPython device is
     right-clicked works as expected when activated.
     """
     mock_menu = mock.MagicMock()
@@ -1060,7 +1060,7 @@ def test_MicroPythonFileList_on_delete():
     mfs.on_delete("my_file.py")
 
     mfs.set_message.emit.assert_called_once_with(
-        "'my_file.py' successfully deleted from micro:bit."
+        "'my_file.py' successfully deleted from device."
     )
     mfs.list_files.emit.assert_called_once_with()
 
@@ -1121,7 +1121,7 @@ def test_LocalFileList_on_get():
     lfs.on_get("my_file.py")
 
     lfs.set_message.emit.assert_called_once_with(
-        "Successfully copied 'my_file.py' from the micro:bit to your computer."
+        "Successfully copied 'my_file.py' from the device to your computer."
     )
     lfs.list_files.emit.assert_called_once_with()
 


### PR DESCRIPTION
To fix it stop showing any right click menu if no entry in the list is selected, which also applies when the list is empty.

I've also added more tests for this area as there was a couple of missing cases.

And replaced `micro:bit` with `device` in the Files pane texts, as this applies to all MicroPython modes enabling this feature, not just the micro:bit.

Fixes https://github.com/mu-editor/mu/issues/1422.