### PR TITLE
CI: Add Arm Raspbian test runner

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -109,8 +109,8 @@ jobs:
         uses: appleboy/ssh-action@master
         with:
           host: rpios
-          username: ${{ secrets.PI_USERNAME }}
-          password: ${{ secrets.PI_PASSWORD }}
+          username: pi
+          password: raspberry
           port:  ${{ job.services.rpios.ports[5022] }}
           script: |
             mkdir ~/mu && cd ~/mu
@@ -124,8 +124,8 @@ jobs:
         uses: appleboy/ssh-action@master
         with:
           host: rpios
-          username: ${{ secrets.PI_USERNAME }}
-          password: ${{ secrets.PI_PASSWORD }}
+          username: pi
+          password: raspberry
           port:  ${{ job.services.rpios.ports[5022] }}
           # Purposely skip apt update, install version from image stale index
           script: sudo apt-get install -y python3-virtualenv
@@ -133,8 +133,8 @@ jobs:
         uses: appleboy/ssh-action@master
         with:
           host: rpios
-          username: ${{ secrets.PI_USERNAME }}
-          password: ${{ secrets.PI_PASSWORD }}
+          username: pi
+          password: raspberry
           port:  ${{ job.services.rpios.ports[5022] }}
           command_timeout: 20m
           script: |
@@ -148,8 +148,8 @@ jobs:
         uses: appleboy/ssh-action@master
         with:
           host: rpios
-          username: ${{ secrets.PI_USERNAME }}
-          password: ${{ secrets.PI_PASSWORD }}
+          username: pi
+          password: raspberry
           port:  ${{ job.services.rpios.ports[5022] }}
           script: |
             uname -a
@@ -161,8 +161,8 @@ jobs:
         uses: appleboy/ssh-action@master
         with:
           host: rpios
-          username: ${{ secrets.PI_USERNAME }}
-          password: ${{ secrets.PI_PASSWORD }}
+          username: pi
+          password: raspberry
           port:  ${{ job.services.rpios.ports[5022] }}
           command_timeout: 25m
           script: xvfb-run python make.py check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ on:
     branches: '*'
 
 jobs:
-  build:
+  test:
     timeout-minutes: 30
     strategy:
       matrix:
@@ -50,7 +50,7 @@ jobs:
         run: python make.py check
         timeout-minutes: 5
 
-  build-arm:
+  test-arm:
     runs-on: ubuntu-latest
     name: Test Py 3.7 - arm-debian-buster
     steps:
@@ -88,3 +88,76 @@ jobs:
               xvfb-run python make.py check &&
               echo 'Finished successfully! :)'
             "
+
+  test-pios:
+    name: Test Py 3.5 - Raspbian Stretch (virtualenv)
+    runs-on: ubuntu-latest
+    services:
+      rpios:
+        image: ghcr.io/carlosperate/qemu-rpi-os-lite:stretch-2018-03-13-mu
+        ports: ["5022:5022"]
+    steps:
+      # This delay is a bit hacky, but can't find a way to signal when OS is ready
+      - name: Wait 2m30s for the docker image to start up QEMU and Raspberry Pi OS
+        run: sleep 150
+      - name: Clone project & setup it as the bash entry directory
+        uses: appleboy/ssh-action@master
+        with:
+          host: rpios
+          username: ${{ secrets.PI_USERNAME }}
+          password: ${{ secrets.PI_PASSWORD }}
+          port:  ${{ job.services.rpios.ports[5022] }}
+          script: |
+            mkdir ~/mu && cd ~/mu
+            git init
+            git remote add origin ${{ github.server_url }}/${{ github.repository }}.git
+            git fetch --progress --depth=1 origin ${{ github.sha }}
+            git checkout --progress FETCH_HEAD
+            echo "cd ~/mu" > ~/.bashrc_new && cat ~/.bashrc >> ~/.bashrc_new
+            rm ~/.bashrc && mv ~/.bashrc_new ~/.bashrc
+      - name: Install Mu extra apt dependencies
+        uses: appleboy/ssh-action@master
+        with:
+          host: rpios
+          username: ${{ secrets.PI_USERNAME }}
+          password: ${{ secrets.PI_PASSWORD }}
+          port:  ${{ job.services.rpios.ports[5022] }}
+          # Purposely skip apt update, install version from image stale index
+          script: sudo apt-get install -y python3-virtualenv
+      - name: Create venv and install Python dependencies
+        uses: appleboy/ssh-action@master
+        with:
+          host: rpios
+          username: ${{ secrets.PI_USERNAME }}
+          password: ${{ secrets.PI_PASSWORD }}
+          port:  ${{ job.services.rpios.ports[5022] }}
+          command_timeout: 20m
+          script: |
+            python3 -m virtualenv ~/mu/.venv -v --python=python3 --system-site-packages
+            echo "source ~/mu/.venv/bin/activate" > ~/.bashrc_new && cat ~/.bashrc >> ~/.bashrc_new
+            rm ~/.bashrc && mv ~/.bashrc_new ~/.bashrc
+            source .venv/bin/activate
+            python -m pip list
+            python -m pip install ."[dev]"
+      - name: Environment info
+        uses: appleboy/ssh-action@master
+        with:
+          host: rpios
+          username: ${{ secrets.PI_USERNAME }}
+          password: ${{ secrets.PI_PASSWORD }}
+          port:  ${{ job.services.rpios.ports[5022] }}
+          script: |
+            uname -a
+            cat /etc/os-release
+            python3 -c "import platform as p, sys; print(sys.executable, p.architecture(), p.machine(), sys.version, sep='\n')"
+            python3 -m pip --version
+            python3 -m pip list
+      - name: Run tests
+        uses: appleboy/ssh-action@master
+        with:
+          host: rpios
+          username: ${{ secrets.PI_USERNAME }}
+          password: ${{ secrets.PI_PASSWORD }}
+          port:  ${{ job.services.rpios.ports[5022] }}
+          command_timeout: 25m
+          script: xvfb-run python make.py check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,11 +90,16 @@ jobs:
             "
 
   test-pios:
-    name: Test Py 3.5 - Raspbian Stretch (virtualenv)
+    name: Test Raspbian ${{ matrix.docker-tag }}
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        docker-tag: ['stretch-2018-03-13', 'buster-2021-03-25']
+      fail-fast: false
     services:
       rpios:
-        image: ghcr.io/carlosperate/qemu-rpi-os-lite:stretch-2018-03-13-mu
+        # Custom made images for Mu: https://github.com/carlosperate/docker-qemu-rpi-os
+        image: ghcr.io/carlosperate/qemu-rpi-os-lite:${{ matrix.docker-tag }}-mu
         ports: ["5022:5022"]
     steps:
       # This delay is a bit hacky, but can't find a way to signal when OS is ready


### PR DESCRIPTION
Originally looked into this way back during the Christmas break, finally got around to put it together for Mu.

It basically utilises the awesome [dockerpi](https://github.com/lukechilds/dockerpi) project to create a docker image with Qemu emulating armv6 and running Rasbian/RaspberryPi-OS. Kudos to all the hard work done over there to get this running.

I simply had to create some custom Raspbian images to enable SSH access and install the Debian packages needed (PyQt5 et all): https://github.com/carlosperate/rpi-os-custom-image

And then created the new docker images to wrap it all up: https://github.com/carlosperate/docker-qemu-rpi-os

This PR updates the GitHub Actions workflow to create a new job with these docker images.
Unfortunately because of the way the docker is run in the GH Actions platform, we cannot bash directly into Raspbian as one would do when running these images locally, so I had to set it up as a "service" and SSH into it on each test step.

To start this adds 2 jobs, both on the same Raspbian Stretch image. One installs Mu in a virtual environment, the other on the system Python. The majority of the crash logs we get from Raspbian have been pip installed in the system Python, so it'll be good to test that as well (mostly how it might or might not clash with the Debian system Python packages).

Once I have pushed more docker images with Buster I'll add those here as well.