### PR TITLE
Raspbian CI: Check the repo checkout works with forks

### DIFF
--- a/mu/app.py
+++ b/mu/app.py
@@ -295,6 +295,8 @@ def run():
     app.setApplicationVersion(__version__)
     app.setAttribute(Qt.AA_DontShowIconsInMenus)
 
+    1 / 0
+
     def splash_context():
         """
         Function context (to ensure garbage collection) for displaying the


### PR DESCRIPTION
This PR has been created only to make sure that the git checkout step from the Raspbian CI job added in https://github.com/mu-editor/mu/pull/1578 works well.

This PR adds a small error, so if the Raspbian tests fail with a `ZeroDivisionError` exception, then it all works as expected.