### PR TITLE
Unify black config to a single place.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,16 +56,10 @@ coverage: clean
 	export LANG=en_GB.utf8
 	pytest -v --random-order --cov-config .coveragerc --cov-report term-missing --cov=mu tests/
 
-tidy: clean
-	@echo "\nTidying code with black..."
-	black -l 79 setup.py
-	black -l 79 make.py
-	black -l 79 mu
-	black -l 79 package
-	black -l 79 tests
-	black -l 79 utils
+tidy: 
+	python make.py tidy
 
-black: clean
+black:
 	python make.py black
 
 check: clean black flake8 coverage

--- a/make.py
+++ b/make.py
@@ -7,7 +7,8 @@ import subprocess
 
 PYTEST = "pytest"
 FLAKE8 = "flake8"
-TIDY = "black"
+BLACK = "black"
+BLACK_FLAGS = ["-l", "79"]
 PYGETTEXT = os.path.join(sys.base_prefix, "tools", "i18n", "pygettext.py")
 
 INCLUDE_PATTERNS = {"*.py"}
@@ -152,6 +153,7 @@ def flake8(*flake8_args):
 @export
 def tidy():
     """Tidy code with the 'black' formatter."""
+    clean()
     print("\nTidy")
     for target in [
         "setup.py",
@@ -161,7 +163,7 @@ def tidy():
         "tests",
         "utils",
     ]:
-        return_code = subprocess.run([TIDY, "-l", "79", target]).returncode
+        return_code = subprocess.run([BLACK, target] + BLACK_FLAGS).returncode
         if return_code != 0:
             return return_code
     return 0
@@ -170,10 +172,11 @@ def tidy():
 @export
 def black():
     """Check code with the 'black' formatter."""
+    clean()
     print("\nblack")
     # Black is no available in Python 3.5, in that case let the tests continue
     try:
-        subprocess.run([TIDY, "--version"])
+        subprocess.run([BLACK, "--version"])
     except FileNotFoundError as e:
         python_version = sys.version_info
         if python_version.major == 3 and python_version.minor == 5:
@@ -191,7 +194,7 @@ def black():
         "utils",
     ]:
         return_code = subprocess.run(
-            [TIDY, "--check", "-l", "79", target]
+            [BLACK, target, "--check"] + BLACK_FLAGS
         ).returncode
         if return_code != 0:
             return return_code


### PR DESCRIPTION
Fixes https://github.com/mu-editor/mu/issues/930.

>The configuration of the behaviour of Black should be consistent across all platforms and expressed in a single location.
>
>See the context from @tmontes here:
>
>https://github.com/mu-editor/mu/pull/929#issuecomment-539467092

The make logic has been slowly been shifting to make.py, so this follows that pattern and the Makefile `tidy` and `black` commands now simply call make.py, this way we have a single source for the black configuration.

Also adds the `clean` step to the `tidy` and `black` commands  in make.py, as this was done originally in the Makefile.