### PR TITLE
Add paste to REPL

### DIFF
--- a/mu/interface/editor.py
+++ b/mu/interface/editor.py
@@ -85,8 +85,10 @@ class EditorPane(QsciScintilla):
     Represents the text editor.
     """
 
-    # Signal fired when a script or hex is droped on this editor
+    # Signal fired when a script or hex is droped on this editor.
     open_file = pyqtSignal(str)
+    # Signal fired when a context menu is requested.
+    context_menu = pyqtSignal()
 
     def __init__(self, path, text, newline=NEWLINE):
         super().__init__()
@@ -122,6 +124,12 @@ class EditorPane(QsciScintilla):
         self.setModified(False)
         self.breakpoint_handles = set()
         self.configure()
+
+    def contextMenuEvent(self, event):
+        """
+        A context menu (right click) has been actioned.
+        """
+        self.context_menu.emit()
 
     def wheelEvent(self, event):
         """

--- a/mu/interface/main.py
+++ b/mu/interface/main.py
@@ -519,8 +519,14 @@ class Window(QMainWindow):
         has_selection = any([x > -1 for x in self.current_tab.getSelection()])
         # Flag to indicate if the REPL pane is active.
         has_repl = hasattr(self, "repl") and self.repl
-        # Flag to indicate if the Python process runner pane is active.
-        has_runner = hasattr(self, "process_runner") and self.process_runner
+        # Flag to indicate if the Python process runner pane is active and in
+        # interactive Python3 mode (pasting into other "standard" Python modes
+        # doesn't make sense).
+        has_runner = (
+            hasattr(self, "process_runner")
+            and self.process_runner
+            and self.process_runner.is_interactive
+        )
         if has_selection and (has_repl or has_runner):
             # Text selected with REPL/process context, so add the bespoke
             # "copy to repl" item to the standard context menu to handle this

--- a/mu/interface/main.py
+++ b/mu/interface/main.py
@@ -516,7 +516,9 @@ class Window(QMainWindow):
         if self.current_tab.getSelection() == (-1, -1, -1, -1):
             # No text selected.
             return
-        if hasattr(self, "repl") and self.repl:
+        if (hasattr(self, "repl") and self.repl) or (
+            hasattr(self, "process_runner") and self.process_runner
+        ):
             menu = QMenu(self)
             copy_to_repl = menu.addAction(_("Copy selected text to REPL"))
             copy_to_repl.triggered.connect(self.copy_to_repl)
@@ -554,8 +556,12 @@ class Window(QMainWindow):
         logger.info("\n" + to_paste)
         clipboard = QApplication.clipboard()
         clipboard.setText(to_paste)
-        self.repl_pane.paste()
-        self.repl_pane.setFocus()
+        if hasattr(self, "repl_pane") and self.repl_pane:
+            self.repl_pane.paste()
+            self.repl_pane.setFocus()
+        elif hasattr(self, "process_runner") and self.process_runner:
+            self.process_runner.paste()
+            self.process_runner.setFocus()
 
     def on_stdout_write(self, data):
         """

--- a/mu/interface/panes.py
+++ b/mu/interface/panes.py
@@ -841,6 +841,7 @@ class PythonProcessPane(QTextEdit):
         self.history_position = 0  # current position when navigation history.
         self.stdout_buffer = b""  # contains non-decoded bytes from stdout.
         self.reading_stdout = False  # flag showing if already reading stdout.
+        self.is_interactive = False  # flag if the process is interactive mode.
 
     def start_process(
         self,
@@ -875,6 +876,7 @@ class PythonProcessPane(QTextEdit):
         If python_args is given, these are passed as arguments to the Python
         interpreter used to launch the child process.
         """
+        self.is_interactive = interactive
         if not envars:  # Envars must be a list if not passed a value.
             envars = []
         envars = [(name, v) for (name, v) in envars if name != "PYTHONPATH"]

--- a/mu/interface/panes.py
+++ b/mu/interface/panes.py
@@ -192,9 +192,15 @@ class MicroPythonREPLPane(QTextEdit):
             to_paste = (
                 clipboard.text().replace("\n", "\r").replace("\r\r", "\r")
             )
-            self.connection.write(b"\x05")  # Enter paste mode.
-            self.connection.write(bytes(to_paste, "utf8"))  # Paste the thing.
-            self.connection.write(b"\x04")  # Exit paste mode.
+            if "\r" in to_paste:
+                # Enter MicroPython's paste mode for multi-line pastes so
+                # indentation isn't messed up.
+                self.connection.write(b"\x05")  # Enter paste mode.
+                self.connection.write(bytes(to_paste, "utf8"))  # Paste.
+                self.connection.write(b"\x04")  # Exit paste mode.
+            else:
+                # Only a fragment to paste, so just insert as is.
+                self.connection.write(bytes(to_paste, "utf8"))  # Paste.
 
     def context_menu(self):
         """

--- a/mu/interface/panes.py
+++ b/mu/interface/panes.py
@@ -192,7 +192,9 @@ class MicroPythonREPLPane(QTextEdit):
             to_paste = (
                 clipboard.text().replace("\n", "\r").replace("\r\r", "\r")
             )
-            self.connection.write(bytes(to_paste, "utf8"))
+            self.connection.write(b"\x05")  # Enter paste mode.
+            self.connection.write(bytes(to_paste, "utf8"))  # Paste the thing.
+            self.connection.write(b"\x04")  # Exit paste mode.
 
     def context_menu(self):
         """

--- a/tests/interface/test_editor.py
+++ b/tests/interface/test_editor.py
@@ -950,3 +950,13 @@ def test_EditorPane_wheelEvent_with_modifier_ignored():
     ) as mw:
         ep.wheelEvent(None)
         assert mw.call_count == 0
+
+
+def test_EditorPane_contextMenuEvent():
+    """
+    Context menu raises the expected signal.
+    """
+    ep = mu.interface.editor.EditorPane(None, "baz")
+    ep.context_menu = mock.MagicMock()
+    ep.contextMenuEvent(None)
+    ep.context_menu.emit.assert_called_once_with()

--- a/tests/interface/test_main.py
+++ b/tests/interface/test_main.py
@@ -2,7 +2,7 @@
 """
 Tests for the user interface elements of Mu.
 """
-from PyQt5.QtWidgets import QAction, QWidget, QFileDialog, QMessageBox
+from PyQt5.QtWidgets import QAction, QWidget, QFileDialog, QMessageBox, QMenu
 from PyQt5.QtCore import Qt, QSize
 from PyQt5.QtGui import QIcon, QKeySequence
 from unittest import mock
@@ -732,9 +732,17 @@ def test_Window_on_context_menu_nothing_selected():
     w.tabs = mock.MagicMock()
     w.tabs.currentWidget.return_value = mock_tab
     mock_tab.getSelection.return_value = -1, -1, -1, -1
-    with mock.patch("mu.interface.main.QMenu") as mqm:
-        w.on_context_menu()
-        assert mqm.call_count == 0
+    menu = QMenu()
+    menu.insertAction = mock.MagicMock()
+    menu.insertSeparator = mock.MagicMock()
+    menu.exec_ = mock.MagicMock()
+    mock_tab.createStandardContextMenu = mock.MagicMock(return_value=menu)
+    w.on_context_menu()
+    assert mock_tab.createStandardContextMenu.call_count == 1
+    # No additional items added to the menu.
+    assert menu.insertAction.call_count == 0
+    assert menu.insertSeparator.call_count == 0
+    assert menu.exec_.call_count == 1
 
 
 def test_Window_on_context_menu_has_selection_but_no_repl():
@@ -748,9 +756,17 @@ def test_Window_on_context_menu_has_selection_but_no_repl():
     w.tabs = mock.MagicMock()
     w.tabs.currentWidget.return_value = mock_tab
     mock_tab.getSelection.return_value = 0, 0, 10, 10
-    with mock.patch("mu.interface.main.QMenu") as mqm:
-        w.on_context_menu()
-        assert mqm.call_count == 0
+    menu = QMenu()
+    menu.insertAction = mock.MagicMock()
+    menu.insertSeparator = mock.MagicMock()
+    menu.exec_ = mock.MagicMock()
+    mock_tab.createStandardContextMenu = mock.MagicMock(return_value=menu)
+    w.on_context_menu()
+    assert mock_tab.createStandardContextMenu.call_count == 1
+    # No additional items added to the menu.
+    assert menu.insertAction.call_count == 0
+    assert menu.insertSeparator.call_count == 0
+    assert menu.exec_.call_count == 1
 
 
 def test_Window_on_context_menu_with_repl():
@@ -764,16 +780,21 @@ def test_Window_on_context_menu_with_repl():
     w.tabs = mock.MagicMock()
     w.tabs.currentWidget.return_value = mock_tab
     mock_tab.getSelection.return_value = 0, 0, 10, 10
-    mock_menu = mock.MagicMock()
-    with mock.patch("mu.interface.main.QMenu", return_value=mock_menu) as mqm:
-        w.on_context_menu()
-        assert mqm.call_count == 1
-        mock_menu.addAction.assert_called_once_with(
-            "Copy selected text to REPL"
-        )
-        item = mock_menu.addAction()
-        item.triggered.connect.assert_called_once_with(w.copy_to_repl)
-        assert mock_menu.exec_.call_count == 1
+    menu = QMenu()
+    menu.insertAction = mock.MagicMock()
+    menu.insertSeparator = mock.MagicMock()
+    menu.exec_ = mock.MagicMock()
+    menu.actions = mock.MagicMock(
+        return_value=[
+            "foo",
+        ]
+    )
+    mock_tab.createStandardContextMenu = mock.MagicMock(return_value=menu)
+    w.on_context_menu()
+    assert mock_tab.createStandardContextMenu.call_count == 1
+    assert menu.insertAction.call_count == 1
+    assert menu.insertSeparator.call_count == 1
+    assert menu.exec_.call_count == 1
 
 
 def test_Window_on_context_menu_with_process_runner():
@@ -788,16 +809,21 @@ def test_Window_on_context_menu_with_process_runner():
     w.tabs = mock.MagicMock()
     w.tabs.currentWidget.return_value = mock_tab
     mock_tab.getSelection.return_value = 0, 0, 10, 10
-    mock_menu = mock.MagicMock()
-    with mock.patch("mu.interface.main.QMenu", return_value=mock_menu) as mqm:
-        w.on_context_menu()
-        assert mqm.call_count == 1
-        mock_menu.addAction.assert_called_once_with(
-            "Copy selected text to REPL"
-        )
-        item = mock_menu.addAction()
-        item.triggered.connect.assert_called_once_with(w.copy_to_repl)
-        assert mock_menu.exec_.call_count == 1
+    menu = QMenu()
+    menu.insertAction = mock.MagicMock()
+    menu.insertSeparator = mock.MagicMock()
+    menu.exec_ = mock.MagicMock()
+    menu.actions = mock.MagicMock(
+        return_value=[
+            "foo",
+        ]
+    )
+    mock_tab.createStandardContextMenu = mock.MagicMock(return_value=menu)
+    w.on_context_menu()
+    assert mock_tab.createStandardContextMenu.call_count == 1
+    assert menu.insertAction.call_count == 1
+    assert menu.insertSeparator.call_count == 1
+    assert menu.exec_.call_count == 1
 
 
 def test_Window_copy_to_repl_fragment():

--- a/tests/interface/test_main.py
+++ b/tests/interface/test_main.py
@@ -769,6 +769,31 @@ def test_Window_on_context_menu_has_selection_but_no_repl():
     assert menu.exec_.call_count == 1
 
 
+def test_Window_on_context_menu_has_selection_but_no_interactive_process():
+    """
+    If the current tab has selected text, but there is no process in
+    interactive mode, there should be no QMenu created.
+    """
+    w = mu.interface.main.Window()
+    w.process_runner = mock.MagicMock()
+    w.process_runner.is_interactive = False
+    mock_tab = mock.MagicMock()
+    w.tabs = mock.MagicMock()
+    w.tabs.currentWidget.return_value = mock_tab
+    mock_tab.getSelection.return_value = 0, 0, 10, 10
+    menu = QMenu()
+    menu.insertAction = mock.MagicMock()
+    menu.insertSeparator = mock.MagicMock()
+    menu.exec_ = mock.MagicMock()
+    mock_tab.createStandardContextMenu = mock.MagicMock(return_value=menu)
+    w.on_context_menu()
+    assert mock_tab.createStandardContextMenu.call_count == 1
+    # No additional items added to the menu.
+    assert menu.insertAction.call_count == 0
+    assert menu.insertSeparator.call_count == 0
+    assert menu.exec_.call_count == 1
+
+
 def test_Window_on_context_menu_with_repl():
     """
     If the current tab has selected text, and there is an active REPL, there
@@ -804,7 +829,8 @@ def test_Window_on_context_menu_with_process_runner():
     manner.
     """
     w = mu.interface.main.Window()
-    w.process_runner = True
+    w.process_runner = mock.MagicMock()
+    w.process_runner.is_interactive = True
     mock_tab = mock.MagicMock()
     w.tabs = mock.MagicMock()
     w.tabs.currentWidget.return_value = mock_tab

--- a/tests/interface/test_main.py
+++ b/tests/interface/test_main.py
@@ -753,13 +753,37 @@ def test_Window_on_context_menu_has_selection_but_no_repl():
         assert mqm.call_count == 0
 
 
-def test_Window_on_context_menu():
+def test_Window_on_context_menu_with_repl():
     """
     If the current tab has selected text, and there is an active REPL, there
     should be a QMenu created in the expected manner.
     """
     w = mu.interface.main.Window()
     w.repl = True
+    mock_tab = mock.MagicMock()
+    w.tabs = mock.MagicMock()
+    w.tabs.currentWidget.return_value = mock_tab
+    mock_tab.getSelection.return_value = 0, 0, 10, 10
+    mock_menu = mock.MagicMock()
+    with mock.patch("mu.interface.main.QMenu", return_value=mock_menu) as mqm:
+        w.on_context_menu()
+        assert mqm.call_count == 1
+        mock_menu.addAction.assert_called_once_with(
+            "Copy selected text to REPL"
+        )
+        item = mock_menu.addAction()
+        item.triggered.connect.assert_called_once_with(w.copy_to_repl)
+        assert mock_menu.exec_.call_count == 1
+
+
+def test_Window_on_context_menu_with_process_runner():
+    """
+    If the current tab has selected text, and there is an active
+    PythonProcessRunner, there should be a QMenu created in the expected
+    manner.
+    """
+    w = mu.interface.main.Window()
+    w.process_runner = True
     mock_tab = mock.MagicMock()
     w.tabs = mock.MagicMock()
     w.tabs.currentWidget.return_value = mock_tab
@@ -795,6 +819,27 @@ def test_Window_copy_to_repl_fragment():
         clipboard.setText.assert_called_once_with("Hello")
         w.repl_pane.paste.assert_called_once_with()
         w.repl_pane.setFocus.assert_called_once_with()
+
+
+def test_Window_copy_to_repl_with_python_runner():
+    """
+    If a fragment of text from a single line is selected, only paste that into
+    the active PythonProcessRunner.
+    """
+    w = mu.interface.main.Window()
+    mock_tab = mock.MagicMock()
+    w.tabs = mock.MagicMock()
+    w.tabs.currentWidget.return_value = mock_tab
+    mock_tab.getSelection.return_value = 0, 0, 0, 5
+    mock_tab.text.return_value = "Hello world!"
+    w.process_runner = mock.MagicMock()
+    with mock.patch("mu.interface.main.QApplication") as mock_app:
+        w.copy_to_repl()
+        mock_app.clipboard.assert_called_once_with()
+        clipboard = mock_app.clipboard()
+        clipboard.setText.assert_called_once_with("Hello")
+        w.process_runner.paste.assert_called_once_with()
+        w.process_runner.setFocus.assert_called_once_with()
 
 
 def test_Window_copy_to_repl_multi_line():

--- a/tests/interface/test_panes.py
+++ b/tests/interface/test_panes.py
@@ -42,9 +42,12 @@ def test_MicroPythonREPLPane_paste():
     with mock.patch("mu.interface.panes.QApplication", mock_application):
         rp = mu.interface.panes.MicroPythonREPLPane(mock_repl_connection)
         rp.paste()
-    mock_repl_connection.write.assert_called_once_with(
-        bytes("paste me!", "utf8")
+    assert mock_repl_connection.write.call_count == 3
+    assert mock_repl_connection.write.call_args_list[0][0][0] == b"\x05"
+    assert mock_repl_connection.write.call_args_list[1][0][0] == bytes(
+        "paste me!", "utf8"
     )
+    assert mock_repl_connection.write.call_args_list[2][0][0] == b"\x04"
 
 
 def test_MicroPythonREPLPane_paste_handle_unix_newlines():
@@ -61,9 +64,12 @@ def test_MicroPythonREPLPane_paste_handle_unix_newlines():
     with mock.patch("mu.interface.panes.QApplication", mock_application):
         rp = mu.interface.panes.MicroPythonREPLPane(mock_repl_connection)
         rp.paste()
-    mock_repl_connection.write.assert_called_once_with(
-        bytes("paste\rme!", "utf8")
+    assert mock_repl_connection.write.call_count == 3
+    assert mock_repl_connection.write.call_args_list[0][0][0] == b"\x05"
+    assert mock_repl_connection.write.call_args_list[1][0][0] == bytes(
+        "paste\rme!", "utf8"
     )
+    assert mock_repl_connection.write.call_args_list[2][0][0] == b"\x04"
 
 
 def test_MicroPythonREPLPane_paste_handle_windows_newlines():
@@ -80,9 +86,12 @@ def test_MicroPythonREPLPane_paste_handle_windows_newlines():
     with mock.patch("mu.interface.panes.QApplication", mock_application):
         rp = mu.interface.panes.MicroPythonREPLPane(mock_repl_connection)
         rp.paste()
-    mock_repl_connection.write.assert_called_once_with(
-        bytes("paste\rme!", "utf8")
+    assert mock_repl_connection.write.call_count == 3
+    assert mock_repl_connection.write.call_args_list[0][0][0] == b"\x05"
+    assert mock_repl_connection.write.call_args_list[1][0][0] == bytes(
+        "paste\rme!", "utf8"
     )
+    assert mock_repl_connection.write.call_args_list[2][0][0] == b"\x04"
 
 
 def test_MicroPythonREPLPane_paste_only_works_if_something_to_paste():

--- a/tests/interface/test_panes.py
+++ b/tests/interface/test_panes.py
@@ -30,7 +30,7 @@ def test_PANE_ZOOM_SIZES():
     assert len(expected_sizes) == len(mu.interface.panes.PANE_ZOOM_SIZES)
 
 
-def test_MicroPythonREPLPane_paste():
+def test_MicroPythonREPLPane_paste_fragment():
     """
     Pasting into the REPL should send bytes via the serial connection.
     """
@@ -42,10 +42,25 @@ def test_MicroPythonREPLPane_paste():
     with mock.patch("mu.interface.panes.QApplication", mock_application):
         rp = mu.interface.panes.MicroPythonREPLPane(mock_repl_connection)
         rp.paste()
+    mock_repl_connection.write.assert_called_once_with(b"paste me!")
+
+
+def test_MicroPythonREPLPane_paste_multiline():
+    """
+    Pasting into the REPL should send bytes via the serial connection.
+    """
+    mock_repl_connection = mock.MagicMock()
+    mock_clipboard = mock.MagicMock()
+    mock_clipboard.text.return_value = "paste\nme!"
+    mock_application = mock.MagicMock()
+    mock_application.clipboard.return_value = mock_clipboard
+    with mock.patch("mu.interface.panes.QApplication", mock_application):
+        rp = mu.interface.panes.MicroPythonREPLPane(mock_repl_connection)
+        rp.paste()
     assert mock_repl_connection.write.call_count == 3
     assert mock_repl_connection.write.call_args_list[0][0][0] == b"\x05"
     assert mock_repl_connection.write.call_args_list[1][0][0] == bytes(
-        "paste me!", "utf8"
+        "paste\rme!", "utf8"
     )
     assert mock_repl_connection.write.call_args_list[2][0][0] == b"\x04"
 


### PR DESCRIPTION
This PR implements (and includes tests for) a mechanism for quickly pasting content from the editor pane to an active REPL. The context menu (accessed by right/alt clicking in the editor widget) is only active if two conditions are met:

1. There is some text selected in the editor pane to paste into the REPL.
2. There is an active REPL open.

In addition, single line fragments of code can be pasted as well as multi line code. If the highlighted code is indented in a way that wouldn't work with the REPL, Mu tries to correct this by looking at the indent level of the first selected line. I've also added unit tests to exercise all code paths.

You can see this in action in the following screenie:

![paste_demo_full](https://user-images.githubusercontent.com/37602/118016047-d6596000-b34c-11eb-80b2-51174f51570b.gif)

As the demo shows, I've ensured that pasting text into a MicroPython-ish REPL is enclosed in the `CTRL-E` and `CTRL-D` commands to switch off MicroPython's native "intelligent indent" feature of the REPL.

@tjguk, @carlosperate I've tested this on Linux. Would be helpful to know if this works on Windows and OSX (thank you). I expect it to work across all MicroPython/CircuitPython devices (I've checked micro:bit and CircuitPython) and in Python3 REPL.

Any thoughts on pasting into the Python "REPL" after running a script in Python3 mode..? This currently doesn't work, but I think we probably need it, and I've not had the time over my lunch break to implement it yet (but wanted to give you a heads up of what this looks like).