### PR TITLE
Update what dependencies are included in setup.py and wheels/__init__.py

### DIFF
--- a/mu/wheels/__init__.py
+++ b/mu/wheels/__init__.py
@@ -21,7 +21,6 @@ mode_packages = [
     ("flask", "flask==1.1.2"),
     ("serial", "pyserial>=3.0"),
     ("qtconsole", "qtconsole==4.7.4"),
-    ("nudatus", "nudatus>=0.0.3"),
     ("esptool", "esptool==3.*"),
 ]
 WHEELS_DIRPATH = os.path.dirname(__file__)

--- a/mu/wheels/__init__.py
+++ b/mu/wheels/__init__.py
@@ -19,7 +19,6 @@ logger = logging.getLogger(__name__)
 mode_packages = [
     ("pgzero", "pgzero>=1.2.1"),
     ("flask", "flask==1.1.2"),
-    ("serial", "pyserial>=3.0"),
     ("qtconsole", "qtconsole==4.7.4"),
     ("esptool", "esptool==3.*"),
 ]

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ install_requires = [
     #
     "qtconsole==4.7.4",
     "pyserial==3.4",
+    "nudatus>=0.0.3",
     # `flake8` is actually a testing/packaging dependency that, among other
     # packages, brings in `pycodestyle` and `pyflakes` which are runtime
     # dependencies. For the sake of "locality", it is being declared here,
@@ -71,7 +72,6 @@ extras_require = {
         # under the runtime venv?
         #
         'black>=19.10b0;python_version > "3.5"',
-        "nudatus",
     ],
     "docs": [
         "sphinx",

--- a/setup.py
+++ b/setup.py
@@ -31,10 +31,6 @@ install_requires = [
     + ';"arm" not in platform_machine and "aarch" not in platform_machine',
     "PyQtChart==5.13.1"
     + ';"arm" not in platform_machine and "aarch" not in platform_machine',
-    #
-    # FIXME: Maybe should be in a mode?
-    # qtconsole, pyserial
-    #
     "qtconsole==4.7.4",
     "pyserial==3.4",
     "nudatus>=0.0.3",
@@ -66,12 +62,6 @@ extras_require = {
         "pytest-faulthandler",
         "pytest-timeout",
         "coverage",
-        #
-        # Mode-specific modules needed for testing
-        # TODO -- maybe mode-based tests should be run
-        # under the runtime venv?
-        #
-        'black>=19.10b0;python_version > "3.5"',
     ],
     "docs": [
         "sphinx",


### PR DESCRIPTION
Each commit explains the individual changes:

- nudatus is moved back as a Mu basic dependency
    - It is imported directly by Mu in the micro:bit mode, and not via the user venv, so it needs to be an `install_requires` dependency and can be removed from wheels/__init__.py.
- PySerial is removed from `wheels/__init__.py` as it not used by Mu from the user venv, it is needed to run Mu itself and so it's a `install_requires` dependency.
    - Technically it is needed for esptool, but it is already listed as a dependency of that package 
- As the `qtconsole` and `pyserial` dependencies in setup.py are needed to run the Mu editor and cannot be moved to the venv wheels, I've removed the comments suggesting that.
- `black` is removed as a testing requirement, because it is already a Mu dependency in `install_requires`.