### PR TITLE
Set jupyter-client min version needed by Python3 mode launching Jupyter Kernel

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,9 +31,9 @@ install_requires = [
     + ';"arm" not in platform_machine and "aarch" not in platform_machine',
     "PyQtChart==5.13.1"
     + ';"arm" not in platform_machine and "aarch" not in platform_machine',
-    # FIXME: jupyter-client added for Py3.5 compatibility, to be dropped after
-    # Mu v1.1 release. So, qtconsole < 5 and jupyter-client < 6.2 (issue #1444)
-    "jupyter-client>=4.1,<6.2",
+    # FIXME: jupyter-client max version added for Py3.5 compatibility. It can
+    # be dropped, and qtconsole v5 used, after Mu v1.1 release (issue #1444).
+    "jupyter-client>=6.1.0,<6.2",
     "qtconsole==4.7.7",
     #
     # adafruit-board-toolkit is used to find serial ports and help identify


### PR DESCRIPTION
In PR https://github.com/mu-editor/mu/pull/1240 we started using `KernelManager.pre_start_kernel()` via inheritance from the `jupyter_client`package, which was only introduced in v6.1.0:
- https://github.com/jupyter/jupyter_client/commit/6c67f530726f0d3f70df8580be783d5f510bcd69
- https://github.com/jupyter/jupyter_client/releases/tag/6.1.0

This PR configures this version as the minimum required by Mu.

However, taking in consideration this version is less than a year old, and people might be installing Mu using pip from their system python packages (https://github.com/mu-editor/mu/issues/1516), it would be better if we could update Mu to be compatible with older versions of `jupyter_client`, as otherwise people might inadvertently upgrade their Jupyter dependencies to what could potentially be a breaking change for them.

@devdanzin can we avoid the use of `KernelManager.pre_start_kernel()` from PR https://github.com/mu-editor/mu/pull/1240? Is it necessary to run? Or could other method like `start_kernel()` be enough?

I didn't see this documented in https://jupyter-client.readthedocs.io/en/latest/api/manager.html#jupyter_client.KernelManager so maybe is not an API we should be using?