### PR TITLE
Make the issue template more instructive

### DIFF
--- a/.github/ISSUE_TEMPLATE/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE/ISSUE_TEMPLATE.md
@@ -4,20 +4,57 @@ name: New Bug Report
 about: Report a problem with the Mu editor.
 
 ---
+# Bug Report
 
-If you are reporting a bug, we would like to know:
+<!-- Please answer each question below to the best of your ability. It's okay to leave some blank if it doesn't apply to your problem. -->
+What were you trying to do?
+---------------------------
 
-* What you were trying to do,
-* What steps you took to make this happen,
-* What you expected to happen,
-* What actually happened,
-* Why this difference is problematic (it may not be a bug!),
-* Technical details like the version of Mu you're using, your OS version and
-  other aspects of the context in which Mu was running. 
 
+What steps did you take to trigger the issue?
+---------------------------------------------
+
+
+What did you expect to happen?
+------------------------------
+
+
+What actually happened?
+-----------------------
+
+
+Why is this difference problematic? (it might not be a bug!)
+----------------------------------------------------------
+
+
+Technical Info
+--------------
+* Mu version: 
+* Operating system version:
+
+
+Other Info
+----------
+<!-- You can put any info here that you think might help us track down the bug. -->
+
+Editor Log
+----------
+<!--
 Please remember to attach a **copy of the full log files for Mu**. You can get
 the logs by clicking on the cog icon in the bottom right of the editor window.
 Click on the logs and use CTRL-A to select all, then CTRL-C to copy and CTRL-V
 to paste the contents into the issue.
+If Mu doesn't open, you can find the logs in one of these locations, depending on your OS:
+* Windows: %LOCALAPPDATA%\python\mu\Logs
+* macOS: ~/Library/Logs/mu
+* Linux: ~/.cache/mu/
+-->
+<details> <summary>Mu Log Files</summary>
+  <pre>
+  Replace me with your logs...
+  </pre>
+</details>
 
+<!--
 Thank you for contributing to Mu! :-)
+-->


### PR DESCRIPTION
I added some instructions to the issue template. These:
* Make it seem more like a form, and easier for someone to fill out
* Put the logs in a `<details>` tag, making it collapsible. (as done in #1347)
