### PR TITLE
Update Tidy button usage of black to be compatible with latest version 

### DIFF
--- a/mu/logic.py
+++ b/mu/logic.py
@@ -1139,7 +1139,9 @@ class Editor(QObject):
             self._load(path)
 
     def direct_load(self, path):
-        """ for loading files passed from command line or the OS launch"""
+        """
+        For loading files passed from command line or the OS launch.
+        """
         self._load(path)
 
     def load_cli(self, paths):

--- a/mu/logic.py
+++ b/mu/logic.py
@@ -1776,14 +1776,15 @@ class Editor(QObject):
         # Only works on Python, so abort.
         if tab.path and not self.has_python_extension(tab.path):
             return
-        from black import format_str, FileMode, PY36_VERSIONS
+        from black import format_str, FileMode, TargetVersion
 
         try:
             source_code = tab.text()
             logger.info("Tidy code.")
             logger.info(source_code)
             filemode = FileMode(
-                target_versions=PY36_VERSIONS, line_length=MAX_LINE_LENGTH
+                target_versions={TargetVersion.PY36},
+                line_length=MAX_LINE_LENGTH,
             )
             tidy_code = format_str(source_code, mode=filemode)
             # The following bypasses tab.setText which resets the undo history.

--- a/mu/modes/circuitpython.py
+++ b/mu/modes/circuitpython.py
@@ -183,8 +183,7 @@ class CircuitPythonMode(MicroPythonMode):
                 except PermissionError as e:
                     logger.error(
                         "Received '{}' running command: {}".format(
-                            repr(e),
-                            mount_command,
+                            repr(e), mount_command
                         )
                     )
                     m = _("Permission error running mount command")
@@ -198,8 +197,7 @@ class CircuitPythonMode(MicroPythonMode):
                 except Exception as e:
                     logger.error(
                         "Received '{}' running command: {}".format(
-                            repr(e),
-                            mount_command,
+                            repr(e), mount_command
                         )
                     )
 

--- a/mu/modes/debugger.py
+++ b/mu/modes/debugger.py
@@ -122,11 +122,7 @@ class DebugMode(BaseMode):
             envars = self.editor.envars
             cwd = os.path.dirname(tab.path)
             self.runner = self.view.add_python3_runner(
-                venv.interpreter,
-                tab.path,
-                cwd,
-                debugger=True,
-                envars=envars,
+                venv.interpreter, tab.path, cwd, debugger=True, envars=envars
             )
             self.runner.process.waitForStarted()
             self.runner.process.finished.connect(self.finished)

--- a/mu/virtual_environment.py
+++ b/mu/virtual_environment.py
@@ -119,10 +119,7 @@ class Process(QObject):
         self.process.started.connect(self._started)
         self.process.finished.connect(self._finished)
         partial = functools.partial(self.process.start, command, args)
-        QTimer.singleShot(
-            1,
-            partial,
-        )
+        QTimer.singleShot(1, partial)
 
     def wait(self, wait_for_s=30.0):
         finished = self.process.waitForFinished(1000 * wait_for_s)
@@ -763,11 +760,7 @@ class VirtualEnvironment(object):
         """
         logger.info("Installing user packages: %s", ", ".join(packages))
         self.reset_pip()
-        self.pip.install(
-            packages,
-            slots=slots,
-            upgrade=True,
-        )
+        self.pip.install(packages, slots=slots, upgrade=True)
 
     def remove_user_packages(self, packages, slots=Process.Slots()):
         """
@@ -775,10 +768,7 @@ class VirtualEnvironment(object):
         """
         logger.info("Removing user packages: %s", ", ".join(packages))
         self.reset_pip()
-        self.pip.uninstall(
-            packages,
-            slots=slots,
-        )
+        self.pip.uninstall(packages, slots=slots)
 
     def installed_packages(self):
         """

--- a/mu/wheels/__init__.py
+++ b/mu/wheels/__init__.py
@@ -47,10 +47,7 @@ if sys.version_info[:2] == (3, 8) and platform.system() == "Darwin":
             "https://github.com/mu-editor/pygame/releases/download/2.0.1/"
             "pygame-2.0.1-cp38-cp38-macosx_10_9_intel.whl",
         ),
-        (
-            "numpy",
-            "numpy==1.20.1",
-        ),
+        ("numpy", "numpy==1.20.1"),
         (
             "pgzero",
             "https://github.com/mu-editor/pgzero/releases/download/mu-wheel/"

--- a/setup.py
+++ b/setup.py
@@ -70,9 +70,7 @@ extras_require = {
         "pytest-timeout",
         "coverage",
     ],
-    "docs": [
-        "sphinx",
-    ],
+    "docs": ["sphinx"],
     "package": [
         # Wheel building and PyPI uploading
         "wheel",

--- a/tests/interface/test_editor.py
+++ b/tests/interface/test_editor.py
@@ -929,7 +929,7 @@ def test_EditorPane_toggle_comments_selection_follows_len_change():
 
 
 def test_EditorPane_wheelEvent():
-    """"""
+    """ """
     ep = mu.interface.editor.EditorPane(None, "baz")
     mock_app = mock.MagicMock()
     mock_app.keyboardModifiers.return_value = []
@@ -941,7 +941,7 @@ def test_EditorPane_wheelEvent():
 
 
 def test_EditorPane_wheelEvent_with_modifier_ignored():
-    """"""
+    """ """
     ep = mu.interface.editor.EditorPane(None, "baz")
     mock_app = mock.MagicMock()
     mock_app.keyboardModifiers.return_value = ["CTRL"]

--- a/tests/modes/test_microbit.py
+++ b/tests/modes/test_microbit.py
@@ -207,9 +207,7 @@ def test_flash_with_attached_device_has_latest_firmware_v2(microbit):
         mm.copy_main.assert_called_once_with(b"foo")
 
 
-def test_flash_device_has_latest_firmware_encounters_serial_problem(
-    microbit,
-):
+def test_flash_device_has_latest_firmware_encounters_serial_problem(microbit):
     """
     If copy_main encounters an IOError (likely on Windows), revert to
     old-school flashing.

--- a/tests/modes/test_python3.py
+++ b/tests/modes/test_python3.py
@@ -377,9 +377,7 @@ def test_python_add_repl():
         pm.add_repl()
     mock_qthread.assert_called_once_with()
     mock_kernel_runner.assert_called_once_with(
-        kernel_name="name",
-        cwd=pm.workspace_dir(),
-        envars=editor.envars,
+        kernel_name="name", cwd=pm.workspace_dir(), envars=editor.envars
     )
     assert pm.kernel_thread == mock_qthread()
     assert pm.kernel_runner == mock_kernel_runner()

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -751,14 +751,7 @@ def test_devicelist_add_device_in_sorted_order(
     assert dl[1] == microbit_com1
 
     xyz_device = mu.logic.Device(
-        0x123B,
-        0x333A,
-        "COM1",
-        123456,
-        "ARM",
-        "ESP Mode",
-        "esp",
-        "xyz",
+        0x123B, 0x333A, "COM1", 123456, "ARM", "ESP Mode", "esp", "xyz"
     )
     dl.add_device(xyz_device)
     assert dl[2] == xyz_device

--- a/tests/virtual_environment/test_virtual_environment.py
+++ b/tests/virtual_environment/test_virtual_environment.py
@@ -378,9 +378,7 @@ def test_venv_folder_created(venv):
     """When not existing venv is ensured we create a new one"""
     os.rmdir(venv.path)
     with mock.patch.object(VE, "create") as mock_create, mock.patch.object(
-        VE,
-        "ensure",
-        _ensure_venv([True, VEError("Failed")]),
+        VE, "ensure", _ensure_venv([True, VEError("Failed")])
     ):
         venv.ensure_and_create()
 
@@ -390,9 +388,7 @@ def test_venv_folder_created(venv):
 def test_venv_second_try(venv):
     """If the creation of a venv fails to produce a valid venv, try again"""
     with mock.patch.object(VE, "create") as mock_create, mock.patch.object(
-        VE,
-        "ensure",
-        _ensure_venv([True, VEError("Failed")]),
+        VE, "ensure", _ensure_venv([True, VEError("Failed")])
     ):
         venv.ensure_and_create()
 


### PR DESCRIPTION
This PR contains two things:
- The fix to the black deprecation of `PY36_VERSIONS` in https://github.com/mu-editor/mu/commit/5587168ca89cac632c487541d504dac8be4de788
- Reformatting of the source code so that it works in the minimum version of black supported and the latest
    - Had to manually massage the formatting a bit (mostly removing trailing commas in single line argument lists) to ensure it passes with both versions.


Fixes https://github.com/mu-editor/mu/issues/1518.
