### PR TITLE
Update adafruit-board-toolkit to ~=1.1 to fix M1 MacOS issues

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ install_requires = [
     #
     # adafruit-board-toolkit is used to find serial ports and help identify
     # CircuitPython boards in the CircuitPython mode.
-    "adafruit-board-toolkit>=1.0.1",
+    "adafruit-board-toolkit~=1.1",
     "pyserial~=3.5",
     "nudatus>=0.0.3",
     # `flake8` is actually a testing/packaging dependency that, among other


### PR DESCRIPTION
Updates the version specifier for `adafruit-board-toolkit` so the minimum version is `1.1.0.` Any 1.x version will be upward compatible and be OK.

`adafruit-board-toolkit` 1.1.0 has two important fixes:
- MacOS interface name fetching is improved so it works back to Sierra and forward to MacOS Big Sur on M1. There are differences between M1 MacOS and non-M1. See https://github.com/adafruit/Adafruit_Board_Toolkit/pull/4.
- The interface names don't have to start with "CircuitPython"; there are some boards that uses other prefixes. See https://github.com/adafruit/Adafruit_Board_Toolkit/pull/2.

Fixes #1543.