### PR TITLE
Update virtualenv dependency to a version packing pip v19.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ install_requires = [
     #
     # Needed for creating the runtime virtual environment
     #
-    "virtualenv>=16.0.0",
+    "virtualenv>=16.7.6",
     #
     # Needed for packaging
     #


### PR DESCRIPTION
virtualenv vendors its own pip, and we need to ensure users have pip v19.3 or higher so that it's capable to install all dependencies in the user venv correctly.

The `cryptography` package used by `esptool` now uses Rust, so it needs pip v19.0. The next PyQt5 wheels requires `manylinux2010` support so that needs pip v19.3.

`virtualenv` v16.7.6 is the earliest version to pack v19.3 (the v19.1 included is only required for Python 3.4, which Mu does not support): https://github.com/gaborbernat/virtualenv/tree/16.7.6/virtualenv_support

More info in these GH issues:
https://github.com/mu-editor/mu/issues/1441#issuecomment-814790143
https://github.com/mu-editor/mu/issues/1556#issuecomment-842503883