### PR TITLE
CI: Increase timeout for the make check step

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,11 +44,11 @@ jobs:
       - name: Run tests
         if: runner.os == 'Linux'
         run: xvfb-run make check
-        timeout-minutes: 3
+        timeout-minutes: 5
       - name: Run tests
         if: runner.os != 'Linux'
         run: python make.py check
-        timeout-minutes: 3
+        timeout-minutes: 5
 
   build-arm:
     runs-on: ubuntu-latest


### PR DESCRIPTION
In some cases `make check` doesn't have enough time to finish. I noticed this once a few days ago (didn't capture the log) and then again today:
https://github.com/mu-editor/mu/runs/2307637871?check_suite_focus=true#logs

So this PR simply increases the timeout a couple of minutes.