### PR TITLE
venv: Log the output of the ipykernel installation.

### DIFF
--- a/mu/virtual_environment.py
+++ b/mu/virtual_environment.py
@@ -604,15 +604,17 @@ class VirtualEnvironment(object):
         """
         kernel_name = '"Python/Mu ({})"'.format(self.name)
         logger.info("Installing Jupyter Kernel: %s", kernel_name)
-        return self.run_python(
-            "-m",
-            "ipykernel",
-            "install",
-            "--user",
-            "--name",
-            self.name,
-            "--display-name",
-            kernel_name,
+        logger.debug(
+            self.run_python(
+                "-m",
+                "ipykernel",
+                "install",
+                "--user",
+                "--name",
+                self.name,
+                "--display-name",
+                kernel_name,
+            )
         )
 
     def install_baseline_packages(self):


### PR DESCRIPTION
Also changes to return value from the command output to `None`.

This method is only called in `VirtualEnvironment().create()`, together with `install_baseline_packages()` and `register_baseline_packages()`, which also log this output instead of returning it.

This should get us a bit more info in the logs when we see things like:

```
2021-04-07 00:16:16,533 - mu.virtual_environment:606(install_jupyter_kernel) INFO: Installing Jupyter Kernel: "Python/Mu (mu_venv-36-20210407-001608)"
2021-04-07 00:16:16,989 - mu.virtual_environment:456(ensure_and_create) ERROR: Unable to create a working virtual environment.
2021-04-07 00:16:24,005 - root:174(excepthook) ERROR: Unrecoverable error
Traceback (most recent call last):
  File "/home/carlos/workspace/mu/mu/app.py", line 162, in run
    raise ex
  File "/home/carlos/workspace/mu/mu/app.py", line 149, in run
    venv.ensure_and_create(self.display_text)
  File "/home/carlos/workspace/mu/mu/virtual_environment.py", line 460, in ensure_and_create
    "Unable to create a working virtual environment."
mu.virtual_environment.VirtualEnvironmentError: Unable to create a working virtual environment.
```