### PR TITLE
Added SVG versions of all circular button images in mu/resources/images

### DIFF
--- a/mu/resources/images/svg/browse.svg
+++ b/mu/resources/images/svg/browse.svg
@@ -81,14 +81,7 @@
      inkscape:label="Layer 1"
      inkscape:groupmode="layer"
      id="layer1"
-     transform="translate(0,-237.38055)">
-    <ellipse
-       style="fill:none;stroke:#ffcc33;stroke-width:4.34999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="path871"
-       cx="29.809498"
-       cy="266.46942"
-       rx="2.4063713e-13"
-       ry="0.72084588" />
+     transform="translate(0,-237.38055)"> -->
     <g
        id="g895">
       <path

--- a/mu/resources/images/svg/browse.svg
+++ b/mu/resources/images/svg/browse.svg
@@ -81,7 +81,7 @@
      inkscape:label="Layer 1"
      inkscape:groupmode="layer"
      id="layer1"
-     transform="translate(0,-237.38055)"> -->
+     transform="translate(0,-237.38055)">
     <g
        id="g895">
       <path

--- a/mu/resources/images/svg/browse.svg
+++ b/mu/resources/images/svg/browse.svg
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="59.619438mm"
+   height="59.619438mm"
+   viewBox="0 0 59.619438 59.619438"
+   version="1.1"
+   id="svg8"
+   inkscape:version="1.0.2-2 (e86c870879, 2021-01-15)"
+   sodipodi:docname="browse.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="5.0271529"
+     inkscape:cx="125.9087"
+     inkscape:cy="124.07886"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     inkscape:document-rotation="0"
+     showgrid="false"
+     inkscape:snap-page="true"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:window-width="1920"
+     inkscape:window-height="1001"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:snap-to-guides="true">
+    <sodipodi:guide
+       position="29.809499,69.619441"
+       orientation="-1,0"
+       id="guide24"
+       inkscape:label=""
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       position="-9.9999998,29.809721"
+       orientation="0,1"
+       id="guide26"
+       inkscape:label=""
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       position="-19.894461,69.619437"
+       orientation="0,1"
+       id="guide879"
+       inkscape:label=""
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-237.38055)">
+    <ellipse
+       style="fill:none;stroke:#ffcc33;stroke-width:4.34999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path871"
+       cx="29.809498"
+       cy="266.46942"
+       rx="2.4063713e-13"
+       ry="0.72084588" />
+    <g
+       id="g895">
+      <path
+         id="path895"
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#336699;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3.77953;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;stop-color:#000000;stop-opacity:1"
+         d="M 112.66211 53.962891 C 80.308605 53.962891 53.960937 80.310591 53.960938 112.66406 C 53.960938 145.01757 80.308605 171.37109 112.66211 171.37109 C 121.14933 171.37109 129.21556 169.54285 136.50977 166.2832 C 135.12934 162.3123 134.14328 159.47329 132.78711 155.57227 C 132.10564 155.89133 131.41568 156.19527 130.7168 156.48242 C 131.27164 155.74793 131.8047 155.00707 132.33008 154.26367 C 131.1972 151.00495 130.28046 148.36477 129.20508 145.27148 C 126.19574 150.25759 122.46056 155.10076 117.98242 159.73047 C 117.80097 159.75062 117.62152 159.77681 117.43945 159.79492 L 117.43945 137.91406 C 120.44608 137.81698 123.44984 137.61872 126.44727 137.33789 C 125.62946 134.98555 124.62473 132.09522 123.88477 129.9668 C 121.73851 130.13905 119.58999 130.28013 117.43945 130.35352 L 117.43945 109.91406 C 124.45699 109.68746 131.46175 108.96702 138.40039 107.74023 C 138.54983 109.53088 138.63864 111.32224 138.625 113.11328 C 138.60984 115.1041 138.48855 117.09547 138.26758 119.08398 L 145.42773 122.51562 C 145.89468 119.41331 146.15982 116.29668 146.18359 113.17383 C 146.20126 110.85303 146.092 108.53272 145.86523 106.21875 C 150.2663 105.2042 154.63082 103.98201 158.94727 102.55859 C 159.65096 105.8145 160.03125 109.1926 160.03125 112.66406 C 160.03125 116.06231 159.66922 119.37179 158.99414 122.56445 C 156.30709 123.50494 153.59566 124.35018 150.86914 125.12109 L 167.66406 133.16797 C 170.05559 126.78025 171.37109 119.87261 171.37109 112.66406 C 171.37109 80.310591 145.01561 53.962891 112.66211 53.962891 z M 109.87891 65.388672 L 109.87891 102.41406 C 103.0496 102.2788 96.229341 101.639 89.470703 100.50586 C 92.021401 88.266269 98.455021 76.27997 108.96875 65.457031 C 109.27211 65.433783 109.57395 65.406218 109.87891 65.388672 z M 117.43945 65.539062 C 117.62484 65.557496 117.80745 65.584918 117.99219 65.605469 C 128.35239 76.318058 134.7332 88.162004 137.30664 100.26172 C 130.73108 101.43557 124.09088 102.12656 117.43945 102.35352 L 117.43945 65.539062 z M 96.763672 68.027344 C 89.243309 77.742311 84.302288 88.269877 82.054688 99.0625 C 77.51568 98.047343 73.015578 96.796802 68.570312 95.324219 C 73.552385 82.610654 83.850465 72.605321 96.763672 68.027344 z M 130.68359 68.839844 C 142.60071 73.724467 152.05237 83.31454 156.75977 95.322266 C 152.78006 96.640526 148.75546 97.774662 144.69922 98.726562 C 142.48406 88.351481 137.7776 78.227087 130.68359 68.839844 z M 66.384766 102.55859 C 71.179025 104.13961 76.032936 105.46823 80.929688 106.54492 C 80.724479 108.75073 80.623786 110.96204 80.640625 113.17383 C 80.676139 117.83867 81.213754 122.49352 82.232422 127.09961 C 76.871772 125.908 71.564131 124.39771 66.337891 122.56836 C 65.662516 119.37455 65.300781 116.06364 65.300781 112.66406 C 65.300781 109.1926 65.681294 105.8145 66.384766 102.55859 z M 88.404297 107.98633 C 95.516366 109.16994 102.69349 109.83508 109.87891 109.9707 L 109.87891 130.41406 C 103.36402 130.28503 96.857193 129.69925 90.404297 128.66211 C 88.982362 123.51871 88.238808 118.31341 88.199219 113.11328 C 88.186208 111.40427 88.268851 109.69509 88.404297 107.98633 z M 69.152344 131.43945 C 74.236698 133.00601 79.385202 134.29218 84.574219 135.29688 C 87.26722 142.92132 91.35188 150.32161 96.755859 157.30273 C 84.335357 152.89555 74.328934 143.46949 69.152344 131.43945 z M 93.224609 136.71484 C 98.753472 137.44849 104.31393 137.86371 109.87891 137.96875 L 109.87891 159.94727 C 109.57917 159.93001 109.28255 159.90167 108.98438 159.87891 C 101.90893 152.59708 96.668769 144.78463 93.224609 136.71484 z "
+         transform="matrix(0.26458333,0,0,0.26458333,0,237.38055)" />
+      <g
+         id="path897"
+         style="opacity:1">
+        <path
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;stop-color:#000000;stop-opacity:1"
+           d="m 33.849609,269.51953 15.541016,7.44727 -6.859375,1.32617 4.652344,5.02344 -1.056641,0.99609 -4.566406,-5.10352 -2.078125,6.50977 z"
+           id="path49"
+           sodipodi:nodetypes="cccccccc" />
+        <path
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#336699;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;stop-color:#000000;stop-opacity:1"
+           d="m 33.849609,269.51953 15.541016,7.44727 -6.859375,1.32617 4.652344,5.02344 -1.056641,0.99609 -4.566406,-5.10352 -2.078125,6.50977 z"
+           id="path55"
+           sodipodi:nodetypes="cccccccc" />
+      </g>
+    </g>
+    <circle
+       style="fill:none;stroke:#ffcc33;stroke-width:4.3585;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path853"
+       cx="29.809719"
+       cy="267.19028"
+       r="27.630468" />
+  </g>
+</svg>

--- a/mu/resources/images/svg/button.svg
+++ b/mu/resources/images/svg/button.svg
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="59.619438mm"
+   height="59.619438mm"
+   viewBox="0 0 59.619438 59.619438"
+   version="1.1"
+   id="svg8"
+   inkscape:version="1.0.2-2 (e86c870879, 2021-01-15)"
+   sodipodi:docname="button.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="2.5135764"
+     inkscape:cx="115.32023"
+     inkscape:cy="107.01798"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     inkscape:document-rotation="0"
+     showgrid="false"
+     inkscape:snap-page="true"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:window-width="1920"
+     inkscape:window-height="1001"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1">
+    <sodipodi:guide
+       position="29.809499,69.619441"
+       orientation="-1,0"
+       id="guide24"
+       inkscape:label=""
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       position="-9.9999998,29.809721"
+       orientation="0,1"
+       id="guide26"
+       inkscape:label=""
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-237.38055)">
+    <circle
+       style="fill:none;stroke:#ffcc33;stroke-width:4.3585;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path853"
+       cx="29.809719"
+       cy="267.19028"
+       r="27.630468" />
+  </g>
+</svg>

--- a/mu/resources/images/svg/check-bad.svg
+++ b/mu/resources/images/svg/check-bad.svg
@@ -82,13 +82,6 @@
      inkscape:groupmode="layer"
      id="layer1"
      transform="translate(0,-237.38055)">
-    <ellipse
-       style="fill:none;stroke:#ffcc33;stroke-width:4.34999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="path871"
-       cx="29.809498"
-       cy="266.46942"
-       rx="2.4063713e-13"
-       ry="0.72084588" />
     <circle
        style="fill:none;stroke:#ffcc33;stroke-width:4.3585;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="path853"

--- a/mu/resources/images/svg/check-bad.svg
+++ b/mu/resources/images/svg/check-bad.svg
@@ -1,0 +1,129 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="59.619438mm"
+   height="59.619438mm"
+   viewBox="0 0 59.619438 59.619438"
+   version="1.1"
+   id="svg8"
+   inkscape:version="1.0.2-2 (e86c870879, 2021-01-15)"
+   sodipodi:docname="check-bad.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="2.5135765"
+     inkscape:cx="130.0053"
+     inkscape:cy="134.37301"
+     inkscape:document-units="mm"
+     inkscape:current-layer="g843"
+     inkscape:document-rotation="0"
+     showgrid="false"
+     inkscape:snap-page="true"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:window-width="1920"
+     inkscape:window-height="1001"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:snap-to-guides="true">
+    <sodipodi:guide
+       position="29.809499,69.619441"
+       orientation="-1,0"
+       id="guide24"
+       inkscape:label=""
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       position="-9.9999998,29.809721"
+       orientation="0,1"
+       id="guide26"
+       inkscape:label=""
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       position="-19.894461,69.619437"
+       orientation="0,1"
+       id="guide879"
+       inkscape:label=""
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-237.38055)">
+    <ellipse
+       style="fill:none;stroke:#ffcc33;stroke-width:4.34999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path871"
+       cx="29.809498"
+       cy="266.46942"
+       rx="2.4063713e-13"
+       ry="0.72084588" />
+    <circle
+       style="fill:none;stroke:#ffcc33;stroke-width:4.3585;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path853"
+       cx="29.809719"
+       cy="267.19028"
+       r="27.630468" />
+    <g
+       id="g843">
+      <g
+         id="g849">
+        <g
+           id="g941"
+           transform="matrix(1,0,0,-1,0,542.48914)">
+          <rect
+             style="fill:#336699;fill-opacity:1;stroke:none;stroke-width:5.85063;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             id="rect917"
+             width="6.75"
+             height="12.5"
+             x="16.747034"
+             y="264.99457"
+             rx="1"
+             ry="1" />
+          <circle
+             style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:2;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             id="path921"
+             cx="19.855726"
+             cy="274.45078"
+             r="1" />
+        </g>
+        <path
+           style="fill:#a51d2d;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="m 24.78561,277.03528 c 1.635086,-0.0217 5.335708,5.41911 5.801123,5.77481 0.662276,2.08381 0.559599,2.2498 0.80333,3.25318 0.210416,0.65085 0.356671,1.19397 1.039781,1.50497 2.018418,0.52998 2.936134,-0.13171 3.855397,-1.85985 0.21591,-0.74668 0.442616,-1.47176 0.111646,-3.31219 -0.147542,-0.70956 -0.313524,-1.42321 -1.079254,-2.27015 l 0.02631,-0.81423 5.181617,-0.0526 c 1.453444,-0.0247 3.483088,-2.97118 1.342019,-5.19929 0.919149,-1.36591 0.274636,-3.36871 -0.446587,-3.64713 0.316837,-1.61057 0.01855,-2.84698 -0.857556,-3.40495 0.09145,-0.83576 0.135777,-1.5872 -0.120951,-2.07478 -1.89217,-4.95573 -12.027589,-0.75718 -15.582448,0.11614 l -0.07443,11.9861 z"
+           id="path923"
+           sodipodi:nodetypes="cccccccccccccccc" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/mu/resources/images/svg/check-good.svg
+++ b/mu/resources/images/svg/check-good.svg
@@ -82,13 +82,6 @@
      inkscape:groupmode="layer"
      id="layer1"
      transform="translate(0,-237.38055)">
-    <ellipse
-       style="fill:none;stroke:#ffcc33;stroke-width:4.34999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="path871"
-       cx="29.809498"
-       cy="266.46942"
-       rx="2.4063713e-13"
-       ry="0.72084588" />
     <circle
        style="fill:none;stroke:#ffcc33;stroke-width:4.3585;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="path853"

--- a/mu/resources/images/svg/check-good.svg
+++ b/mu/resources/images/svg/check-good.svg
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="59.619438mm"
+   height="59.619438mm"
+   viewBox="0 0 59.619438 59.619438"
+   version="1.1"
+   id="svg8"
+   inkscape:version="1.0.2-2 (e86c870879, 2021-01-15)"
+   sodipodi:docname="check-good.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="2.5135766"
+     inkscape:cx="111.6322"
+     inkscape:cy="138.17806"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     inkscape:document-rotation="0"
+     showgrid="false"
+     inkscape:snap-page="true"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:window-width="1920"
+     inkscape:window-height="1001"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:snap-to-guides="true">
+    <sodipodi:guide
+       position="29.809499,69.619441"
+       orientation="-1,0"
+       id="guide24"
+       inkscape:label=""
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       position="-9.9999998,29.809721"
+       orientation="0,1"
+       id="guide26"
+       inkscape:label=""
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       position="-19.894461,69.619437"
+       orientation="0,1"
+       id="guide879"
+       inkscape:label=""
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-237.38055)">
+    <ellipse
+       style="fill:none;stroke:#ffcc33;stroke-width:4.34999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path871"
+       cx="29.809498"
+       cy="266.46942"
+       rx="2.4063713e-13"
+       ry="0.72084588" />
+    <circle
+       style="fill:none;stroke:#ffcc33;stroke-width:4.3585;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path853"
+       cx="29.809719"
+       cy="267.19028"
+       r="27.630468" />
+    <g
+       id="g843">
+      <g
+         id="g985"
+         transform="rotate(-16,25.6657,266.37151)">
+        <rect
+           style="fill:#336699;fill-opacity:1;stroke:none;stroke-width:5.85063;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="rect917"
+           width="6.75"
+           height="12.5"
+           x="16.747034"
+           y="264.99457"
+           rx="1"
+           ry="1" />
+        <circle
+           style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:2;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="path921"
+           cx="19.855726"
+           cy="274.45078"
+           r="1" />
+      </g>
+      <path
+         style="fill:#26a269;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m 24.404266,265.40757 c 1.577726,-0.42983 3.635302,-6.6799 3.984644,-7.15011 0.06224,-2.18564 -0.08221,-2.31689 -0.12449,-3.34859 0.02286,-0.68363 0.01376,-1.24603 0.584675,-1.73326 1.794147,-1.06581 2.858698,-0.68271 4.218691,0.72511 0.413359,0.65824 0.831141,1.29274 1.020284,3.1531 0.05375,0.72275 0.09091,1.4545 -0.411707,2.4797 l 0.249723,0.77543 4.995388,-1.37769 c 1.403948,-0.37687 4.167127,1.89602 2.72315,4.62797 1.260039,1.05964 1.19254,3.16251 0.575998,3.62894 0.748496,1.46085 0.802566,2.73158 0.114195,3.50943 0.318275,0.77817 0.56801,1.48829 0.455622,2.02774 -0.452886,5.28531 -11.352953,4.04311 -15.010823,4.18347 l -3.375364,-11.50127 z"
+         id="path923"
+         sodipodi:nodetypes="cccccccccccccccc" />
+    </g>
+  </g>
+</svg>

--- a/mu/resources/images/svg/check.svg
+++ b/mu/resources/images/svg/check.svg
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="59.619438mm"
+   height="59.619438mm"
+   viewBox="0 0 59.619438 59.619438"
+   version="1.1"
+   id="svg8"
+   inkscape:version="1.0.2-2 (e86c870879, 2021-01-15)"
+   sodipodi:docname="check.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="3.5547339"
+     inkscape:cx="116.27725"
+     inkscape:cy="117.06939"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     inkscape:document-rotation="0"
+     showgrid="false"
+     inkscape:snap-page="true"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:window-width="1920"
+     inkscape:window-height="1001"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:snap-to-guides="true">
+    <sodipodi:guide
+       position="29.809499,69.619441"
+       orientation="-1,0"
+       id="guide24"
+       inkscape:label=""
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       position="-9.9999998,29.809721"
+       orientation="0,1"
+       id="guide26"
+       inkscape:label=""
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       position="-19.894461,69.619437"
+       orientation="0,1"
+       id="guide879"
+       inkscape:label=""
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-237.38055)">
+    <ellipse
+       style="fill:none;stroke:#ffcc33;stroke-width:4.34999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path871"
+       cx="29.809498"
+       cy="266.46942"
+       rx="2.4063713e-13"
+       ry="0.72084588" />
+    <circle
+       style="fill:none;stroke:#ffcc33;stroke-width:4.3585;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path853"
+       cx="29.809719"
+       cy="267.19028"
+       r="27.630468" />
+    <g
+       id="g846">
+      <g
+         id="g840">
+        <rect
+           style="fill:#336699;fill-opacity:1;stroke:none;stroke-width:5.85063;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="rect917"
+           width="6.75"
+           height="12.5"
+           x="16.747034"
+           y="264.99457"
+           rx="1"
+           ry="1" />
+        <circle
+           style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:2;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="path921"
+           cx="19.855726"
+           cy="274.45078"
+           r="1" />
+      </g>
+      <path
+         style="fill:#336699;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m 24.78561,265.33136 c 1.635086,0.0217 5.335708,-5.41911 5.801123,-5.77481 0.662276,-2.08381 0.559599,-2.2498 0.80333,-3.25318 0.210416,-0.65085 0.356671,-1.19397 1.039781,-1.50497 2.018418,-0.52998 2.936134,0.13171 3.855397,1.85985 0.21591,0.74668 0.442616,1.47176 0.111646,3.31219 -0.147542,0.70956 -0.313524,1.42321 -1.079254,2.27015 l 0.02631,0.81423 5.181617,0.0526 c 1.453444,0.0247 3.483088,2.97118 1.342019,5.19929 0.919149,1.36591 0.274636,3.36871 -0.446587,3.64713 0.316837,1.61057 0.01855,2.84698 -0.857556,3.40495 0.09145,0.83576 0.135777,1.5872 -0.120951,2.07478 -1.89217,4.95573 -12.027589,0.75718 -15.582448,-0.11614 l -0.07443,-11.9861 z"
+         id="path923"
+         sodipodi:nodetypes="cccccccccccccccc" />
+    </g>
+  </g>
+</svg>

--- a/mu/resources/images/svg/check.svg
+++ b/mu/resources/images/svg/check.svg
@@ -82,13 +82,6 @@
      inkscape:groupmode="layer"
      id="layer1"
      transform="translate(0,-237.38055)">
-    <ellipse
-       style="fill:none;stroke:#ffcc33;stroke-width:4.34999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="path871"
-       cx="29.809498"
-       cy="266.46942"
-       rx="2.4063713e-13"
-       ry="0.72084588" />
     <circle
        style="fill:none;stroke:#ffcc33;stroke-width:4.3585;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="path853"

--- a/mu/resources/images/svg/css.svg
+++ b/mu/resources/images/svg/css.svg
@@ -83,13 +83,6 @@
      inkscape:groupmode="layer"
      id="layer1"
      transform="translate(0,-237.38055)">
-    <ellipse
-       style="fill:none;stroke:#ffcc33;stroke-width:4.34999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="path871"
-       cx="29.809498"
-       cy="266.46942"
-       rx="2.4063713e-13"
-       ry="0.72084588" />
     <circle
        style="fill:none;stroke:#ffcc33;stroke-width:4.3585;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="path853"

--- a/mu/resources/images/svg/css.svg
+++ b/mu/resources/images/svg/css.svg
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="59.619438mm"
+   height="59.619438mm"
+   viewBox="0 0 59.619438 59.619438"
+   version="1.1"
+   id="svg8"
+   inkscape:version="1.0.2-2 (e86c870879, 2021-01-15)"
+   sodipodi:docname="css.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="1.7773671"
+     inkscape:cx="171.64854"
+     inkscape:cy="161.32155"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     inkscape:document-rotation="0"
+     showgrid="false"
+     inkscape:snap-page="true"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:window-width="1920"
+     inkscape:window-height="1001"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:snap-to-guides="true"
+     inkscape:snap-global="false">
+    <sodipodi:guide
+       position="29.809499,69.619441"
+       orientation="-1,0"
+       id="guide24"
+       inkscape:label=""
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       position="-9.9999998,29.809721"
+       orientation="0,1"
+       id="guide26"
+       inkscape:label=""
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       position="-19.894461,69.619437"
+       orientation="0,1"
+       id="guide879"
+       inkscape:label=""
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-237.38055)">
+    <ellipse
+       style="fill:none;stroke:#ffcc33;stroke-width:4.34999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path871"
+       cx="29.809498"
+       cy="266.46942"
+       rx="2.4063713e-13"
+       ry="0.72084588" />
+    <circle
+       style="fill:none;stroke:#ffcc33;stroke-width:4.3585;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path853"
+       cx="29.809719"
+       cy="267.19028"
+       r="27.630468" />
+    <g
+       id="g845">
+      <path
+         id="rect1562"
+         style="fill:#336699;fill-opacity:1;stroke-width:7.55906"
+         d="M 61.068359 54.890625 C 50.599089 54.890625 42.171875 63.319792 42.171875 73.789062 L 42.171875 91.570312 C 42.171875 92.495701 42.257476 93.398024 42.384766 94.287109 C 42.380708 94.449005 42.361328 94.606623 42.361328 94.769531 L 42.361328 152.21875 C 42.361328 162.68804 50.790474 171.11719 61.259766 171.11719 L 161.41797 171.11719 C 171.88726 171.11719 180.31445 162.68804 180.31445 152.21875 L 180.31445 94.769531 C 180.31445 84.30024 171.88726 75.873047 161.41797 75.873047 L 106.02344 75.873047 L 106.02344 73.789062 C 106.02344 63.319792 97.596223 54.890625 87.126953 54.890625 L 61.068359 54.890625 z "
+         transform="matrix(0.26458333,0,0,0.26458333,0,237.38055)" />
+      <rect
+         style="fill:#ffffff;stroke-width:2;fill-opacity:1"
+         id="rect839"
+         width="2.9400353"
+         height="3.1261134"
+         x="14.551311"
+         y="271.61899" />
+      <path
+         style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.01;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 25.716,265.57139 v 2.30737 c -6.699689,-3.65891 -6.126138,7.67815 0,4.03789 v 2.19573 c -10.238161,4.50018 -9.746439,-13.28865 0,-8.54099 z"
+         id="path841"
+         sodipodi:nodetypes="ccccc" />
+      <path
+         style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.01;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 35.317632,265.29227 -0.0186,2.00965 c -3.072249,-1.15712 -7.190778,0.42568 -1.693311,1.45141 3.588642,0.63671 4.360749,8.25469 -4.931069,5.37765 l 0.03721,-2.25154 c 3.983818,2.06603 7.693087,-0.42716 2.363195,-1.39559 -4.762769,-0.9848 -2.977477,-7.44118 4.242575,-5.19158 z"
+         id="path843"
+         sodipodi:nodetypes="ccccccc" />
+      <path
+         style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.01;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 45.557885,265.29227 -0.0186,2.00965 c -3.072249,-1.15712 -7.190778,0.42568 -1.693311,1.45141 3.588642,0.63671 4.360749,8.25469 -4.931069,5.37765 l 0.03721,-2.25154 c 3.983818,2.06603 7.693087,-0.42716 2.363195,-1.39559 -4.762769,-0.9848 -2.977477,-7.44118 4.242575,-5.19158 z"
+         id="path847"
+         sodipodi:nodetypes="ccccccc" />
+    </g>
+  </g>
+</svg>

--- a/mu/resources/images/svg/debug.svg
+++ b/mu/resources/images/svg/debug.svg
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="59.619438mm"
+   height="59.619438mm"
+   viewBox="0 0 59.619438 59.619438"
+   version="1.1"
+   id="svg8"
+   inkscape:version="1.0.2-2 (e86c870879, 2021-01-15)"
+   sodipodi:docname="debug.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="2.5135766"
+     inkscape:cx="52.181732"
+     inkscape:cy="158.37531"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     inkscape:document-rotation="0"
+     showgrid="false"
+     inkscape:snap-page="true"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:window-width="1920"
+     inkscape:window-height="1001"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:snap-to-guides="true"
+     inkscape:snap-global="false">
+    <sodipodi:guide
+       position="29.809499,69.619441"
+       orientation="-1,0"
+       id="guide24"
+       inkscape:label=""
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       position="-9.9999998,29.809721"
+       orientation="0,1"
+       id="guide26"
+       inkscape:label=""
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       position="-19.894461,69.619437"
+       orientation="0,1"
+       id="guide879"
+       inkscape:label=""
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-237.38055)">
+    <ellipse
+       style="fill:none;stroke:#ffcc33;stroke-width:4.34999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path871"
+       cx="29.809498"
+       cy="266.46942"
+       rx="2.4063713e-13"
+       ry="0.72084588" />
+    <circle
+       style="fill:none;stroke:#ffcc33;stroke-width:4.3585;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path853"
+       cx="29.809719"
+       cy="267.19028"
+       r="27.630468" />
+    <g
+       id="g839">
+      <path
+         style="fill:#336699;fill-opacity:1;stroke:none;stroke-width:0.01;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="path1440"
+         sodipodi:type="arc"
+         sodipodi:cx="29.772503"
+         sodipodi:cy="258.89127"
+         sodipodi:rx="6"
+         sodipodi:ry="6"
+         sodipodi:start="3.1415927"
+         sodipodi:end="0"
+         sodipodi:arc-type="slice"
+         d="m 23.772503,258.89127 a 6,6 0 0 1 6,-6 6,6 0 0 1 6,6 h -6 z" />
+      <path
+         id="path1446"
+         style="fill:#336699;fill-opacity:1;stroke:#000000;stroke-width:0.0377953;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 68.457031 76.287109 C 67.345994 76.287109 66.234147 76.713119 65.382812 77.564453 C 63.680144 79.267122 63.680144 82.008269 65.382812 83.710938 L 77.642578 95.970703 L 77.642578 116.12695 L 61.931641 116.12695 C 59.523704 116.12695 57.585938 118.06472 57.585938 120.47266 C 57.585938 122.88059 59.523704 124.82031 61.931641 124.82031 L 77.642578 124.82031 L 77.642578 130.88867 C 77.642578 135.59153 79.179722 140.48743 81.689453 144.79102 C 81.571991 144.88638 81.447322 144.96869 81.337891 145.07812 L 67.492188 158.92383 C 65.789519 160.6265 65.789519 163.36764 67.492188 165.07031 C 69.194856 166.77298 71.936003 166.77298 73.638672 165.07031 L 87.056641 151.65234 C 87.058623 151.65425 87.060517 151.6563 87.0625 151.6582 C 92.583596 156.95548 100.07285 159.93164 107.88086 159.93164 L 107.88086 98.75 L 117.44336 98.75 L 117.44336 159.93164 C 125.18124 159.93164 132.60489 157.00521 138.11133 151.79688 L 151.80664 165.49219 C 153.50931 167.19486 156.25046 167.19486 157.95312 165.49219 C 159.65579 163.78952 159.65579 161.04837 157.95312 159.3457 L 144.10938 145.50195 C 143.92066 145.31324 143.71531 145.15274 143.50391 145.00586 C 146.08944 140.65005 147.68359 135.67112 147.68359 130.88867 L 147.68359 124.82031 L 163.51367 124.82031 C 165.92161 124.82031 167.86133 122.88059 167.86133 120.47266 C 167.86133 118.06472 165.92161 116.12695 163.51367 116.12695 L 147.68359 116.12695 L 147.68359 96.089844 L 159.92188 83.851562 C 161.62454 82.148894 161.62454 79.407747 159.92188 77.705078 C 158.21921 76.00241 155.47806 76.00241 153.77539 77.705078 L 142.14648 89.333984 L 117.44336 89.333984 L 117.44336 89.351562 L 107.88086 89.351562 L 107.88086 89.332031 L 83.300781 89.333984 L 71.529297 77.564453 C 70.677963 76.713119 69.568069 76.287109 68.457031 76.287109 z "
+         transform="matrix(0.26458333,0,0,0.26458333,0,237.38055)" />
+    </g>
+  </g>
+</svg>

--- a/mu/resources/images/svg/debug.svg
+++ b/mu/resources/images/svg/debug.svg
@@ -83,13 +83,6 @@
      inkscape:groupmode="layer"
      id="layer1"
      transform="translate(0,-237.38055)">
-    <ellipse
-       style="fill:none;stroke:#ffcc33;stroke-width:4.34999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="path871"
-       cx="29.809498"
-       cy="266.46942"
-       rx="2.4063713e-13"
-       ry="0.72084588" />
     <circle
        style="fill:none;stroke:#ffcc33;stroke-width:4.3585;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="path853"

--- a/mu/resources/images/svg/files.svg
+++ b/mu/resources/images/svg/files.svg
@@ -1,0 +1,128 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="59.619438mm"
+   height="59.619438mm"
+   viewBox="0 0 59.619438 59.619438"
+   version="1.1"
+   id="svg8"
+   inkscape:version="1.0.2-2 (e86c870879, 2021-01-15)"
+   sodipodi:docname="files.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="2.5135766"
+     inkscape:cx="63.989735"
+     inkscape:cy="132.50436"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     inkscape:document-rotation="0"
+     showgrid="false"
+     inkscape:snap-page="true"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:window-width="1920"
+     inkscape:window-height="1001"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:snap-to-guides="true"
+     inkscape:snap-global="false">
+    <sodipodi:guide
+       position="29.809499,69.619441"
+       orientation="-1,0"
+       id="guide24"
+       inkscape:label=""
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       position="-9.9999998,29.809721"
+       orientation="0,1"
+       id="guide26"
+       inkscape:label=""
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       position="-19.894461,69.619437"
+       orientation="0,1"
+       id="guide879"
+       inkscape:label=""
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-237.38055)">
+    <ellipse
+       style="fill:none;stroke:#ffcc33;stroke-width:4.34999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path871"
+       cx="29.809498"
+       cy="266.46942"
+       rx="2.4063713e-13"
+       ry="0.72084588" />
+    <circle
+       style="fill:none;stroke:#ffcc33;stroke-width:4.3585;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path853"
+       cx="29.809719"
+       cy="267.19028"
+       r="27.630468" />
+    <g
+       id="g849">
+      <path
+         id="rect1562"
+         style="fill:#336699;fill-opacity:1;stroke-width:7.55906"
+         d="M 61.068359 54.890625 C 50.599089 54.890625 42.171875 63.319792 42.171875 73.789062 L 42.171875 91.570312 C 42.171875 92.495701 42.257476 93.398024 42.384766 94.287109 C 42.380708 94.449005 42.361328 94.606623 42.361328 94.769531 L 42.361328 152.21875 C 42.361328 162.68804 50.790474 171.11719 61.259766 171.11719 L 161.41797 171.11719 C 171.88726 171.11719 180.31445 162.68804 180.31445 152.21875 L 180.31445 94.769531 C 180.31445 84.30024 171.88726 75.873047 161.41797 75.873047 L 106.02344 75.873047 L 106.02344 73.789062 C 106.02344 63.319792 97.596223 54.890625 87.126953 54.890625 L 61.068359 54.890625 z "
+         transform="matrix(0.26458333,0,0,0.26458333,0,237.38055)" />
+      <g
+         id="g842">
+        <path
+           id="rect2084"
+           style="fill:none;stroke:#ffffff;stroke-width:3.25001;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="m 23.657755,263.98977 h 11.26189 c 3.4625,0 6.25,2.66827 6.25,6.02892 v 0.14886 c 0,3.36064 -2.7875,6.06614 -6.25,6.06614 h -11.26189 c -3.4625,0 -6.25,-2.7055 -6.25,-6.06614 v -0.14886 c 0,-3.36065 2.7875,-6.02892 6.25,-6.02892 z"
+           sodipodi:nodetypes="sssssssss" />
+        <circle
+           style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:3.25001;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="path2087"
+           cx="23.483063"
+           cy="270.03726"
+           r="1.6" />
+        <circle
+           style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:3.25001;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="circle2089"
+           cx="34.874695"
+           cy="270.03726"
+           r="1.6" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/mu/resources/images/svg/files.svg
+++ b/mu/resources/images/svg/files.svg
@@ -83,13 +83,6 @@
      inkscape:groupmode="layer"
      id="layer1"
      transform="translate(0,-237.38055)">
-    <ellipse
-       style="fill:none;stroke:#ffcc33;stroke-width:4.34999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="path871"
-       cx="29.809498"
-       cy="266.46942"
-       rx="2.4063713e-13"
-       ry="0.72084588" />
     <circle
        style="fill:none;stroke:#ffcc33;stroke-width:4.3585;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="path853"

--- a/mu/resources/images/svg/flash.svg
+++ b/mu/resources/images/svg/flash.svg
@@ -83,13 +83,6 @@
      inkscape:groupmode="layer"
      id="layer1"
      transform="translate(0,-237.38055)">
-    <ellipse
-       style="fill:none;stroke:#ffcc33;stroke-width:4.34999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="path871"
-       cx="29.809498"
-       cy="266.46942"
-       rx="2.4063713e-13"
-       ry="0.72084588" />
     <circle
        style="fill:none;stroke:#ffcc33;stroke-width:4.3585;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="path853"

--- a/mu/resources/images/svg/flash.svg
+++ b/mu/resources/images/svg/flash.svg
@@ -1,0 +1,128 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="59.619438mm"
+   height="59.619438mm"
+   viewBox="0 0 59.619438 59.619438"
+   version="1.1"
+   id="svg8"
+   inkscape:version="1.0.2-2 (e86c870879, 2021-01-15)"
+   sodipodi:docname="flash.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="2.5135766"
+     inkscape:cx="77.660528"
+     inkscape:cy="117.90152"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     inkscape:document-rotation="0"
+     showgrid="false"
+     inkscape:snap-page="true"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:window-width="1920"
+     inkscape:window-height="1001"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:snap-to-guides="true"
+     inkscape:snap-global="true">
+    <sodipodi:guide
+       position="29.809499,69.619441"
+       orientation="-1,0"
+       id="guide24"
+       inkscape:label=""
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       position="-9.9999998,29.809721"
+       orientation="0,1"
+       id="guide26"
+       inkscape:label=""
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       position="-19.894461,69.619437"
+       orientation="0,1"
+       id="guide879"
+       inkscape:label=""
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-237.38055)">
+    <ellipse
+       style="fill:none;stroke:#ffcc33;stroke-width:4.34999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path871"
+       cx="29.809498"
+       cy="266.46942"
+       rx="2.4063713e-13"
+       ry="0.72084588" />
+    <circle
+       style="fill:none;stroke:#ffcc33;stroke-width:4.3585;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path853"
+       cx="29.809719"
+       cy="267.19028"
+       r="27.630468" />
+    <g
+       id="g849">
+      <g
+         id="g842">
+        <path
+           id="rect2084"
+           style="fill:none;stroke:#336699;stroke-width:3.25001;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="m 23.992699,267.16479 h 11.26189 c 3.4625,0 6.25,2.66827 6.25,6.02892 v 0.14886 c 0,3.36064 -2.7875,6.06614 -6.25,6.06614 h -11.26189 c -3.4625,0 -6.25,-2.7055 -6.25,-6.06614 v -0.14886 c 0,-3.36065 2.7875,-6.02892 6.25,-6.02892 z"
+           sodipodi:nodetypes="sssssssss" />
+        <circle
+           style="fill:#336699;fill-opacity:1;stroke:none;stroke-width:3.25001;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="path2087"
+           cx="23.818008"
+           cy="273.21231"
+           r="1.6" />
+        <circle
+           style="fill:#336699;fill-opacity:1;stroke:none;stroke-width:3.25001;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="circle2089"
+           cx="35.209641"
+           cy="273.21231"
+           r="1.6" />
+      </g>
+      <path
+         id="rect2105"
+         style="fill:#336699;fill-opacity:1;stroke:none;stroke-width:12.2835;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 106.88281 59.919922 L 106.88281 85.535156 L 92.867188 71.519531 L 92.867188 82.208984 L 106.75781 96.099609 L 112.10352 101.44531 L 117.44727 96.099609 L 131.33789 82.208984 L 131.33789 71.519531 L 117.15039 85.707031 L 117.15039 59.919922 L 106.88281 59.919922 z "
+         transform="matrix(0.26458333,0,0,0.26458333,0,237.38055)" />
+    </g>
+  </g>
+</svg>

--- a/mu/resources/images/svg/fonts.svg
+++ b/mu/resources/images/svg/fonts.svg
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="59.619438mm"
+   height="59.619438mm"
+   viewBox="0 0 59.619438 59.619438"
+   version="1.1"
+   id="svg8"
+   inkscape:version="1.0.2-2 (e86c870879, 2021-01-15)"
+   sodipodi:docname="fonts.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="1.2567883"
+     inkscape:cx="186.56143"
+     inkscape:cy="25.528036"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     inkscape:document-rotation="0"
+     showgrid="false"
+     inkscape:snap-page="true"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:window-width="1920"
+     inkscape:window-height="1001"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:snap-to-guides="true"
+     inkscape:snap-global="false">
+    <sodipodi:guide
+       position="29.809499,69.619441"
+       orientation="-1,0"
+       id="guide24"
+       inkscape:label=""
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       position="-9.9999998,29.809721"
+       orientation="0,1"
+       id="guide26"
+       inkscape:label=""
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       position="-19.894461,69.619437"
+       orientation="0,1"
+       id="guide879"
+       inkscape:label=""
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-237.38055)">
+    <ellipse
+       style="fill:none;stroke:#ffcc33;stroke-width:4.34999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path871"
+       cx="29.809498"
+       cy="266.46942"
+       rx="2.4063713e-13"
+       ry="0.72084588" />
+    <circle
+       style="fill:none;stroke:#ffcc33;stroke-width:4.3585;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path853"
+       cx="29.809719"
+       cy="267.19028"
+       r="27.630468" />
+    <path
+       id="path2129"
+       style="fill:#336699;fill-opacity:1;stroke:none;stroke-width:0.0377953;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 108.41211,56.119141 74.595703,143.81836 c -0.720295,1.82649 -1.863276,3.16213 -4.376953,3.58203 l -10.142578,1.88281 v 5.40821 c 25.802037,-2.35915 26.356117,-0.91625 37.148437,-0.26953 v -5.23243 l -9.408203,-2.09375 c -2.612145,-0.56655 -4.343863,-2.92686 -2.876953,-6.6582 l 8.154297,-19.89258 h 28.24805 l 10.14453,23.47266 c 0.36475,0.91623 0.343,2.81822 -2.38672,3.38281 l -11.53711,1.98828 v 4.77539 c 18.34824,-1.65867 35.00773,-0.98182 48.78516,0.0742 v -4.99805 l -6.41602,-1.24414 c -2.44506,-0.51987 -5.41724,-1.62524 -6.96289,-4.57421 L 116.73633,56.119141 Z m -1.65047,27.216732 11.67776,29.120187 H 95.283203 Z"
+       transform="matrix(0.26458333,0,0,0.26458333,0,237.38055)"
+       sodipodi:nodetypes="ccccccccccccccccccccccccc" />
+  </g>
+</svg>

--- a/mu/resources/images/svg/fonts.svg
+++ b/mu/resources/images/svg/fonts.svg
@@ -83,13 +83,6 @@
      inkscape:groupmode="layer"
      id="layer1"
      transform="translate(0,-237.38055)">
-    <ellipse
-       style="fill:none;stroke:#ffcc33;stroke-width:4.34999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="path871"
-       cx="29.809498"
-       cy="266.46942"
-       rx="2.4063713e-13"
-       ry="0.72084588" />
     <circle
        style="fill:none;stroke:#ffcc33;stroke-width:4.3585;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="path853"

--- a/mu/resources/images/svg/help.svg
+++ b/mu/resources/images/svg/help.svg
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="59.619438mm"
+   height="59.619438mm"
+   viewBox="0 0 59.619438 59.619438"
+   version="1.1"
+   id="svg8"
+   inkscape:version="1.0.2-2 (e86c870879, 2021-01-15)"
+   sodipodi:docname="help.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="3.5547341"
+     inkscape:cx="72.909404"
+     inkscape:cy="107.89055"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     inkscape:document-rotation="0"
+     showgrid="false"
+     inkscape:snap-page="true"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:window-width="1920"
+     inkscape:window-height="1001"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:snap-to-guides="true"
+     inkscape:snap-global="false">
+    <sodipodi:guide
+       position="29.809499,69.619441"
+       orientation="-1,0"
+       id="guide24"
+       inkscape:label=""
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       position="-9.9999998,29.809721"
+       orientation="0,1"
+       id="guide26"
+       inkscape:label=""
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       position="-19.894461,69.619437"
+       orientation="0,1"
+       id="guide879"
+       inkscape:label=""
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-237.38055)">
+    <ellipse
+       style="fill:none;stroke:#ffcc33;stroke-width:4.34999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path871"
+       cx="29.809498"
+       cy="266.46942"
+       rx="2.4063713e-13"
+       ry="0.72084588" />
+    <circle
+       style="fill:none;stroke:#ffcc33;stroke-width:4.3585;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path853"
+       cx="29.809719"
+       cy="267.19028"
+       r="27.630468" />
+    <g
+       id="g839">
+      <path
+         style="fill:#336699;fill-opacity:1;stroke:none;stroke-width:0.01;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 27.196,272.44855 h 4.941 v 4.777 h -4.941 z"
+         id="path2723"
+         sodipodi:nodetypes="ccccc" />
+      <path
+         style="fill:#336699;fill-opacity:1;stroke:none;stroke-width:0.01;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 25.687814,263.87621 -3.135143,-2.56601 c 2.355234,-3.31405 3.628101,-4.29403 7.219833,-4.35423 5.370972,-0.0167 7.252989,3.73199 7.257047,6.06615 0.04457,1.82981 -0.822063,3.4903 -3.163329,4.91246 -1.246978,0.83093 -1.674219,1.22963 -1.921666,3.09979 l -4.674532,0.005 c -0.331791,-3.66854 1.823975,-5.17227 3.246792,-5.85827 3.752968,-1.4698 0.790573,-3.86949 -0.781528,-3.94485 -1.82232,-0.0182 -2.419653,1.02941 -4.047474,2.64041 z"
+         id="path2725"
+         sodipodi:nodetypes="ccccccccccc" />
+    </g>
+  </g>
+</svg>

--- a/mu/resources/images/svg/help.svg
+++ b/mu/resources/images/svg/help.svg
@@ -83,13 +83,6 @@
      inkscape:groupmode="layer"
      id="layer1"
      transform="translate(0,-237.38055)">
-    <ellipse
-       style="fill:none;stroke:#ffcc33;stroke-width:4.34999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="path871"
-       cx="29.809498"
-       cy="266.46942"
-       rx="2.4063713e-13"
-       ry="0.72084588" />
     <circle
        style="fill:none;stroke:#ffcc33;stroke-width:4.3585;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="path853"

--- a/mu/resources/images/svg/images.svg
+++ b/mu/resources/images/svg/images.svg
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="59.619438mm"
+   height="59.619438mm"
+   viewBox="0 0 59.619438 59.619438"
+   version="1.1"
+   id="svg8"
+   inkscape:version="1.0.2-2 (e86c870879, 2021-01-15)"
+   sodipodi:docname="images.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="2.5135766"
+     inkscape:cx="90.158202"
+     inkscape:cy="123.33704"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     inkscape:document-rotation="0"
+     showgrid="false"
+     inkscape:snap-page="true"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:window-width="1920"
+     inkscape:window-height="1001"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:snap-to-guides="true"
+     inkscape:snap-global="false">
+    <sodipodi:guide
+       position="29.809499,69.619441"
+       orientation="-1,0"
+       id="guide24"
+       inkscape:label=""
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       position="-9.9999998,29.809721"
+       orientation="0,1"
+       id="guide26"
+       inkscape:label=""
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       position="-19.894461,69.619437"
+       orientation="0,1"
+       id="guide879"
+       inkscape:label=""
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-237.38055)">
+    <ellipse
+       style="fill:none;stroke:#ffcc33;stroke-width:4.34999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path871"
+       cx="29.809498"
+       cy="266.46942"
+       rx="2.4063713e-13"
+       ry="0.72084588" />
+    <circle
+       style="fill:none;stroke:#ffcc33;stroke-width:4.3585;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path853"
+       cx="29.809719"
+       cy="267.19028"
+       r="27.630468" />
+    <g
+       id="g839">
+      <path
+         style="fill:#336699;fill-opacity:1;stroke:none;stroke-width:0.01;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 30.597131,273.04565 c -2.732562,-0.68754 -3.73873,-2.09974 -4.266293,-3.52306 -4.349608,-0.12702 -6.649434,1.59809 -7.693133,4.7894 -0.203002,0.50211 -0.80671,0.54471 -1.322156,0.38383 -0.478891,-0.18769 -0.731556,-0.15359 -3.157851,-2.10523 0.09096,1.61851 0.07573,3.51166 1.210509,5.6315 1.46442,2.56167 3.100956,4.36445 7.052534,4.21047 2.305547,-0.008 4.498024,-0.51599 6.315702,-2.68418 1.966699,-2.47705 1.998193,-4.60513 1.860688,-6.70273 z"
+         id="path2741"
+         sodipodi:nodetypes="ccccccccc" />
+      <path
+         style="fill:#336699;fill-opacity:1;stroke:none;stroke-width:0.01;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 28.221034,263.26722 c -3.935241,5.48442 3.826023,11.5252 8.370562,6.19183 2.537202,-2.9198 5.159717,-8.22835 7.763051,-12.99982 1.864073,-3.20199 -1.802846,-6.27574 -4.381518,-3.94731 -9.590999,8.45039 -10.788791,9.56667 -11.752095,10.7553 z"
+         id="path2743"
+         sodipodi:nodetypes="ccccc" />
+    </g>
+  </g>
+</svg>

--- a/mu/resources/images/svg/images.svg
+++ b/mu/resources/images/svg/images.svg
@@ -83,13 +83,6 @@
      inkscape:groupmode="layer"
      id="layer1"
      transform="translate(0,-237.38055)">
-    <ellipse
-       style="fill:none;stroke:#ffcc33;stroke-width:4.34999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="path871"
-       cx="29.809498"
-       cy="266.46942"
-       rx="2.4063713e-13"
-       ry="0.72084588" />
     <circle
        style="fill:none;stroke:#ffcc33;stroke-width:4.3585;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="path853"

--- a/mu/resources/images/svg/load.svg
+++ b/mu/resources/images/svg/load.svg
@@ -83,13 +83,6 @@
      inkscape:groupmode="layer"
      id="layer1"
      transform="translate(0,-237.38055)">
-    <ellipse
-       style="fill:none;stroke:#ffcc33;stroke-width:4.34999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="path871"
-       cx="29.809498"
-       cy="266.46942"
-       rx="2.4063713e-13"
-       ry="0.72084588" />
     <circle
        style="fill:none;stroke:#ffcc33;stroke-width:4.3585;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="path853"

--- a/mu/resources/images/svg/load.svg
+++ b/mu/resources/images/svg/load.svg
@@ -1,0 +1,136 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="59.619438mm"
+   height="59.619438mm"
+   viewBox="0 0 59.619438 59.619438"
+   version="1.1"
+   id="svg8"
+   inkscape:version="1.0.2-2 (e86c870879, 2021-01-15)"
+   sodipodi:docname="load.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="5.6568542"
+     inkscape:cx="135.28299"
+     inkscape:cy="115.34769"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     inkscape:document-rotation="0"
+     showgrid="false"
+     inkscape:snap-page="true"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:window-width="1920"
+     inkscape:window-height="1001"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:snap-to-guides="true"
+     inkscape:snap-global="false">
+    <sodipodi:guide
+       position="29.809499,69.619441"
+       orientation="-1,0"
+       id="guide24"
+       inkscape:label=""
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       position="-9.9999998,29.809721"
+       orientation="0,1"
+       id="guide26"
+       inkscape:label=""
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       position="-19.894461,69.619437"
+       orientation="0,1"
+       id="guide879"
+       inkscape:label=""
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-237.38055)">
+    <ellipse
+       style="fill:none;stroke:#ffcc33;stroke-width:4.34999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path871"
+       cx="29.809498"
+       cy="266.46942"
+       rx="2.4063713e-13"
+       ry="0.72084588" />
+    <circle
+       style="fill:none;stroke:#ffcc33;stroke-width:4.3585;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path853"
+       cx="29.809719"
+       cy="267.19028"
+       r="27.630468" />
+    <g
+       id="g855">
+      <path
+         id="path2771"
+         style="fill:#336699;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m 29.835387,254.00073 c -0.07674,0.004 -0.15463,0.0422 -0.235643,0.11627 l -8.096147,7.92045 c -0.519989,0.51983 -0.132153,1.60393 0.621151,1.60093 l 3.92224,0.01 c 0.54846,0.001 0.5817,0.0319 0.586012,0.58033 l 0.05064,7.23831 c -0.0097,0.4264 0.09511,0.60835 0.659907,0.61134 h 5.005896 c 0.564798,-0.003 0.669594,-0.18494 0.65991,-0.61134 l 0.05116,-7.23831 c 0.0043,-0.54845 0.03704,-0.57922 0.585496,-0.58033 l 3.922239,-0.01 c 0.753303,0.003 1.14114,-1.0811 0.621152,-1.60093 L 30.093253,254.117 c -0.08099,-0.074 -0.158411,-0.11196 -0.235127,-0.11627 -0.0072,0 -0.01491,-0.003 -0.02274,0 z" />
+      <g
+         id="g846">
+        <circle
+           style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:2;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.638978"
+           id="path2777"
+           cx="36.099087"
+           cy="277.26648"
+           r="1.0252604" />
+        <g
+           id="g2786">
+          <path
+             id="rect2759"
+             style="fill:#336699;fill-opacity:1;stroke:none;stroke-width:0.0377953;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             d="M 67.417969 130.81055 C 64.277181 130.81055 61.748047 133.33968 61.748047 136.48047 L 61.748047 156.79102 C 61.748047 159.9318 64.277181 162.45898 67.417969 162.45898 L 158.33789 162.45898 C 161.47868 162.45898 164.00586 159.9318 164.00586 156.79102 L 164.00586 136.48047 C 164.00586 133.33968 161.47868 130.81055 158.33789 130.81055 L 132.20508 130.81055 C 131.50143 135.75042 127.48384 138.65668 122.28711 138.70117 L 103.32422 138.70117 C 98.127484 138.65665 94.11152 135.75042 93.408203 130.81055 L 67.417969 130.81055 z M 101.58398 130.81055 C 101.96494 131.02937 102.52414 131.13628 103.3457 131.14062 L 122.26562 131.14062 C 123.08719 131.13627 123.64638 131.02937 124.02734 130.81055 L 101.58398 130.81055 z "
+             transform="matrix(0.26458333,0,0,0.26458333,0,237.38055)" />
+          <circle
+             style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:2;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.638978"
+             id="circle2779"
+             cx="36.066013"
+             cy="277.26648"
+             r="1.0252604" />
+          <circle
+             style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:2;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.638978"
+             id="circle2781"
+             cx="40.233204"
+             cy="277.26648"
+             r="1.0252604" />
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/mu/resources/images/svg/modes.svg
+++ b/mu/resources/images/svg/modes.svg
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="59.619438mm"
+   height="59.619438mm"
+   viewBox="0 0 59.619438 59.619438"
+   version="1.1"
+   id="svg8"
+   inkscape:version="1.0.2-2 (e86c870879, 2021-01-15)"
+   sodipodi:docname="modes.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="2.8284271"
+     inkscape:cx="200.98915"
+     inkscape:cy="125.5305"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     inkscape:document-rotation="0"
+     showgrid="false"
+     inkscape:snap-page="true"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:window-width="1920"
+     inkscape:window-height="1001"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:snap-to-guides="true"
+     inkscape:snap-global="false">
+    <sodipodi:guide
+       position="29.809499,69.619441"
+       orientation="-1,0"
+       id="guide24"
+       inkscape:label=""
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       position="-9.9999998,29.809721"
+       orientation="0,1"
+       id="guide26"
+       inkscape:label=""
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       position="-19.894461,69.619437"
+       orientation="0,1"
+       id="guide879"
+       inkscape:label=""
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-237.38055)">
+    <ellipse
+       style="fill:none;stroke:#ffcc33;stroke-width:4.34999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path871"
+       cx="29.809498"
+       cy="266.46942"
+       rx="2.4063713e-13"
+       ry="0.72084588" />
+    <circle
+       style="fill:none;stroke:#ffcc33;stroke-width:4.3585;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path853"
+       cx="29.809719"
+       cy="267.19028"
+       r="27.630468" />
+    <g
+       id="g839">
+      <path
+         id="rect2802"
+         style="fill:#336699;fill-opacity:1;stroke:none;stroke-width:2;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.638978"
+         d="m 15.949309,261.28113 c 0.04643,-2.80384 3.046713,-4.86299 5.144938,-5.3788 3.473791,-0.85225 11.974648,-0.93749 18.00093,8.7e-4 3.272456,0.58224 5.011626,0.95699 5.741744,3.30406 0.406891,1.65846 0.278388,4.42091 0.267675,7.36687 H 28.110073 v 14.02393 H 15.949309 Z"
+         sodipodi:nodetypes="ccccccccc" />
+      <circle
+         style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:2;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.638978"
+         id="path2807"
+         cx="39.943432"
+         cy="261.31421"
+         r="2.9934187" />
+    </g>
+  </g>
+</svg>

--- a/mu/resources/images/svg/modes.svg
+++ b/mu/resources/images/svg/modes.svg
@@ -83,13 +83,6 @@
      inkscape:groupmode="layer"
      id="layer1"
      transform="translate(0,-237.38055)">
-    <ellipse
-       style="fill:none;stroke:#ffcc33;stroke-width:4.34999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="path871"
-       cx="29.809498"
-       cy="266.46942"
-       rx="2.4063713e-13"
-       ry="0.72084588" />
     <circle
        style="fill:none;stroke:#ffcc33;stroke-width:4.3585;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="path853"

--- a/mu/resources/images/svg/music.svg
+++ b/mu/resources/images/svg/music.svg
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="59.619438mm"
+   height="59.619438mm"
+   viewBox="0 0 59.619438 59.619438"
+   version="1.1"
+   id="svg8"
+   inkscape:version="1.0.2-2 (e86c870879, 2021-01-15)"
+   sodipodi:docname="music.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="2.8284271"
+     inkscape:cx="69.027419"
+     inkscape:cy="124.58119"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     inkscape:document-rotation="0"
+     showgrid="false"
+     inkscape:snap-page="true"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     showguides="false"
+     inkscape:guide-bbox="true"
+     inkscape:window-width="1920"
+     inkscape:window-height="1001"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:snap-to-guides="true"
+     inkscape:snap-global="true">
+    <sodipodi:guide
+       position="29.809499,69.619441"
+       orientation="-1,0"
+       id="guide24"
+       inkscape:label=""
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       position="-9.9999998,29.809721"
+       orientation="0,1"
+       id="guide26"
+       inkscape:label=""
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       position="-19.894461,69.619437"
+       orientation="0,1"
+       id="guide879"
+       inkscape:label=""
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-237.38055)">
+    <ellipse
+       style="fill:none;stroke:#ffcc33;stroke-width:4.34999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path871"
+       cx="29.809498"
+       cy="266.46942"
+       rx="2.4063713e-13"
+       ry="0.72084588" />
+    <circle
+       style="fill:none;stroke:#ffcc33;stroke-width:4.3585;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path853"
+       cx="29.809719"
+       cy="267.19028"
+       r="27.630468" />
+    <path
+       id="rect3405"
+       style="fill:#336699;fill-opacity:1;stroke:none;stroke-width:7.35084;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.638978"
+       d="M 159.35938 48.548828 C 158.47068 48.558899 157.52642 48.714173 156.54492 49.029297 L 99.042969 67.490234 C 89.541249 70.540903 89.595703 70.300505 89.595703 79.972656 L 89.595703 98.871094 L 89.595703 147.90234 A 24.041629 14.318913 0 0 0 74.246094 144.60352 A 24.041629 14.318913 0 0 0 50.205078 158.92188 A 24.041629 14.318913 0 0 0 74.246094 173.24219 A 24.041629 14.318913 0 0 0 98.287109 158.92188 A 24.041629 14.318913 0 0 0 98.287109 158.89648 L 98.287109 105.49023 C 98.5371 105.42964 98.787756 105.3671 99.042969 105.28516 L 156.54492 86.824219 C 156.80028 86.742231 157.05065 86.642965 157.30078 86.542969 L 157.30078 128.81055 A 24.041629 14.318913 0 0 0 141.95117 125.51172 A 24.041629 14.318913 0 0 0 117.91016 139.83008 A 24.041629 14.318913 0 0 0 141.95117 154.14844 A 24.041629 14.318913 0 0 0 165.99414 139.83008 A 24.041629 14.318913 0 0 0 165.99219 139.71094 L 165.99414 139.71094 L 165.99414 74.341797 L 165.99414 55.443359 C 165.99414 51.19021 163.21037 48.505187 159.35938 48.548828 z "
+       transform="matrix(0.26458333,0,0,0.26458333,0,237.38055)" />
+  </g>
+</svg>

--- a/mu/resources/images/svg/music.svg
+++ b/mu/resources/images/svg/music.svg
@@ -83,13 +83,6 @@
      inkscape:groupmode="layer"
      id="layer1"
      transform="translate(0,-237.38055)">
-    <ellipse
-       style="fill:none;stroke:#ffcc33;stroke-width:4.34999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="path871"
-       cx="29.809498"
-       cy="266.46942"
-       rx="2.4063713e-13"
-       ry="0.72084588" />
     <circle
        style="fill:none;stroke:#ffcc33;stroke-width:4.3585;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="path853"

--- a/mu/resources/images/svg/new.svg
+++ b/mu/resources/images/svg/new.svg
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="59.619438mm"
+   height="59.619438mm"
+   viewBox="0 0 59.619438 59.619438"
+   version="1.1"
+   id="svg8"
+   inkscape:version="1.0.2-2 (e86c870879, 2021-01-15)"
+   sodipodi:docname="new.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="2.8284271"
+     inkscape:cx="135.154"
+     inkscape:cy="118.27762"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     inkscape:document-rotation="0"
+     showgrid="false"
+     inkscape:snap-page="true"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:window-width="1920"
+     inkscape:window-height="1001"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:snap-to-guides="true"
+     inkscape:snap-global="true">
+    <sodipodi:guide
+       position="29.809499,69.619441"
+       orientation="-1,0"
+       id="guide24"
+       inkscape:label=""
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       position="-9.9999998,29.809721"
+       orientation="0,1"
+       id="guide26"
+       inkscape:label=""
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       position="-19.894461,69.619437"
+       orientation="0,1"
+       id="guide879"
+       inkscape:label=""
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-237.38055)">
+    <ellipse
+       style="fill:none;stroke:#ffcc33;stroke-width:4.34999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path871"
+       cx="29.809498"
+       cy="266.46942"
+       rx="2.4063713e-13"
+       ry="0.72084588" />
+    <circle
+       style="fill:none;stroke:#ffcc33;stroke-width:4.3585;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path853"
+       cx="29.809719"
+       cy="267.19028"
+       r="27.630468" />
+    <path
+       id="rect3427"
+       style="fill:#336699;fill-opacity:1;stroke:none;stroke-width:7.55906;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.638978"
+       d="M 105.45898 69.738281 C 102.3182 69.738281 99.791016 72.267416 99.791016 75.408203 L 99.791016 101.11523 L 74.082031 101.11523 C 70.941244 101.11523 68.412109 103.64437 68.412109 106.78516 L 68.412109 118.42773 C 68.412109 121.56852 70.941244 124.09766 74.082031 124.09766 L 99.791016 124.09766 L 99.791016 149.80469 C 99.791016 152.94547 102.3182 155.47461 105.45898 155.47461 L 117.10156 155.47461 C 120.24235 155.47461 122.77148 152.94547 122.77148 149.80469 L 122.77148 124.09766 L 148.48047 124.09766 C 151.62126 124.09766 154.14844 121.56852 154.14844 118.42773 L 154.14844 106.78516 C 154.14844 103.64437 151.62126 101.11523 148.48047 101.11523 L 122.77148 101.11523 L 122.77148 75.408203 C 122.77148 72.267416 120.24235 69.738281 117.10156 69.738281 L 105.45898 69.738281 z "
+       transform="matrix(0.26458333,0,0,0.26458333,0,237.38055)" />
+  </g>
+</svg>

--- a/mu/resources/images/svg/new.svg
+++ b/mu/resources/images/svg/new.svg
@@ -83,13 +83,6 @@
      inkscape:groupmode="layer"
      id="layer1"
      transform="translate(0,-237.38055)">
-    <ellipse
-       style="fill:none;stroke:#ffcc33;stroke-width:4.34999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="path871"
-       cx="29.809498"
-       cy="266.46942"
-       rx="2.4063713e-13"
-       ry="0.72084588" />
     <circle
        style="fill:none;stroke:#ffcc33;stroke-width:4.3585;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="path853"

--- a/mu/resources/images/svg/play.svg
+++ b/mu/resources/images/svg/play.svg
@@ -1,0 +1,127 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="59.619438mm"
+   height="59.619438mm"
+   viewBox="0 0 59.619438 59.619438"
+   version="1.1"
+   id="svg8"
+   inkscape:version="1.0.2-2 (e86c870879, 2021-01-15)"
+   sodipodi:docname="play.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="5.6568542"
+     inkscape:cx="151.46757"
+     inkscape:cy="133.52826"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     inkscape:document-rotation="0"
+     showgrid="false"
+     inkscape:snap-page="true"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:window-width="1920"
+     inkscape:window-height="1001"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:snap-to-guides="true"
+     inkscape:snap-global="false">
+    <sodipodi:guide
+       position="29.809499,69.619441"
+       orientation="-1,0"
+       id="guide24"
+       inkscape:label=""
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       position="-9.9999998,29.809721"
+       orientation="0,1"
+       id="guide26"
+       inkscape:label=""
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       position="-19.894461,69.619437"
+       orientation="0,1"
+       id="guide879"
+       inkscape:label=""
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-237.38055)">
+    <ellipse
+       style="fill:none;stroke:#ffcc33;stroke-width:4.34999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path871"
+       cx="29.809498"
+       cy="266.46942"
+       rx="2.4063713e-13"
+       ry="0.72084588" />
+    <circle
+       style="fill:none;stroke:#ffcc33;stroke-width:4.3585;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path853"
+       cx="29.809719"
+       cy="267.19028"
+       r="27.630468" />
+    <g
+       id="g843">
+      <path
+         id="path3446"
+         style="fill:#336699;fill-opacity:1;stroke:none;stroke-width:7.55906;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.638978"
+         d="M 87 84 L 87 84.015625 A 30.23622 30.23622 0 0 0 57.013672 114.25 A 30.23622 30.23622 0 0 0 87.25 144.48633 A 30.23622 30.23622 0 0 0 107.26367 136.91406 L 123.36133 136.91406 A 30.23622 30.23622 0 0 0 143.375 144.48633 A 30.23622 30.23622 0 0 0 173.61133 114.25 A 30.23622 30.23622 0 0 0 144.125 84.023438 L 144.125 84 L 87 84 z "
+         transform="matrix(0.26458333,0,0,0.26458333,0,237.38055)" />
+      <path
+         id="rect3454"
+         style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:7.55906;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.638978"
+         d="M 83.765625 94.375 C 82.718696 94.375 81.875 95.218696 81.875 96.265625 L 81.875 108.25586 L 69.904297 108.25586 C 68.895288 108.25586 68.082031 109.18289 68.082031 110.33398 L 68.082031 118.27344 C 68.082031 119.42454 68.895288 120.35156 69.904297 120.35156 L 81.875 120.35156 L 81.875 132.48438 C 81.875 133.5313 82.718696 134.375 83.765625 134.375 L 90.984375 134.375 C 92.031304 134.375 92.875 133.5313 92.875 132.48438 L 92.875 120.35156 L 104.8125 120.35156 C 105.82151 120.35156 106.63281 119.42454 106.63281 118.27344 L 106.63281 110.33398 C 106.63281 109.18289 105.82151 108.25586 104.8125 108.25586 L 92.875 108.25586 L 92.875 96.265625 C 92.875 95.218696 92.031304 94.375 90.984375 94.375 L 83.765625 94.375 z "
+         transform="matrix(0.26458333,0,0,0.26458333,0,237.38055)" />
+      <ellipse
+         style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:2;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.638978"
+         id="path3459"
+         cx="35.68716"
+         cy="269.70007"
+         rx="2.25"
+         ry="2.1047475" />
+      <ellipse
+         style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:2;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.638978"
+         id="ellipse3461"
+         cx="39.849884"
+         cy="265.56073"
+         rx="2.25"
+         ry="2.1047475" />
+    </g>
+  </g>
+</svg>

--- a/mu/resources/images/svg/play.svg
+++ b/mu/resources/images/svg/play.svg
@@ -83,13 +83,6 @@
      inkscape:groupmode="layer"
      id="layer1"
      transform="translate(0,-237.38055)">
-    <ellipse
-       style="fill:none;stroke:#ffcc33;stroke-width:4.34999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="path871"
-       cx="29.809498"
-       cy="266.46942"
-       rx="2.4063713e-13"
-       ry="0.72084588" />
     <circle
        style="fill:none;stroke:#ffcc33;stroke-width:4.3585;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="path853"

--- a/mu/resources/images/svg/plotter.svg
+++ b/mu/resources/images/svg/plotter.svg
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="59.619438mm"
+   height="59.619438mm"
+   viewBox="0 0 59.619438 59.619438"
+   version="1.1"
+   id="svg8"
+   inkscape:version="1.0.2-2 (e86c870879, 2021-01-15)"
+   sodipodi:docname="plotter.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="1"
+     inkscape:cx="420.36214"
+     inkscape:cy="172.9264"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     inkscape:document-rotation="0"
+     showgrid="false"
+     inkscape:snap-page="true"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:window-width="1920"
+     inkscape:window-height="1001"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:snap-to-guides="true"
+     inkscape:snap-global="false">
+    <sodipodi:guide
+       position="29.809499,69.619441"
+       orientation="-1,0"
+       id="guide24"
+       inkscape:label=""
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       position="-9.9999998,29.809721"
+       orientation="0,1"
+       id="guide26"
+       inkscape:label=""
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       position="-19.894461,69.619437"
+       orientation="0,1"
+       id="guide879"
+       inkscape:label=""
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-237.38055)">
+    <ellipse
+       style="fill:none;stroke:#ffcc33;stroke-width:4.34999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path871"
+       cx="29.809498"
+       cy="266.46942"
+       rx="2.4063713e-13"
+       ry="0.72084588" />
+    <circle
+       style="fill:none;stroke:#ffcc33;stroke-width:4.3585;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path853"
+       cx="29.809719"
+       cy="267.19028"
+       r="27.630468" />
+    <path
+       id="rect3477"
+       style="fill:#336699;fill-opacity:1;stroke:none;stroke-width:0.01;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.638978"
+       d="m 11.693041,266.7067 h 7.764181 L 22.38,255.15355 c 0.514232,-1.65035 3.104491,-1.57543 3.597223,0 l 4.486917,15.91745 3.003714,-9.49545 c 0.603888,-1.72946 2.804718,-1.70249 3.750024,0 l 2.678924,5.131 7.202771,1.5e-4 v 3.695 l -8.861166,-1.5e-4 c -1.142282,0.0195 -1.614615,-0.79195 -1.762332,-1.10604 l -0.684151,-1.65053 -3.457504,10.95856 c -0.73318,1.79389 -2.881094,1.8719 -3.788827,0 l -4.224066,-14.79673 c -1.054714,2.54928 -0.722754,6.5764 -3.07825,6.59488 h -9.550236 z"
+       sodipodi:nodetypes="ccccccccccccccccccc" />
+  </g>
+</svg>

--- a/mu/resources/images/svg/plotter.svg
+++ b/mu/resources/images/svg/plotter.svg
@@ -83,13 +83,6 @@
      inkscape:groupmode="layer"
      id="layer1"
      transform="translate(0,-237.38055)">
-    <ellipse
-       style="fill:none;stroke:#ffcc33;stroke-width:4.34999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="path871"
-       cx="29.809498"
-       cy="266.46942"
-       rx="2.4063713e-13"
-       ry="0.72084588" />
     <circle
        style="fill:none;stroke:#ffcc33;stroke-width:4.3585;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="path853"

--- a/mu/resources/images/svg/quit.svg
+++ b/mu/resources/images/svg/quit.svg
@@ -27,7 +27,7 @@
      inkscape:cx="167.23506"
      inkscape:cy="131.00728"
      inkscape:document-units="mm"
-     inkscape:current-layer="layer1"
+     inkscape:current-layer="g839"
      inkscape:document-rotation="0"
      showgrid="false"
      inkscape:snap-page="true"
@@ -86,31 +86,14 @@
     <g
        id="g839">
       <path
-         style="fill:none;fill-opacity:1;stroke:#336699;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         id="path3494"
-         sodipodi:type="arc"
-         sodipodi:cx="29.501045"
-         sodipodi:cy="268.20444"
-         sodipodi:rx="10.451041"
-         sodipodi:ry="10.451041"
-         sodipodi:start="5.3721234"
-         sodipodi:end="4.0543999"
-         sodipodi:arc-type="arc"
-         d="m 35.906562,259.94649 a 10.451041,10.451041 0 0 1 3.480582,11.64754 10.451041,10.451041 0 0 1 -9.895219,7.06144 10.451041,10.451041 0 0 1 -9.88288,-7.0787 10.451041,10.451041 0 0 1 3.500906,-11.64144"
-         sodipodi:open="true" />
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#336699;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;stop-color:#000000;stop-opacity:1;opacity:1"
+         d="M 23.152344 257.93555 A 2 2 0 0 0 21.886719 258.35352 C 17.680026 261.60482 16.001213 267.19036 17.716797 272.22266 C 19.43238 277.25495 24.173544 280.65161 29.490234 280.65625 C 34.806925 280.66089 39.554933 277.27148 41.279297 272.24219 C 43.003661 267.21289 41.333824 261.62387 37.132812 258.36523 A 2 2 0 0 0 34.326172 258.7207 A 2 2 0 0 0 34.681641 261.52734 C 37.542909 263.74677 38.670541 267.51991 37.496094 270.94531 C 36.321646 274.37072 33.115287 276.65941 29.494141 276.65625 C 25.872994 276.65309 22.67042 274.35909 21.501953 270.93164 C 20.333486 267.50419 21.466894 263.73201 24.332031 261.51758 A 2 2 0 0 0 24.693359 258.71289 A 2 2 0 0 0 23.152344 257.93555 z "
+         id="path3494" />
       <path
-         style="fill:none;stroke:#336699;stroke-width:4;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         d="m 29.553228,255.63638 v 10.46229"
-         id="path3496"
-         sodipodi:nodetypes="cc" />
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#336699;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;stop-color:#000000;stop-opacity:1;opacity:1"
+         d="M 29.552734 253.63672 A 2 2 0 0 0 27.552734 255.63672 L 27.552734 266.09961 A 2 2 0 0 0 29.552734 268.09961 A 2 2 0 0 0 31.552734 266.09961 L 31.552734 255.63672 A 2 2 0 0 0 29.552734 253.63672 z "
+         id="path3496" />
     </g>
-    <ellipse
-       style="fill:none;stroke:#ffcc33;stroke-width:4.34999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="path871"
-       cx="29.809498"
-       cy="266.46942"
-       rx="2.4063713e-13"
-       ry="0.72084588" />
     <circle
        style="fill:none;stroke:#ffcc33;stroke-width:4.3585;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="path853"

--- a/mu/resources/images/svg/quit.svg
+++ b/mu/resources/images/svg/quit.svg
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="59.619438mm"
+   height="59.619438mm"
+   viewBox="0 0 59.619438 59.619438"
+   version="1.1"
+   id="svg8"
+   inkscape:version="1.0.2-2 (e86c870879, 2021-01-15)"
+   sodipodi:docname="quit.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="1.4142136"
+     inkscape:cx="167.23506"
+     inkscape:cy="131.00728"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     inkscape:document-rotation="0"
+     showgrid="false"
+     inkscape:snap-page="true"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:window-width="1920"
+     inkscape:window-height="1001"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:snap-to-guides="true"
+     inkscape:snap-global="false">
+    <sodipodi:guide
+       position="29.809499,69.619441"
+       orientation="-1,0"
+       id="guide24"
+       inkscape:label=""
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       position="-9.9999998,29.809721"
+       orientation="0,1"
+       id="guide26"
+       inkscape:label=""
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       position="-19.894461,69.619437"
+       orientation="0,1"
+       id="guide879"
+       inkscape:label=""
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-237.38055)">
+    <g
+       id="g839">
+      <path
+         style="fill:none;fill-opacity:1;stroke:#336699;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="path3494"
+         sodipodi:type="arc"
+         sodipodi:cx="29.501045"
+         sodipodi:cy="268.20444"
+         sodipodi:rx="10.451041"
+         sodipodi:ry="10.451041"
+         sodipodi:start="5.3721234"
+         sodipodi:end="4.0543999"
+         sodipodi:arc-type="arc"
+         d="m 35.906562,259.94649 a 10.451041,10.451041 0 0 1 3.480582,11.64754 10.451041,10.451041 0 0 1 -9.895219,7.06144 10.451041,10.451041 0 0 1 -9.88288,-7.0787 10.451041,10.451041 0 0 1 3.500906,-11.64144"
+         sodipodi:open="true" />
+      <path
+         style="fill:none;stroke:#336699;stroke-width:4;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 29.553228,255.63638 v 10.46229"
+         id="path3496"
+         sodipodi:nodetypes="cc" />
+    </g>
+    <ellipse
+       style="fill:none;stroke:#ffcc33;stroke-width:4.34999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path871"
+       cx="29.809498"
+       cy="266.46942"
+       rx="2.4063713e-13"
+       ry="0.72084588" />
+    <circle
+       style="fill:none;stroke:#ffcc33;stroke-width:4.3585;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path853"
+       cx="29.809719"
+       cy="267.19028"
+       r="27.630468" />
+  </g>
+</svg>

--- a/mu/resources/images/svg/repl.svg
+++ b/mu/resources/images/svg/repl.svg
@@ -1,0 +1,203 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="59.619438mm"
+   height="59.619438mm"
+   viewBox="0 0 59.619438 59.619438"
+   version="1.1"
+   id="svg8"
+   inkscape:version="1.0.2-2 (e86c870879, 2021-01-15)"
+   sodipodi:docname="repl.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="2.8284271"
+     inkscape:cx="155.77915"
+     inkscape:cy="105.19391"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     inkscape:document-rotation="0"
+     showgrid="false"
+     inkscape:snap-page="true"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:window-width="1920"
+     inkscape:window-height="1001"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:snap-to-guides="true"
+     inkscape:snap-global="false">
+    <sodipodi:guide
+       position="29.809499,69.619441"
+       orientation="-1,0"
+       id="guide24"
+       inkscape:label=""
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       position="-9.9999998,29.809721"
+       orientation="0,1"
+       id="guide26"
+       inkscape:label=""
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       position="-19.894461,69.619437"
+       orientation="0,1"
+       id="guide879"
+       inkscape:label=""
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-237.38055)">
+    <ellipse
+       style="fill:none;stroke:#ffcc33;stroke-width:4.34999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path871"
+       cx="29.809498"
+       cy="266.46942"
+       rx="2.4063713e-13"
+       ry="0.72084588" />
+    <circle
+       style="fill:none;stroke:#ffcc33;stroke-width:4.3585;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path853"
+       cx="29.809719"
+       cy="267.19028"
+       r="27.630468" />
+    <g
+       id="g865">
+      <rect
+         style="fill:#336699;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.619048"
+         id="rect3538"
+         width="1.8825797"
+         height="1.8942871"
+         x="39.279205"
+         y="270.29749" />
+      <g
+         id="g3586">
+        <rect
+           style="fill:none;fill-opacity:1;stroke:#336699;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="rect3512"
+           width="29.25"
+           height="16.5"
+           x="15.200956"
+           y="258.94254"
+           rx="1" />
+        <rect
+           style="fill:#336699;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.619048"
+           id="rect3514"
+           width="1.8825797"
+           height="1.8942871"
+           x="18.428234"
+           y="261.83069" />
+        <rect
+           style="fill:#336699;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.619048"
+           id="rect3516"
+           width="1.8825797"
+           height="1.8942871"
+           x="22.649878"
+           y="261.83069" />
+        <rect
+           style="fill:#336699;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.619048"
+           id="rect3518"
+           width="1.8825797"
+           height="1.8942871"
+           x="26.777969"
+           y="261.83069" />
+        <rect
+           style="fill:#336699;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.619048"
+           id="rect3520"
+           width="1.8825797"
+           height="1.8942871"
+           x="30.952837"
+           y="261.83069" />
+        <rect
+           style="fill:#336699;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.619048"
+           id="rect3522"
+           width="1.8825797"
+           height="1.8942871"
+           x="35.05756"
+           y="261.83069" />
+        <path
+           id="rect3524"
+           style="fill:#336699;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.619048"
+           d="m 39.279255,261.83074 v 4.23333 h -2.104781 v 1.89448 l 3.987355,-2e-5 v -6.12779 z"
+           sodipodi:nodetypes="ccccccc" />
+        <rect
+           style="fill:#336699;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.619048"
+           id="rect3526"
+           width="3.999248"
+           height="1.8942871"
+           x="18.428234"
+           y="266.06409" />
+        <rect
+           style="fill:#336699;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.619048"
+           id="rect3528"
+           width="1.8825797"
+           height="1.8942871"
+           x="24.766546"
+           y="266.06409" />
+        <rect
+           style="fill:#336699;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.619048"
+           id="rect3530"
+           width="1.8825797"
+           height="1.8942871"
+           x="28.894638"
+           y="266.06409" />
+        <rect
+           style="fill:#336699;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.619048"
+           id="rect3532"
+           width="1.8825797"
+           height="1.8942871"
+           x="33.069504"
+           y="266.06409" />
+        <rect
+           style="fill:#336699;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.619048"
+           id="rect3536"
+           width="1.8825797"
+           height="1.8942871"
+           x="18.428234"
+           y="270.29749" />
+        <rect
+           style="fill:#336699;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.619048"
+           id="rect3540"
+           width="14.35103"
+           height="1.8942871"
+           x="22.544632"
+           y="270.29749" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/mu/resources/images/svg/repl.svg
+++ b/mu/resources/images/svg/repl.svg
@@ -83,13 +83,6 @@
      inkscape:groupmode="layer"
      id="layer1"
      transform="translate(0,-237.38055)">
-    <ellipse
-       style="fill:none;stroke:#ffcc33;stroke-width:4.34999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="path871"
-       cx="29.809498"
-       cy="266.46942"
-       rx="2.4063713e-13"
-       ry="0.72084588" />
     <circle
        style="fill:none;stroke:#ffcc33;stroke-width:4.3585;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="path853"

--- a/mu/resources/images/svg/run.svg
+++ b/mu/resources/images/svg/run.svg
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="59.619438mm"
+   height="59.619438mm"
+   viewBox="0 0 59.619438 59.619438"
+   version="1.1"
+   id="svg8"
+   inkscape:version="1.0.2-2 (e86c870879, 2021-01-15)"
+   sodipodi:docname="run.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="0.70710678"
+     inkscape:cx="73.478866"
+     inkscape:cy="114.51311"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     inkscape:document-rotation="0"
+     showgrid="false"
+     inkscape:snap-page="true"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:window-width="1920"
+     inkscape:window-height="1001"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:snap-to-guides="true"
+     inkscape:snap-global="false">
+    <sodipodi:guide
+       position="29.809499,69.619441"
+       orientation="-1,0"
+       id="guide24"
+       inkscape:label=""
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       position="-9.9999998,29.809721"
+       orientation="0,1"
+       id="guide26"
+       inkscape:label=""
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       position="-19.894461,69.619437"
+       orientation="0,1"
+       id="guide879"
+       inkscape:label=""
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-237.38055)">
+    <ellipse
+       style="fill:none;stroke:#ffcc33;stroke-width:4.34999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path871"
+       cx="29.809498"
+       cy="266.46942"
+       rx="2.4063713e-13"
+       ry="0.72084588" />
+    <circle
+       style="fill:none;stroke:#ffcc33;stroke-width:4.3585;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path853"
+       cx="29.809719"
+       cy="267.19028"
+       r="27.630468" />
+    <path
+       style="fill:#336699;stroke:none;stroke-width:0.265;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;fill-opacity:1;stroke-miterlimit:4;stroke-dasharray:none"
+       d="m 21.5,254.25908 v 25.41605 l 22.666037,-12.6225 z"
+       id="path3602"
+       sodipodi:nodetypes="cccc" />
+  </g>
+</svg>

--- a/mu/resources/images/svg/run.svg
+++ b/mu/resources/images/svg/run.svg
@@ -83,13 +83,6 @@
      inkscape:groupmode="layer"
      id="layer1"
      transform="translate(0,-237.38055)">
-    <ellipse
-       style="fill:none;stroke:#ffcc33;stroke-width:4.34999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="path871"
-       cx="29.809498"
-       cy="266.46942"
-       rx="2.4063713e-13"
-       ry="0.72084588" />
     <circle
        style="fill:none;stroke:#ffcc33;stroke-width:4.3585;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="path853"

--- a/mu/resources/images/svg/save.svg
+++ b/mu/resources/images/svg/save.svg
@@ -83,13 +83,6 @@
      inkscape:groupmode="layer"
      id="layer1"
      transform="translate(0,-237.38055)">
-    <ellipse
-       style="fill:none;stroke:#ffcc33;stroke-width:4.34999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="path871"
-       cx="29.809498"
-       cy="266.46942"
-       rx="2.4063713e-13"
-       ry="0.72084588" />
     <circle
        style="fill:none;stroke:#ffcc33;stroke-width:4.3585;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="path853"

--- a/mu/resources/images/svg/save.svg
+++ b/mu/resources/images/svg/save.svg
@@ -1,0 +1,129 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="59.619438mm"
+   height="59.619438mm"
+   viewBox="0 0 59.619438 59.619438"
+   version="1.1"
+   id="svg8"
+   inkscape:version="1.0.2-2 (e86c870879, 2021-01-15)"
+   sodipodi:docname="save.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="2.8284271"
+     inkscape:cx="83.550671"
+     inkscape:cy="133.61811"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     inkscape:document-rotation="0"
+     showgrid="false"
+     inkscape:snap-page="true"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:window-width="1920"
+     inkscape:window-height="1001"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:snap-to-guides="true"
+     inkscape:snap-global="false">
+    <sodipodi:guide
+       position="29.809499,69.619441"
+       orientation="-1,0"
+       id="guide24"
+       inkscape:label=""
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       position="-9.9999998,29.809721"
+       orientation="0,1"
+       id="guide26"
+       inkscape:label=""
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       position="-19.894461,69.619437"
+       orientation="0,1"
+       id="guide879"
+       inkscape:label=""
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-237.38055)">
+    <ellipse
+       style="fill:none;stroke:#ffcc33;stroke-width:4.34999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path871"
+       cx="29.809498"
+       cy="266.46942"
+       rx="2.4063713e-13"
+       ry="0.72084588" />
+    <circle
+       style="fill:none;stroke:#ffcc33;stroke-width:4.3585;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path853"
+       cx="29.809719"
+       cy="267.19028"
+       r="27.630468" />
+    <g
+       id="g845">
+      <path
+         id="path2771"
+         style="fill:#336699;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m 29.471584,272.60615 c -0.07674,-0.004 -0.15463,-0.0422 -0.235643,-0.11627 l -8.096147,-7.92045 c -0.519989,-0.51983 -0.132153,-1.60393 0.621151,-1.60093 l 3.92224,-0.01 c 0.54846,-0.001 0.5817,-0.0319 0.586012,-0.58033 l 0.05064,-7.23831 c -0.0097,-0.4264 0.09511,-0.60835 0.659907,-0.61134 h 5.005896 c 0.564798,0.003 0.669594,0.18494 0.65991,0.61134 l 0.05116,7.23831 c 0.0043,0.54845 0.03704,0.57922 0.585496,0.58033 l 3.922239,0.01 c 0.753303,-0.003 1.14114,1.0811 0.621152,1.60093 l -8.096147,7.92045 c -0.08099,0.074 -0.158411,0.11196 -0.235127,0.11627 -0.0072,0 -0.01491,0.003 -0.02274,0 z" />
+      <g
+         id="g2786"
+         transform="translate(-0.38885016,-0.68415591)">
+        <path
+           id="rect2759"
+           style="fill:#336699;fill-opacity:1;stroke:none;stroke-width:0.0377953;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="m 65.949219,128.22461 c -3.140788,0 -5.669922,2.52913 -5.669922,5.66992 v 20.31055 c 0,3.14078 2.529134,5.66797 5.669922,5.66797 h 90.919921 c 3.14079,0 5.66797,-2.52719 5.66797,-5.66797 v -20.31055 c 0,-3.14079 -2.52718,-5.66992 -5.66797,-5.66992 h -28.27148 l -9.04883,8.91016 -0.0508,0.0508 c -4.57221,4.1743 -11.59905,4.09122 -15.92969,-0.0664 l -9.214844,-8.89453 z"
+           transform="matrix(0.26458333,0,0,0.26458333,0.38885016,238.06471)"
+           sodipodi:nodetypes="sssssssscccccs" />
+        <circle
+           style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:2;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.638978"
+           id="circle2779"
+           cx="36.066013"
+           cy="277.26648"
+           r="1.0252604" />
+        <circle
+           style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:2;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.638978"
+           id="circle2781"
+           cx="40.233204"
+           cy="277.26648"
+           r="1.0252604" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/mu/resources/images/svg/serial.svg
+++ b/mu/resources/images/svg/serial.svg
@@ -83,13 +83,6 @@
      inkscape:groupmode="layer"
      id="layer1"
      transform="translate(0,-237.38055)">
-    <ellipse
-       style="fill:none;stroke:#ffcc33;stroke-width:4.34999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="path871"
-       cx="29.809498"
-       cy="266.46942"
-       rx="2.4063713e-13"
-       ry="0.72084588" />
     <circle
        style="fill:none;stroke:#ffcc33;stroke-width:4.3585;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="path853"

--- a/mu/resources/images/svg/serial.svg
+++ b/mu/resources/images/svg/serial.svg
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="59.619438mm"
+   height="59.619438mm"
+   viewBox="0 0 59.619438 59.619438"
+   version="1.1"
+   id="svg8"
+   inkscape:version="1.0.2-2 (e86c870879, 2021-01-15)"
+   sodipodi:docname="serial.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="2.8284271"
+     inkscape:cx="103.89676"
+     inkscape:cy="113.4335"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     inkscape:document-rotation="0"
+     showgrid="false"
+     inkscape:snap-page="true"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:window-width="1920"
+     inkscape:window-height="1001"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:snap-to-guides="true"
+     inkscape:snap-global="false">
+    <sodipodi:guide
+       position="29.809499,69.619441"
+       orientation="-1,0"
+       id="guide24"
+       inkscape:label=""
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       position="-9.9999998,29.809721"
+       orientation="0,1"
+       id="guide26"
+       inkscape:label=""
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       position="-19.894461,69.619437"
+       orientation="0,1"
+       id="guide879"
+       inkscape:label=""
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-237.38055)">
+    <ellipse
+       style="fill:none;stroke:#ffcc33;stroke-width:4.34999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path871"
+       cx="29.809498"
+       cy="266.46942"
+       rx="2.4063713e-13"
+       ry="0.72084588" />
+    <circle
+       style="fill:none;stroke:#ffcc33;stroke-width:4.3585;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path853"
+       cx="29.809719"
+       cy="267.19028"
+       r="27.630468" />
+    <g
+       id="g839">
+      <path
+         id="rect4232"
+         style="fill:#336699;fill-opacity:1;stroke:none;stroke-width:7.55906;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.57085"
+         d="M 148.45508 69.761719 C 147.92436 69.753435 147.39296 70.104535 147.40234 71 L 147.40234 84.853516 L 54.392578 84.853516 C 53.345649 84.853516 52.501953 85.695258 52.501953 86.742188 L 52.501953 98.873047 C 52.501953 99.919976 53.345649 100.76172 54.392578 100.76172 L 147.40234 100.76172 L 147.40234 115.59375 C 147.37475 116.86594 148.74408 116.93378 149.29102 116.5 L 171.47266 93.785156 C 171.75196 93.480526 171.74498 93.25507 171.45898 92.947266 L 149.29102 70.125 C 149.09136 69.900794 148.77351 69.766689 148.45508 69.761719 z "
+         transform="matrix(0.26458333,0,0,0.26458333,0,237.38055)" />
+      <path
+         id="path4237"
+         style="fill:#336699;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.57085"
+         d="m 20.035507,267.31468 c 0.14042,-0.002 0.281019,0.0907 0.278537,0.32763 v 3.66541 h 24.608833 c 0.277,0 0.500228,0.22271 0.500228,0.49971 v 3.20962 c 0,0.277 -0.223228,0.49971 -0.500228,0.49971 H 20.314044 v 3.92431 c 0.0073,0.3366 -0.355002,0.35455 -0.499713,0.23978 l -5.868892,-6.00997 c -0.0739,-0.0806 -0.07205,-0.14025 0.0036,-0.22169 l 5.865273,-6.03839 c 0.05283,-0.0593 0.136925,-0.0948 0.221176,-0.0961 z" />
+    </g>
+  </g>
+</svg>

--- a/mu/resources/images/svg/snippets.svg
+++ b/mu/resources/images/svg/snippets.svg
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="59.619438mm"
+   height="59.619438mm"
+   viewBox="0 0 59.619438 59.619438"
+   version="1.1"
+   id="svg8"
+   inkscape:version="1.0.2-2 (e86c870879, 2021-01-15)"
+   sodipodi:docname="snippets.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="2.0334552"
+     inkscape:cx="42.563688"
+     inkscape:cy="151.23629"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     inkscape:document-rotation="0"
+     showgrid="false"
+     inkscape:snap-page="true"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:window-width="1920"
+     inkscape:window-height="1001"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:snap-to-guides="true"
+     inkscape:snap-global="false">
+    <sodipodi:guide
+       position="29.809499,69.619441"
+       orientation="-1,0"
+       id="guide24"
+       inkscape:label=""
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       position="-9.9999998,29.809721"
+       orientation="0,1"
+       id="guide26"
+       inkscape:label=""
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       position="-19.894461,69.619437"
+       orientation="0,1"
+       id="guide879"
+       inkscape:label=""
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-237.38055)">
+    <ellipse
+       style="fill:none;stroke:#ffcc33;stroke-width:4.34999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path871"
+       cx="29.809498"
+       cy="266.46942"
+       rx="2.4063713e-13"
+       ry="0.72084588" />
+    <circle
+       style="fill:none;stroke:#ffcc33;stroke-width:4.3585;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path853"
+       cx="29.809719"
+       cy="267.19028"
+       r="27.630468" />
+    <g
+       id="g841">
+      <path
+         id="path4259"
+         style="fill:#336699;fill-opacity:1;stroke:none;stroke-width:0.0377953;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.57085"
+         d="M 85.75 76.125 L 83.654297 87.333984 A 29.124999 29.124999 0 0 0 79.322266 89.15625 L 69.867188 82.681641 L 60.144531 92.404297 L 66.707031 101.96289 A 29.124999 29.124999 0 0 0 65 106.1582 L 53.75 108.25 L 53.75 122 L 65.091797 124.12109 A 29.124999 29.124999 0 0 0 66.917969 128.45117 A 29.124999 29.124999 0 0 0 66.917969 128.45312 L 60.474609 137.86328 L 70.197266 147.58594 L 79.722656 141.04688 A 29.124999 29.124999 0 0 0 83.703125 142.68359 L 85.875 154.375 L 99.625 154.375 L 101.81445 142.67773 A 29.124999 29.124999 0 0 0 105.68164 141.0957 L 115.4082 147.75586 L 125.13086 138.0332 L 118.57031 128.47461 A 29.124999 29.124999 0 0 0 120.33789 124.33789 L 131.5 122.25 L 131.5 108.5 L 120.59766 106.47266 A 29.124999 29.124999 0 0 0 118.61133 101.60742 L 124.80078 92.572266 L 115.07812 82.849609 L 106.01367 89.072266 A 29.124999 29.124999 0 0 0 101.56641 87.242188 L 99.5 76.125 L 85.75 76.125 z M 92.75 99.9375 A 15.25 15.25 0 0 1 108 115.1875 A 15.25 15.25 0 0 1 92.75 130.4375 A 15.25 15.25 0 0 1 77.5 115.1875 A 15.25 15.25 0 0 1 92.75 99.9375 z "
+         transform="matrix(0.26458333,0,0,0.26458333,0,237.38055)" />
+      <path
+         id="path4281"
+         style="fill:#336699;fill-opacity:1;stroke:none;stroke-width:0.0377953;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.57085"
+         d="M 155.92969 60.880859 L 149.6875 68.328125 A 15.749999 15.5 0 0 0 148.125 68.25 A 15.749999 15.5 0 0 0 146.22461 68.363281 L 140.32227 61.322266 L 132.53711 65.896484 L 135.64844 74.291016 A 15.749999 15.5 0 0 0 133.68945 77.552734 L 124.70898 79.080078 L 124.64062 88.111328 L 133.57422 89.681641 A 15.749999 15.5 0 0 0 135.58789 93.130859 L 132.44727 101.59961 L 140.23438 106.17188 L 146.14062 99.125 A 15.749999 15.5 0 0 0 148.125 99.25 A 15.749999 15.5 0 0 0 149.9082 99.150391 L 156.01758 106.4375 L 163.80469 101.86523 L 160.59766 93.212891 A 15.749999 15.5 0 0 0 162.67578 89.677734 L 171.58984 88.111328 L 171.52148 79.080078 L 162.5625 77.556641 A 15.749999 15.5 0 0 0 160.49023 74.150391 L 163.7168 65.455078 L 155.92969 60.880859 z M 148.04883 76.240234 A 7.3894023 7.3894023 0 0 1 155.4375 83.630859 A 7.3894023 7.3894023 0 0 1 148.04883 91.019531 A 7.3894023 7.3894023 0 0 1 140.66016 83.630859 A 7.3894023 7.3894023 0 0 1 148.04883 76.240234 z "
+         transform="matrix(0.26458333,0,0,0.26458333,0,237.38055)" />
+      <path
+         id="path4299"
+         style="fill:#336699;fill-opacity:1;stroke:none;stroke-width:0.01;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.57085"
+         d="m 41.256397,270.16905 -1.65158,1.97043 a 4.1671872,4.1010416 0 0 0 -0.413411,-0.0207 4.1671872,4.1010416 0 0 0 -0.502812,0.03 l -1.561661,-1.86294 -2.059823,1.21026 0.823206,2.22106 A 4.1671872,4.1010416 0 0 0 35.372,274.58015 l -2.376083,0.40411 -0.01809,2.38952 2.363682,0.41548 a 4.1671872,4.1010416 0 0 0 0.532783,0.91261 l -0.830955,2.24069 2.060339,1.20974 1.562693,-1.86448 a 4.1671872,4.1010416 0 0 0 0.525034,0.0331 4.1671872,4.1010416 0 0 0 0.471805,-0.0264 l 1.61644,1.92805 2.060339,-1.20974 -0.848526,-2.28927 a 4.1671872,4.1010416 0 0 0 0.549836,-0.93534 l 2.358511,-0.41445 -0.01809,-2.38952 -2.370396,-0.40307 a 4.1671872,4.1010416 0 0 0 -0.548289,-0.90124 l 0.853697,-2.30063 z m -2.085145,4.06384 a 1.9551127,1.9551127 0 0 1 1.954919,1.95543 1.9551127,1.9551127 0 0 1 -1.954919,1.95492 1.9551127,1.9551127 0 0 1 -1.954918,-1.95492 1.9551127,1.9551127 0 0 1 1.954918,-1.95543 z" />
+    </g>
+  </g>
+</svg>

--- a/mu/resources/images/svg/snippets.svg
+++ b/mu/resources/images/svg/snippets.svg
@@ -83,13 +83,6 @@
      inkscape:groupmode="layer"
      id="layer1"
      transform="translate(0,-237.38055)">
-    <ellipse
-       style="fill:none;stroke:#ffcc33;stroke-width:4.34999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="path871"
-       cx="29.809498"
-       cy="266.46942"
-       rx="2.4063713e-13"
-       ry="0.72084588" />
     <circle
        style="fill:none;stroke:#ffcc33;stroke-width:4.3585;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="path853"

--- a/mu/resources/images/svg/sounds.svg
+++ b/mu/resources/images/svg/sounds.svg
@@ -23,9 +23,9 @@
      borderopacity="1.0"
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
-     inkscape:zoom="2.87574"
-     inkscape:cx="85.875566"
-     inkscape:cy="156.29269"
+     inkscape:zoom="4.0669105"
+     inkscape:cx="85.818462"
+     inkscape:cy="122.72774"
      inkscape:document-units="mm"
      inkscape:current-layer="layer1"
      inkscape:document-rotation="0"
@@ -93,65 +93,28 @@
      inkscape:groupmode="layer"
      id="layer1"
      transform="translate(0,-237.38055)">
-    <ellipse
-       style="fill:none;stroke:#ffcc33;stroke-width:4.34999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="path871"
-       cx="29.809498"
-       cy="266.46942"
-       rx="2.4063713e-13"
-       ry="0.72084588" />
     <circle
        style="fill:none;stroke:#ffcc33;stroke-width:4.3585;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="path853"
        cx="29.809719"
        cy="267.19028"
        r="27.630468" />
-    <g
-       id="g843">
-      <path
-         style="fill:#336699;fill-opacity:1;stroke:none;stroke-width:0.01;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         d="m 16.41,271.24255 c -0.490635,-0.005 -0.739733,-0.24476 -0.731,-0.71516 v -6.8959 c -0.02079,-0.49807 0.197843,-0.76507 0.731,-0.78094 h 4.734 l 5.832999,-5.83218 c 0.328752,-0.31937 1.480048,-0.43797 1.486001,0.74818 v 18.3978 c 0.01768,1.31304 -1.12177,1.19221 -1.486001,0.78069 L 21.144,271.24255 Z"
-         id="path4324"
-         sodipodi:nodetypes="ccccccccccc" />
-      <path
-         style="fill:none;fill-opacity:1;stroke:#336699;stroke-width:2.03869;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         id="path4318"
-         sodipodi:type="arc"
-         sodipodi:cx="31.005922"
-         sodipodi:cy="266.98325"
-         sodipodi:rx="2.9414837"
-         sodipodi:ry="3.1792183"
-         sodipodi:start="5.0579642"
-         sodipodi:end="1.2060225"
-         sodipodi:arc-type="arc"
-         d="m 32.002314,263.99198 a 2.9414837,3.1792183 0 0 1 1.944957,2.96075 2.9414837,3.1792183 0 0 1 -1.89201,3.00056"
-         sodipodi:open="true" />
-      <circle
-         style="fill:none;fill-opacity:1;stroke:#336699;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         id="path4320"
-         sodipodi:type="arc"
-         sodipodi:cx="31.005922"
-         sodipodi:cy="266.98325"
-         sodipodi:rx="7.2912841"
-         sodipodi:ry="7.4984436"
-         sodipodi:start="5.0928708"
-         sodipodi:end="1.1955505"
-         sodipodi:open="true"
-         sodipodi:arc-type="arc"
-         d="m 33.713671,260.02105 a 7.2912841,7.4984436 0 0 1 4.58351,6.98183 7.2912841,7.4984436 0 0 1 -4.618994,6.95705" />
-      <circle
-         style="fill:none;fill-opacity:1;stroke:#336699;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         id="path4322"
-         sodipodi:type="arc"
-         sodipodi:cx="31.005922"
-         sodipodi:cy="266.98325"
-         sodipodi:rx="11.708864"
-         sodipodi:ry="11.708864"
-         sodipodi:start="5.0928708"
-         sodipodi:end="1.1885692"
-         sodipodi:open="true"
-         sodipodi:arc-type="arc"
-         d="m 35.354218,256.11173 a 11.708864,11.708864 0 0 1 7.360564,10.8613 11.708864,11.708864 0 0 1 -7.341596,10.87412" />
-    </g>
+    <path
+       style="fill:#336699;fill-opacity:1;stroke:none;stroke-width:0.01;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 16.41,271.24255 c -0.490635,-0.005 -0.739733,-0.24476 -0.731,-0.71516 v -6.8959 c -0.02079,-0.49807 0.197843,-0.76507 0.731,-0.78094 h 4.734 l 5.832999,-5.83218 c 0.328752,-0.31937 1.480048,-0.43797 1.486001,0.74818 v 18.3978 c 0.01768,1.31304 -1.12177,1.19221 -1.486001,0.78069 L 21.144,271.24255 Z"
+       id="path4324"
+       sodipodi:nodetypes="ccccccccccc" />
+    <path
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#336699;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;stop-color:#000000;stop-opacity:1;opacity:1"
+       d="M 32.041016 262.97266 A 1.019345 1.019345 0 0 0 31.052734 263.62305 A 1.019345 1.019345 0 0 0 31.632812 264.94141 C 32.372273 265.22914 32.919402 266.02278 32.927734 266.96094 C 32.936067 267.8991 32.401511 268.70816 31.666016 269.01172 A 1.019345 1.019345 0 0 0 31.113281 270.3418 A 1.019345 1.019345 0 0 0 32.443359 270.89648 C 34.006032 270.25153 34.982079 268.66393 34.966797 266.94336 C 34.951515 265.22279 33.946225 263.65588 32.371094 263.04297 A 1.019345 1.019345 0 0 0 32.041016 262.97266 z "
+       id="path4318" />
+    <path
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#336699;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;stop-color:#000000;stop-opacity:1;opacity:1"
+       d="M 33.683594 259.02148 A 1 1 0 0 0 32.789062 259.64062 A 1 1 0 0 0 33.333984 260.94531 C 35.724868 261.92877 37.303692 264.32221 37.296875 267 C 37.290058 269.67779 35.698473 272.06268 33.302734 273.0332 A 1 1 0 0 0 32.751953 274.33594 A 1 1 0 0 0 34.052734 274.88672 C 37.218041 273.60445 39.288044 270.4748 39.296875 267.00586 C 39.305706 263.53692 37.252366 260.39495 34.09375 259.0957 A 1 1 0 0 0 33.683594 259.02148 z "
+       id="path4320" />
+    <path
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#336699;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;stop-color:#000000;stop-opacity:1;opacity:1"
+       d="M 35.314453 255.11328 A 1 1 0 0 0 34.425781 255.74023 A 1 1 0 0 0 34.982422 257.04102 C 39.047893 258.66709 41.711023 262.59601 41.714844 266.97461 C 41.718665 271.35321 39.062627 275.28676 35 276.91992 A 1 1 0 0 0 34.445312 278.2207 A 1 1 0 0 0 35.746094 278.77539 C 40.561352 276.83967 43.719373 272.16243 43.714844 266.97266 C 43.710315 261.78289 40.545191 257.11091 35.726562 255.18359 A 1 1 0 0 0 35.314453 255.11328 z "
+       id="path4322" />
   </g>
 </svg>

--- a/mu/resources/images/svg/sounds.svg
+++ b/mu/resources/images/svg/sounds.svg
@@ -1,0 +1,157 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="59.619438mm"
+   height="59.619438mm"
+   viewBox="0 0 59.619438 59.619438"
+   version="1.1"
+   id="svg8"
+   inkscape:version="1.0.2-2 (e86c870879, 2021-01-15)"
+   sodipodi:docname="sounds.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="2.87574"
+     inkscape:cx="85.875566"
+     inkscape:cy="156.29269"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     inkscape:document-rotation="0"
+     showgrid="false"
+     inkscape:snap-page="true"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:window-width="1920"
+     inkscape:window-height="1001"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:snap-to-guides="false"
+     inkscape:snap-global="true"
+     inkscape:snap-object-midpoints="true"
+     inkscape:snap-bbox="true"
+     inkscape:snap-bbox-midpoints="true"
+     inkscape:snap-center="true"
+     inkscape:snap-midpoints="false"
+     inkscape:object-paths="false"
+     inkscape:object-nodes="false"
+     inkscape:snap-smooth-nodes="false"
+     inkscape:snap-intersection-paths="true"
+     inkscape:bbox-nodes="true">
+    <sodipodi:guide
+       position="29.809499,69.619441"
+       orientation="-1,0"
+       id="guide24"
+       inkscape:label=""
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       position="-9.9999998,29.809721"
+       orientation="0,1"
+       id="guide26"
+       inkscape:label=""
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       position="-19.894461,69.619437"
+       orientation="0,1"
+       id="guide879"
+       inkscape:label=""
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-237.38055)">
+    <ellipse
+       style="fill:none;stroke:#ffcc33;stroke-width:4.34999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path871"
+       cx="29.809498"
+       cy="266.46942"
+       rx="2.4063713e-13"
+       ry="0.72084588" />
+    <circle
+       style="fill:none;stroke:#ffcc33;stroke-width:4.3585;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path853"
+       cx="29.809719"
+       cy="267.19028"
+       r="27.630468" />
+    <g
+       id="g843">
+      <path
+         style="fill:#336699;fill-opacity:1;stroke:none;stroke-width:0.01;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 16.41,271.24255 c -0.490635,-0.005 -0.739733,-0.24476 -0.731,-0.71516 v -6.8959 c -0.02079,-0.49807 0.197843,-0.76507 0.731,-0.78094 h 4.734 l 5.832999,-5.83218 c 0.328752,-0.31937 1.480048,-0.43797 1.486001,0.74818 v 18.3978 c 0.01768,1.31304 -1.12177,1.19221 -1.486001,0.78069 L 21.144,271.24255 Z"
+         id="path4324"
+         sodipodi:nodetypes="ccccccccccc" />
+      <path
+         style="fill:none;fill-opacity:1;stroke:#336699;stroke-width:2.03869;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="path4318"
+         sodipodi:type="arc"
+         sodipodi:cx="31.005922"
+         sodipodi:cy="266.98325"
+         sodipodi:rx="2.9414837"
+         sodipodi:ry="3.1792183"
+         sodipodi:start="5.0579642"
+         sodipodi:end="1.2060225"
+         sodipodi:arc-type="arc"
+         d="m 32.002314,263.99198 a 2.9414837,3.1792183 0 0 1 1.944957,2.96075 2.9414837,3.1792183 0 0 1 -1.89201,3.00056"
+         sodipodi:open="true" />
+      <circle
+         style="fill:none;fill-opacity:1;stroke:#336699;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="path4320"
+         sodipodi:type="arc"
+         sodipodi:cx="31.005922"
+         sodipodi:cy="266.98325"
+         sodipodi:rx="7.2912841"
+         sodipodi:ry="7.4984436"
+         sodipodi:start="5.0928708"
+         sodipodi:end="1.1955505"
+         sodipodi:open="true"
+         sodipodi:arc-type="arc"
+         d="m 33.713671,260.02105 a 7.2912841,7.4984436 0 0 1 4.58351,6.98183 7.2912841,7.4984436 0 0 1 -4.618994,6.95705" />
+      <circle
+         style="fill:none;fill-opacity:1;stroke:#336699;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="path4322"
+         sodipodi:type="arc"
+         sodipodi:cx="31.005922"
+         sodipodi:cy="266.98325"
+         sodipodi:rx="11.708864"
+         sodipodi:ry="11.708864"
+         sodipodi:start="5.0928708"
+         sodipodi:end="1.1885692"
+         sodipodi:open="true"
+         sodipodi:arc-type="arc"
+         d="m 35.354218,256.11173 a 11.708864,11.708864 0 0 1 7.360564,10.8613 11.708864,11.708864 0 0 1 -7.341596,10.87412" />
+    </g>
+  </g>
+</svg>

--- a/mu/resources/images/svg/static.svg
+++ b/mu/resources/images/svg/static.svg
@@ -1,0 +1,148 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="59.619438mm"
+   height="59.619438mm"
+   viewBox="0 0 59.619438 59.619438"
+   version="1.1"
+   id="svg8"
+   inkscape:version="1.0.2-2 (e86c870879, 2021-01-15)"
+   sodipodi:docname="static.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="2.0334552"
+     inkscape:cx="144.60739"
+     inkscape:cy="177.34507"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     inkscape:document-rotation="0"
+     showgrid="false"
+     inkscape:snap-page="true"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:window-width="1920"
+     inkscape:window-height="1001"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:snap-to-guides="false"
+     inkscape:snap-global="true"
+     inkscape:snap-object-midpoints="true"
+     inkscape:snap-bbox="true"
+     inkscape:snap-bbox-midpoints="true"
+     inkscape:snap-center="true"
+     inkscape:snap-midpoints="false"
+     inkscape:object-paths="false"
+     inkscape:object-nodes="false"
+     inkscape:snap-smooth-nodes="false"
+     inkscape:snap-intersection-paths="true"
+     inkscape:bbox-nodes="true">
+    <sodipodi:guide
+       position="29.809499,69.619441"
+       orientation="-1,0"
+       id="guide24"
+       inkscape:label=""
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       position="-9.9999998,29.809721"
+       orientation="0,1"
+       id="guide26"
+       inkscape:label=""
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       position="-19.894461,69.619437"
+       orientation="0,1"
+       id="guide879"
+       inkscape:label=""
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-237.38055)">
+    <ellipse
+       style="fill:none;stroke:#ffcc33;stroke-width:4.34999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path871"
+       cx="29.809498"
+       cy="266.46942"
+       rx="2.4063713e-13"
+       ry="0.72084588" />
+    <circle
+       style="fill:none;stroke:#ffcc33;stroke-width:4.3585;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path853"
+       cx="29.809719"
+       cy="267.19028"
+       r="27.630468" />
+    <g
+       id="g4364">
+      <rect
+         style="fill:#f8f9fa;fill-opacity:1;stroke:none;stroke-width:0.01;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect4340"
+         width="36.756119"
+         height="30.913782"
+         x="11.132642"
+         y="251.77937"
+         rx="0.49999899"
+         ry="0.49999899" />
+      <rect
+         style="fill:none;fill-opacity:1;stroke:#336699;stroke-width:2.25;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect4342"
+         width="23.737368"
+         height="16.790962"
+         x="20.977209"
+         y="256.37961"
+         rx="1"
+         ry="1" />
+      <path
+         id="rect4344"
+         style="fill:none;fill-opacity:1;stroke:#336699;stroke-width:8.50394;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 149.00512,147.34093 v 4.31773 c 0,2.09386 -1.68567,3.77953 -3.77953,3.77953 H 63.068613 c -2.093858,0 -3.779527,-1.68567 -3.779527,-3.77953 V 95.755814 c 0,-2.093859 1.685669,-3.779528 3.779527,-3.779528 v 0 l 4.229651,2e-6"
+         transform="matrix(0.26458333,0,0,0.26458333,0,237.38055)"
+         sodipodi:nodetypes="csssssscc" />
+      <circle
+         style="fill:#336699;fill-opacity:1;stroke:none;stroke-width:2.25;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="path4354"
+         cx="26.738663"
+         cy="261.28922"
+         r="2.0818424" />
+      <path
+         id="rect4356"
+         style="fill:#336699;fill-opacity:1;stroke:none;stroke-width:2.25;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 25.209806,266.42694 2.314563,-2.31737 2.612165,2.65348 6.163255,-6.12041 4.491307,4.26186 v 4.12657 h -15.58129 z"
+         sodipodi:nodetypes="cccccccc" />
+    </g>
+  </g>
+</svg>

--- a/mu/resources/images/svg/static.svg
+++ b/mu/resources/images/svg/static.svg
@@ -93,13 +93,6 @@
      inkscape:groupmode="layer"
      id="layer1"
      transform="translate(0,-237.38055)">
-    <ellipse
-       style="fill:none;stroke:#ffcc33;stroke-width:4.34999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="path871"
-       cx="29.809498"
-       cy="266.46942"
-       rx="2.4063713e-13"
-       ry="0.72084588" />
     <circle
        style="fill:none;stroke:#ffcc33;stroke-width:4.3585;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="path853"

--- a/mu/resources/images/svg/step-in.svg
+++ b/mu/resources/images/svg/step-in.svg
@@ -1,0 +1,154 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="59.619438mm"
+   height="59.619438mm"
+   viewBox="0 0 59.619438 59.619438"
+   version="1.1"
+   id="svg8"
+   inkscape:version="1.0.2-2 (e86c870879, 2021-01-15)"
+   sodipodi:docname="step-in.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="1.4142136"
+     inkscape:cx="175.11651"
+     inkscape:cy="89.696012"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     inkscape:document-rotation="0"
+     showgrid="false"
+     inkscape:snap-page="true"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:window-width="1920"
+     inkscape:window-height="1001"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:snap-to-guides="false"
+     inkscape:snap-global="true"
+     inkscape:snap-object-midpoints="true"
+     inkscape:snap-bbox="true"
+     inkscape:snap-bbox-midpoints="true"
+     inkscape:snap-center="true"
+     inkscape:snap-midpoints="false"
+     inkscape:object-paths="false"
+     inkscape:object-nodes="false"
+     inkscape:snap-smooth-nodes="false"
+     inkscape:snap-intersection-paths="true"
+     inkscape:bbox-nodes="true">
+    <sodipodi:guide
+       position="29.809499,69.619441"
+       orientation="-1,0"
+       id="guide24"
+       inkscape:label=""
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       position="-9.9999998,29.809721"
+       orientation="0,1"
+       id="guide26"
+       inkscape:label=""
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       position="-19.894461,69.619437"
+       orientation="0,1"
+       id="guide879"
+       inkscape:label=""
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-237.38055)">
+    <ellipse
+       style="fill:none;stroke:#ffcc33;stroke-width:4.34999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path871"
+       cx="29.809498"
+       cy="266.46942"
+       rx="2.4063713e-13"
+       ry="0.72084588" />
+    <circle
+       style="fill:none;stroke:#ffcc33;stroke-width:4.3585;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path853"
+       cx="29.809719"
+       cy="267.19028"
+       r="27.630468" />
+    <g
+       id="g845">
+      <rect
+         style="fill:#336699;fill-opacity:1;stroke:none;stroke-width:2.25;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect4382"
+         width="30.089127"
+         height="3.77337"
+         x="14.5404"
+         y="255.14125"
+         rx="0.5"
+         ry="0.5" />
+      <rect
+         style="fill:#336699;fill-opacity:1;stroke:none;stroke-width:2.25;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect4449"
+         width="19.068623"
+         height="3.7733765"
+         x="25.560902"
+         y="261.76746"
+         rx="0.5"
+         ry="0.5" />
+      <rect
+         style="fill:#336699;fill-opacity:1;stroke:none;stroke-width:2.25;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect4451"
+         width="19.068623"
+         height="3.7733765"
+         x="25.560902"
+         y="268.46265"
+         rx="0.5"
+         ry="0.5" />
+      <rect
+         style="fill:#336699;fill-opacity:1;stroke:none;stroke-width:2.25;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect4453"
+         width="19.068623"
+         height="3.7733765"
+         x="25.560902"
+         y="275.18085"
+         rx="0.5"
+         ry="0.5" />
+      <path
+         style="fill:#336699;fill-opacity:1;stroke:none;stroke-width:0.01;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 14.572905,265.4041 c -0.0044,-0.27187 0.149301,-0.39274 0.422875,-0.39055 H 18.769 v -2.765 c -0.002,-0.27553 0.309775,-0.38089 0.472,-0.211 l 4.602608,4.74902 c 0.163627,0.16576 0.16256,0.34452 0,0.5042 l -4.602824,4.73294 c -0.146463,0.14512 -0.47007,0.0472 -0.471784,-0.21144 v -2.66736 l -3.77322,-3.6e-4 c -0.315054,0.003 -0.42325,-0.106 -0.422875,-0.391 z"
+         id="path4455"
+         sodipodi:nodetypes="ccccccccccccc" />
+    </g>
+  </g>
+</svg>

--- a/mu/resources/images/svg/step-in.svg
+++ b/mu/resources/images/svg/step-in.svg
@@ -93,13 +93,6 @@
      inkscape:groupmode="layer"
      id="layer1"
      transform="translate(0,-237.38055)">
-    <ellipse
-       style="fill:none;stroke:#ffcc33;stroke-width:4.34999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="path871"
-       cx="29.809498"
-       cy="266.46942"
-       rx="2.4063713e-13"
-       ry="0.72084588" />
     <circle
        style="fill:none;stroke:#ffcc33;stroke-width:4.3585;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="path853"

--- a/mu/resources/images/svg/step-out.svg
+++ b/mu/resources/images/svg/step-out.svg
@@ -1,0 +1,154 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="59.619438mm"
+   height="59.619438mm"
+   viewBox="0 0 59.619438 59.619438"
+   version="1.1"
+   id="svg8"
+   inkscape:version="1.0.2-2 (e86c870879, 2021-01-15)"
+   sodipodi:docname="step-out.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="1.4142136"
+     inkscape:cx="315.29296"
+     inkscape:cy="244.30962"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     inkscape:document-rotation="0"
+     showgrid="false"
+     inkscape:snap-page="true"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:window-width="1920"
+     inkscape:window-height="1001"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:snap-to-guides="false"
+     inkscape:snap-global="true"
+     inkscape:snap-object-midpoints="true"
+     inkscape:snap-bbox="true"
+     inkscape:snap-bbox-midpoints="true"
+     inkscape:snap-center="true"
+     inkscape:snap-midpoints="false"
+     inkscape:object-paths="false"
+     inkscape:object-nodes="false"
+     inkscape:snap-smooth-nodes="false"
+     inkscape:snap-intersection-paths="true"
+     inkscape:bbox-nodes="true">
+    <sodipodi:guide
+       position="29.809499,69.619441"
+       orientation="-1,0"
+       id="guide24"
+       inkscape:label=""
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       position="-9.9999998,29.809721"
+       orientation="0,1"
+       id="guide26"
+       inkscape:label=""
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       position="-19.894461,69.619437"
+       orientation="0,1"
+       id="guide879"
+       inkscape:label=""
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-237.38055)">
+    <ellipse
+       style="fill:none;stroke:#ffcc33;stroke-width:4.34999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path871"
+       cx="29.809498"
+       cy="266.46942"
+       rx="2.4063713e-13"
+       ry="0.72084588" />
+    <circle
+       style="fill:none;stroke:#ffcc33;stroke-width:4.3585;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path853"
+       cx="29.809719"
+       cy="267.19028"
+       r="27.630468" />
+    <g
+       id="g845">
+      <rect
+         style="fill:#336699;fill-opacity:1;stroke:none;stroke-width:2.25;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect4382"
+         width="30.089127"
+         height="3.77337"
+         x="14.5404"
+         y="255.14125"
+         rx="0.5"
+         ry="0.5" />
+      <rect
+         style="fill:#336699;fill-opacity:1;stroke:none;stroke-width:2.25;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect4449"
+         width="19.068623"
+         height="3.7733765"
+         x="25.560902"
+         y="261.76746"
+         rx="0.5"
+         ry="0.5" />
+      <rect
+         style="fill:#336699;fill-opacity:1;stroke:none;stroke-width:2.25;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect4451"
+         width="19.068623"
+         height="3.7733765"
+         x="25.560902"
+         y="268.46265"
+         rx="0.5"
+         ry="0.5" />
+      <rect
+         style="fill:#336699;fill-opacity:1;stroke:none;stroke-width:2.25;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect4453"
+         width="19.068623"
+         height="3.7733765"
+         x="25.560902"
+         y="275.18085"
+         rx="0.5"
+         ry="0.5" />
+      <path
+         style="fill:#336699;fill-opacity:1;stroke:none;stroke-width:0.01;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 24.199697,272.03482 c 0.0044,-0.27187 -0.149301,-0.39274 -0.422875,-0.39055 h -3.77322 v -2.765 c 0.002,-0.27553 -0.309775,-0.38089 -0.472,-0.211 l -4.602608,4.74902 c -0.163627,0.16576 -0.16256,0.34452 0,0.5042 l 4.602824,4.73294 c 0.146463,0.14512 0.47007,0.0472 0.471784,-0.21144 v -2.66736 l 3.77322,-3.6e-4 c 0.315054,0.003 0.42325,-0.106 0.422875,-0.391 z"
+         id="path4455"
+         sodipodi:nodetypes="ccccccccccccc" />
+    </g>
+  </g>
+</svg>

--- a/mu/resources/images/svg/step-out.svg
+++ b/mu/resources/images/svg/step-out.svg
@@ -93,13 +93,6 @@
      inkscape:groupmode="layer"
      id="layer1"
      transform="translate(0,-237.38055)">
-    <ellipse
-       style="fill:none;stroke:#ffcc33;stroke-width:4.34999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="path871"
-       cx="29.809498"
-       cy="266.46942"
-       rx="2.4063713e-13"
-       ry="0.72084588" />
     <circle
        style="fill:none;stroke:#ffcc33;stroke-width:4.3585;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="path853"

--- a/mu/resources/images/svg/step-over.svg
+++ b/mu/resources/images/svg/step-over.svg
@@ -1,0 +1,154 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="59.619438mm"
+   height="59.619438mm"
+   viewBox="0 0 59.619438 59.619438"
+   version="1.1"
+   id="svg8"
+   inkscape:version="1.0.2-2 (e86c870879, 2021-01-15)"
+   sodipodi:docname="step-over.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="2.8284271"
+     inkscape:cx="153.98675"
+     inkscape:cy="112.95678"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     inkscape:document-rotation="0"
+     showgrid="false"
+     inkscape:snap-page="true"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:window-width="1920"
+     inkscape:window-height="1001"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:snap-to-guides="false"
+     inkscape:snap-global="true"
+     inkscape:snap-object-midpoints="true"
+     inkscape:snap-bbox="true"
+     inkscape:snap-bbox-midpoints="true"
+     inkscape:snap-center="true"
+     inkscape:snap-midpoints="false"
+     inkscape:object-paths="false"
+     inkscape:object-nodes="false"
+     inkscape:snap-smooth-nodes="false"
+     inkscape:snap-intersection-paths="true"
+     inkscape:bbox-nodes="true">
+    <sodipodi:guide
+       position="29.809499,69.619441"
+       orientation="-1,0"
+       id="guide24"
+       inkscape:label=""
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       position="-9.9999998,29.809721"
+       orientation="0,1"
+       id="guide26"
+       inkscape:label=""
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       position="-19.894461,69.619437"
+       orientation="0,1"
+       id="guide879"
+       inkscape:label=""
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-237.38055)">
+    <ellipse
+       style="fill:none;stroke:#ffcc33;stroke-width:4.34999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path871"
+       cx="29.809498"
+       cy="266.46942"
+       rx="2.4063713e-13"
+       ry="0.72084588" />
+    <circle
+       style="fill:none;stroke:#ffcc33;stroke-width:4.3585;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path853"
+       cx="29.809719"
+       cy="267.19028"
+       r="27.630468" />
+    <g
+       id="g845">
+      <rect
+         style="fill:#336699;fill-opacity:1;stroke:none;stroke-width:2.25;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect4382"
+         width="30.089127"
+         height="3.77337"
+         x="14.5404"
+         y="255.14125"
+         rx="0.5"
+         ry="0.5" />
+      <rect
+         style="fill:#336699;fill-opacity:1;stroke:none;stroke-width:2.25;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect4449"
+         width="19.068623"
+         height="3.7733765"
+         x="25.560902"
+         y="261.76746"
+         rx="0.5"
+         ry="0.5" />
+      <rect
+         style="fill:#336699;fill-opacity:1;stroke:none;stroke-width:2.25;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect4451"
+         width="19.068623"
+         height="3.7733765"
+         x="25.560902"
+         y="268.46265"
+         rx="0.5"
+         ry="0.5" />
+      <rect
+         style="fill:#336699;fill-opacity:1;stroke:none;stroke-width:2.25;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect4453"
+         width="19.068623"
+         height="3.7733765"
+         x="25.560902"
+         y="275.18085"
+         rx="0.5"
+         ry="0.5" />
+      <path
+         style="fill:#336699;fill-opacity:1;stroke:none;stroke-width:0.01;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 18.082479,261.81376 c -0.27187,-0.004 -0.39274,0.14931 -0.39055,0.42288 v 11.2477 h -2.765 c -0.27553,-0.002 -0.38089,0.30977 -0.211,0.472 l 4.74902,4.60261 c 0.16576,0.16362 0.34452,0.16256 0.5042,0 l 4.73294,-4.60283 c 0.14512,-0.14646 0.0472,-0.47007 -0.21144,-0.47178 h -2.66736 l -3.6e-4,-11.2477 c 0.003,-0.31505 -0.106,-0.42325 -0.391,-0.42288 z"
+         id="path4455"
+         sodipodi:nodetypes="ccccccccccccc" />
+    </g>
+  </g>
+</svg>

--- a/mu/resources/images/svg/step-over.svg
+++ b/mu/resources/images/svg/step-over.svg
@@ -93,13 +93,6 @@
      inkscape:groupmode="layer"
      id="layer1"
      transform="translate(0,-237.38055)">
-    <ellipse
-       style="fill:none;stroke:#ffcc33;stroke-width:4.34999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="path871"
-       cx="29.809498"
-       cy="266.46942"
-       rx="2.4063713e-13"
-       ry="0.72084588" />
     <circle
        style="fill:none;stroke:#ffcc33;stroke-width:4.3585;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="path853"

--- a/mu/resources/images/svg/stop.svg
+++ b/mu/resources/images/svg/stop.svg
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="59.619438mm"
+   height="59.619438mm"
+   viewBox="0 0 59.619438 59.619438"
+   version="1.1"
+   id="svg8"
+   inkscape:version="1.0.2-2 (e86c870879, 2021-01-15)"
+   sodipodi:docname="stop.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="2.8284271"
+     inkscape:cx="113.05051"
+     inkscape:cy="121.19971"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     inkscape:document-rotation="0"
+     showgrid="false"
+     inkscape:snap-page="true"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:window-width="1920"
+     inkscape:window-height="1001"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:snap-to-guides="false"
+     inkscape:snap-global="true"
+     inkscape:snap-object-midpoints="true"
+     inkscape:snap-bbox="true"
+     inkscape:snap-bbox-midpoints="true"
+     inkscape:snap-center="true"
+     inkscape:snap-midpoints="false"
+     inkscape:object-paths="false"
+     inkscape:object-nodes="false"
+     inkscape:snap-smooth-nodes="false"
+     inkscape:snap-intersection-paths="true"
+     inkscape:bbox-nodes="true">
+    <sodipodi:guide
+       position="29.809499,69.619441"
+       orientation="-1,0"
+       id="guide24"
+       inkscape:label=""
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       position="-9.9999998,29.809721"
+       orientation="0,1"
+       id="guide26"
+       inkscape:label=""
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       position="-19.894461,69.619437"
+       orientation="0,1"
+       id="guide879"
+       inkscape:label=""
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-237.38055)">
+    <ellipse
+       style="fill:none;stroke:#ffcc33;stroke-width:4.34999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path871"
+       cx="29.809498"
+       cy="266.46942"
+       rx="2.4063713e-13"
+       ry="0.72084588" />
+    <circle
+       style="fill:none;stroke:#ffcc33;stroke-width:4.3585;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path853"
+       cx="29.809719"
+       cy="267.19028"
+       r="27.630468" />
+    <path
+       id="rect4499"
+       style="fill:#336699;fill-opacity:1;stroke:none;stroke-width:0.01;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 20.185732,260.91659 c -0.195869,0.19587 -0.195502,0.51119 3.66e-4,0.70706 l 5.698896,5.6989 -5.599871,5.59987 c -0.195868,0.19587 -0.195869,0.51083 0,0.7067 l 3.327766,3.32776 c 0.195869,0.19587 0.511197,0.19624 0.707065,3.7e-4 l 5.599871,-5.59987 5.698895,5.69889 c 0.195868,0.19587 0.51083,0.19587 0.706699,0 l 3.460044,-3.46004 c 0.195869,-0.19587 0.196234,-0.5112 3.65e-4,-0.70707 l -5.698895,-5.69889 5.599504,-5.5995 c 0.195869,-0.19587 0.195869,-0.51157 0,-0.70744 l -3.327767,-3.32776 c -0.195868,-0.19587 -0.511195,-0.1955 -0.707064,3.6e-4 l -5.599504,5.59951 -5.698896,-5.6989 c -0.195868,-0.19587 -0.511561,-0.19587 -0.70743,0 z" />
+  </g>
+</svg>

--- a/mu/resources/images/svg/stop.svg
+++ b/mu/resources/images/svg/stop.svg
@@ -93,13 +93,6 @@
      inkscape:groupmode="layer"
      id="layer1"
      transform="translate(0,-237.38055)">
-    <ellipse
-       style="fill:none;stroke:#ffcc33;stroke-width:4.34999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="path871"
-       cx="29.809498"
-       cy="266.46942"
-       rx="2.4063713e-13"
-       ry="0.72084588" />
     <circle
        style="fill:none;stroke:#ffcc33;stroke-width:4.3585;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="path853"

--- a/mu/resources/images/svg/templates.svg
+++ b/mu/resources/images/svg/templates.svg
@@ -83,13 +83,6 @@
      inkscape:groupmode="layer"
      id="layer1"
      transform="translate(0,-237.38055)">
-    <ellipse
-       style="fill:none;stroke:#ffcc33;stroke-width:4.34999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="path871"
-       cx="29.809498"
-       cy="266.46942"
-       rx="2.4063713e-13"
-       ry="0.72084588" />
     <circle
        style="fill:none;stroke:#ffcc33;stroke-width:4.3585;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="path853"

--- a/mu/resources/images/svg/templates.svg
+++ b/mu/resources/images/svg/templates.svg
@@ -1,0 +1,123 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="59.619438mm"
+   height="59.619438mm"
+   viewBox="0 0 59.619438 59.619438"
+   version="1.1"
+   id="svg8"
+   inkscape:version="1.0.2-2 (e86c870879, 2021-01-15)"
+   sodipodi:docname="templates.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="2.5135766"
+     inkscape:cx="59.511418"
+     inkscape:cy="119.60287"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     inkscape:document-rotation="0"
+     showgrid="false"
+     inkscape:snap-page="true"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:window-width="1920"
+     inkscape:window-height="1001"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:snap-to-guides="true"
+     inkscape:snap-global="false">
+    <sodipodi:guide
+       position="29.809499,69.619441"
+       orientation="-1,0"
+       id="guide24"
+       inkscape:label=""
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       position="-9.9999998,29.809721"
+       orientation="0,1"
+       id="guide26"
+       inkscape:label=""
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       position="-19.894461,69.619437"
+       orientation="0,1"
+       id="guide879"
+       inkscape:label=""
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-237.38055)">
+    <ellipse
+       style="fill:none;stroke:#ffcc33;stroke-width:4.34999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path871"
+       cx="29.809498"
+       cy="266.46942"
+       rx="2.4063713e-13"
+       ry="0.72084588" />
+    <circle
+       style="fill:none;stroke:#ffcc33;stroke-width:4.3585;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path853"
+       cx="29.809719"
+       cy="267.19028"
+       r="27.630468" />
+    <g
+       id="g843">
+      <path
+         id="rect1562"
+         style="fill:#336699;fill-opacity:1;stroke-width:7.55906"
+         d="M 61.068359 54.890625 C 50.599089 54.890625 42.171875 63.319792 42.171875 73.789062 L 42.171875 91.570312 C 42.171875 92.495701 42.257476 93.398024 42.384766 94.287109 C 42.380708 94.449005 42.361328 94.606623 42.361328 94.769531 L 42.361328 152.21875 C 42.361328 162.68804 50.790474 171.11719 61.259766 171.11719 L 161.41797 171.11719 C 171.88726 171.11719 180.31445 162.68804 180.31445 152.21875 L 180.31445 94.769531 C 180.31445 84.30024 171.88726 75.873047 161.41797 75.873047 L 106.02344 75.873047 L 106.02344 73.789062 C 106.02344 63.319792 97.596223 54.890625 87.126953 54.890625 L 61.068359 54.890625 z "
+         transform="matrix(0.26458333,0,0,0.26458333,0,237.38055)" />
+      <path
+         style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.01;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 14.841899,268.53801 v 2.13155 l 8.763031,3.42101 v -2.13155 l -6.473594,-2.31576 6.473594,-2.28944 v -2.15787 z"
+         id="path5107"
+         sodipodi:nodetypes="cccccccc" />
+      <path
+         style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.01;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 44.093579,268.53801 v 2.13155 l -8.763031,3.42101 v -2.13155 l 6.473594,-2.31576 -6.473594,-2.28944 v -2.15787 z"
+         id="path5109"
+         sodipodi:nodetypes="cccccccc" />
+      <path
+         style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.01;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 31.683769,262.74863 h 1.999972 l -6.526223,13.81558 H 25.18386 Z"
+         id="path5111"
+         sodipodi:nodetypes="ccccc" />
+    </g>
+  </g>
+</svg>

--- a/mu/resources/images/svg/theme.svg
+++ b/mu/resources/images/svg/theme.svg
@@ -83,13 +83,6 @@
      inkscape:groupmode="layer"
      id="layer1"
      transform="translate(0,-237.38055)">
-    <ellipse
-       style="fill:none;stroke:#ffcc33;stroke-width:4.34999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="path871"
-       cx="29.809498"
-       cy="266.46942"
-       rx="2.4063713e-13"
-       ry="0.72084588" />
     <circle
        style="fill:none;stroke:#ffcc33;stroke-width:4.3585;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="path853"

--- a/mu/resources/images/svg/theme.svg
+++ b/mu/resources/images/svg/theme.svg
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="59.619438mm"
+   height="59.619438mm"
+   viewBox="0 0 59.619438 59.619438"
+   version="1.1"
+   id="svg8"
+   inkscape:version="1.0.2-2 (e86c870879, 2021-01-15)"
+   sodipodi:docname="theme.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="1.2567883"
+     inkscape:cx="348.90374"
+     inkscape:cy="245.24205"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     inkscape:document-rotation="0"
+     showgrid="false"
+     inkscape:snap-page="true"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:window-width="1920"
+     inkscape:window-height="1001"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:snap-to-guides="true"
+     inkscape:snap-global="true">
+    <sodipodi:guide
+       position="29.809499,69.619441"
+       orientation="-1,0"
+       id="guide24"
+       inkscape:label=""
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       position="-9.9999998,29.809721"
+       orientation="0,1"
+       id="guide26"
+       inkscape:label=""
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       position="-19.894461,69.619437"
+       orientation="0,1"
+       id="guide879"
+       inkscape:label=""
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-237.38055)">
+    <ellipse
+       style="fill:none;stroke:#ffcc33;stroke-width:4.34999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path871"
+       cx="29.809498"
+       cy="266.46942"
+       rx="2.4063713e-13"
+       ry="0.72084588" />
+    <circle
+       style="fill:none;stroke:#ffcc33;stroke-width:4.3585;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path853"
+       cx="29.809719"
+       cy="267.19028"
+       r="27.630468" />
+    <path
+       id="path5129"
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#326598;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3.77953;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;stop-color:#000000;stop-opacity:1"
+       d="M 112.66406 65.455078 A 3.7795276 3.7795276 0 0 0 112.58789 65.457031 A 3.7795276 3.7795276 0 0 0 112.10352 65.503906 C 112.10287 65.503941 112.10221 65.503871 112.10156 65.503906 C 89.187644 66.743603 70.398038 84.34045 67.728516 107.17969 C 65.039737 130.18367 79.485725 151.80195 101.76758 158.12109 C 124.04944 164.4402 147.68262 153.62145 157.4707 132.63086 A 3.7795276 3.7795276 0 0 0 155.64648 127.61133 A 3.7795276 3.7795276 0 0 0 154.94141 127.36523 A 3.7795276 3.7795276 0 0 0 154.62109 127.30078 A 3.7795276 3.7795276 0 0 0 154.45898 127.2793 A 3.7795276 3.7795276 0 0 0 154.33984 127.26758 A 3.7795276 3.7795276 0 0 0 154.29688 127.26367 A 3.7795276 3.7795276 0 0 0 154.22852 127.25977 A 3.7795276 3.7795276 0 0 0 154.20312 127.25977 A 3.7795276 3.7795276 0 0 0 154.06445 127.25586 A 3.7795276 3.7795276 0 0 0 153.92383 127.25781 A 3.7795276 3.7795276 0 0 0 153.87695 127.25977 A 3.7795276 3.7795276 0 0 0 153.73828 127.26758 A 3.7795276 3.7795276 0 0 0 152.49414 127.58203 C 137.37796 134.3122 119.67543 129.19353 110.47656 115.43945 C 101.37214 101.82659 103.27836 83.754702 114.94531 72.332031 A 3.7795276 3.7795276 0 0 0 116.53711 69.080078 A 3.7795276 3.7795276 0 0 0 113.31641 65.503906 A 3.7795276 3.7795276 0 0 0 113.31445 65.503906 A 3.7795276 3.7795276 0 0 0 113.30273 65.501953 A 3.7795276 3.7795276 0 0 0 113.29297 65.5 A 3.7795276 3.7795276 0 0 0 112.66406 65.455078 z M 103.50977 74.580078 C 95.030622 88.154854 94.957878 105.83474 104.19531 119.64648 C 113.43964 133.46852 129.82594 140.15123 145.62109 137.48242 C 135.83986 149.71121 119.47909 155.28095 103.82617 150.8418 C 85.062662 145.52045 72.972111 127.42827 75.236328 108.05664 C 77.122553 91.918976 88.499961 78.953785 103.50977 74.580078 z "
+       transform="matrix(0.26458333,0,0,0.26458333,0,237.38055)" />
+  </g>
+</svg>

--- a/mu/resources/images/svg/theme_contrast.svg
+++ b/mu/resources/images/svg/theme_contrast.svg
@@ -83,13 +83,6 @@
      inkscape:groupmode="layer"
      id="layer1"
      transform="translate(0,-237.38055)">
-    <ellipse
-       style="fill:none;stroke:#ffcc33;stroke-width:4.34999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="path871"
-       cx="29.809498"
-       cy="266.46942"
-       rx="2.4063713e-13"
-       ry="0.72084588" />
     <circle
        style="fill:none;stroke:#ffcc33;stroke-width:4.3585;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="path853"

--- a/mu/resources/images/svg/theme_contrast.svg
+++ b/mu/resources/images/svg/theme_contrast.svg
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="59.619438mm"
+   height="59.619438mm"
+   viewBox="0 0 59.619438 59.619438"
+   version="1.1"
+   id="svg8"
+   inkscape:version="1.0.2-2 (e86c870879, 2021-01-15)"
+   sodipodi:docname="theme_contrast.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="1.2567883"
+     inkscape:cx="26.325245"
+     inkscape:cy="237.46311"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     inkscape:document-rotation="0"
+     showgrid="false"
+     inkscape:snap-page="true"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:window-width="1920"
+     inkscape:window-height="1001"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:snap-to-guides="true"
+     inkscape:snap-global="true">
+    <sodipodi:guide
+       position="29.809499,69.619441"
+       orientation="-1,0"
+       id="guide24"
+       inkscape:label=""
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       position="-9.9999998,29.809721"
+       orientation="0,1"
+       id="guide26"
+       inkscape:label=""
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       position="-19.894461,69.619437"
+       orientation="0,1"
+       id="guide879"
+       inkscape:label=""
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-237.38055)">
+    <ellipse
+       style="fill:none;stroke:#ffcc33;stroke-width:4.34999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path871"
+       cx="29.809498"
+       cy="266.46942"
+       rx="2.4063713e-13"
+       ry="0.72084588" />
+    <circle
+       style="fill:none;stroke:#ffcc33;stroke-width:4.3585;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path853"
+       cx="29.809719"
+       cy="267.19028"
+       r="27.630468" />
+    <path
+       id="path5159"
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#336699;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3.77953;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;stop-color:#000000;stop-opacity:1"
+       d="M 111.54102 69.582031 C 88.356751 69.582031 69.441406 88.497376 69.441406 111.68164 C 69.441406 134.86591 88.356751 153.78125 111.54102 153.78125 C 134.72528 153.78125 153.63867 134.86591 153.63867 111.68164 C 153.63867 88.497376 134.72528 69.582031 111.54102 69.582031 z M 111.54102 80.921875 C 111.91865 80.921875 112.29178 80.935896 112.66602 80.949219 L 112.66602 142.41406 C 112.29178 142.42738 111.91865 142.44141 111.54102 142.44141 C 94.484575 142.44141 80.779297 128.73808 80.779297 111.68164 C 80.779297 94.6252 94.484575 80.921875 111.54102 80.921875 z "
+       transform="matrix(0.26458333,0,0,0.26458333,0,237.38055)" />
+  </g>
+</svg>

--- a/mu/resources/images/svg/theme_day.svg
+++ b/mu/resources/images/svg/theme_day.svg
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="59.619438mm"
+   height="59.619438mm"
+   viewBox="0 0 59.619438 59.619438"
+   version="1.1"
+   id="svg8"
+   inkscape:version="1.0.2-2 (e86c870879, 2021-01-15)"
+   sodipodi:docname="theme_day.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="2.5135766"
+     inkscape:cx="38.182203"
+     inkscape:cy="145.26463"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     inkscape:document-rotation="0"
+     showgrid="false"
+     inkscape:snap-page="true"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:window-width="1920"
+     inkscape:window-height="1001"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:snap-to-guides="true"
+     inkscape:snap-global="true">
+    <sodipodi:guide
+       position="29.809499,69.619441"
+       orientation="-1,0"
+       id="guide24"
+       inkscape:label=""
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       position="-9.9999998,29.809721"
+       orientation="0,1"
+       id="guide26"
+       inkscape:label=""
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       position="-19.894461,69.619437"
+       orientation="0,1"
+       id="guide879"
+       inkscape:label=""
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-237.38055)">
+    <path
+       id="path5185"
+       style="fill:#336699;fill-opacity:1;stroke:none;stroke-width:11.3386;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.805668"
+       d="M 112.66992 56.951172 L 99.755859 72.925781 L 79.921875 67.589844 L 78.863281 88.103516 L 59.679688 95.445312 L 70.880859 112.66406 L 59.675781 129.87891 L 78.857422 137.22461 L 79.914062 157.73828 L 99.75 152.40625 L 112.66211 168.38086 L 125.57422 152.4082 L 145.41016 157.74414 L 146.46875 137.23047 L 165.65234 129.88867 L 154.45117 112.66992 L 165.6543 95.455078 L 146.47266 88.107422 L 145.41797 67.595703 L 125.58203 72.927734 L 112.66992 56.951172 z M 112.66602 76.740234 A 35.927218 35.927218 0 0 1 148.59375 112.66602 A 35.927218 35.927218 0 0 1 112.66602 148.59375 A 35.927218 35.927218 0 0 1 76.738281 112.66602 A 35.927218 35.927218 0 0 1 112.66602 76.740234 z "
+       transform="matrix(0.26458333,0,0,0.26458333,0,237.38055)" />
+    <ellipse
+       style="fill:none;stroke:#ffcc33;stroke-width:4.34999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path871"
+       cx="29.809498"
+       cy="266.46942"
+       rx="2.4063713e-13"
+       ry="0.72084588" />
+    <circle
+       style="fill:none;stroke:#ffcc33;stroke-width:4.3585;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path853"
+       cx="29.809719"
+       cy="267.19028"
+       r="27.630468" />
+  </g>
+</svg>

--- a/mu/resources/images/svg/theme_day.svg
+++ b/mu/resources/images/svg/theme_day.svg
@@ -88,13 +88,6 @@
        style="fill:#336699;fill-opacity:1;stroke:none;stroke-width:11.3386;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.805668"
        d="M 112.66992 56.951172 L 99.755859 72.925781 L 79.921875 67.589844 L 78.863281 88.103516 L 59.679688 95.445312 L 70.880859 112.66406 L 59.675781 129.87891 L 78.857422 137.22461 L 79.914062 157.73828 L 99.75 152.40625 L 112.66211 168.38086 L 125.57422 152.4082 L 145.41016 157.74414 L 146.46875 137.23047 L 165.65234 129.88867 L 154.45117 112.66992 L 165.6543 95.455078 L 146.47266 88.107422 L 145.41797 67.595703 L 125.58203 72.927734 L 112.66992 56.951172 z M 112.66602 76.740234 A 35.927218 35.927218 0 0 1 148.59375 112.66602 A 35.927218 35.927218 0 0 1 112.66602 148.59375 A 35.927218 35.927218 0 0 1 76.738281 112.66602 A 35.927218 35.927218 0 0 1 112.66602 76.740234 z "
        transform="matrix(0.26458333,0,0,0.26458333,0,237.38055)" />
-    <ellipse
-       style="fill:none;stroke:#ffcc33;stroke-width:4.34999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="path871"
-       cx="29.809498"
-       cy="266.46942"
-       rx="2.4063713e-13"
-       ry="0.72084588" />
     <circle
        style="fill:none;stroke:#ffcc33;stroke-width:4.3585;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="path853"

--- a/mu/resources/images/svg/tidy.svg
+++ b/mu/resources/images/svg/tidy.svg
@@ -83,13 +83,6 @@
      inkscape:groupmode="layer"
      id="layer1"
      transform="translate(0,-237.38055)">
-    <ellipse
-       style="fill:none;stroke:#ffcc33;stroke-width:4.34999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="path871"
-       cx="29.809498"
-       cy="266.46942"
-       rx="2.4063713e-13"
-       ry="0.72084588" />
     <circle
        style="fill:none;stroke:#ffcc33;stroke-width:4.3585;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="path853"

--- a/mu/resources/images/svg/tidy.svg
+++ b/mu/resources/images/svg/tidy.svg
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="59.619438mm"
+   height="59.619438mm"
+   viewBox="0 0 59.619438 59.619438"
+   version="1.1"
+   id="svg8"
+   inkscape:version="1.0.2-2 (e86c870879, 2021-01-15)"
+   sodipodi:docname="tidy.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="0.88868353"
+     inkscape:cx="-240.243"
+     inkscape:cy="266.46085"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     inkscape:document-rotation="0"
+     showgrid="false"
+     inkscape:snap-page="true"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:window-width="1920"
+     inkscape:window-height="1001"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:snap-to-guides="true"
+     inkscape:snap-global="false">
+    <sodipodi:guide
+       position="29.809499,69.619441"
+       orientation="-1,0"
+       id="guide24"
+       inkscape:label=""
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       position="-9.9999998,29.809721"
+       orientation="0,1"
+       id="guide26"
+       inkscape:label=""
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       position="-19.894461,69.619437"
+       orientation="0,1"
+       id="guide879"
+       inkscape:label=""
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-237.38055)">
+    <ellipse
+       style="fill:none;stroke:#ffcc33;stroke-width:4.34999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path871"
+       cx="29.809498"
+       cy="266.46942"
+       rx="2.4063713e-13"
+       ry="0.72084588" />
+    <circle
+       style="fill:none;stroke:#ffcc33;stroke-width:4.3585;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path853"
+       cx="29.809719"
+       cy="267.19028"
+       r="27.630468" />
+    <g
+       id="g841">
+      <path
+         id="rect5259"
+         style="fill:#336699;fill-opacity:1;stroke:none;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.805668"
+         d="m 19.070596,256.62104 h 21.457323 c 0.276999,0 0.499999,0.22299 0.499999,0.49999 v 3.83804 c 0,0.277 -0.223,0.5 -0.499999,0.5 H 19.070596 c -0.277,0 -0.499999,-0.223 -0.499999,-0.5 v -3.83804 c 0,-0.277 0.222999,-0.49999 0.499999,-0.49999 z"
+         sodipodi:nodetypes="sssssssss" />
+      <path
+         id="path5262"
+         style="fill:#336699;fill-opacity:1;stroke:none;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.805668"
+         d="m 22.394462,265.65415 h 21.457323 c 0.276999,0 0.499999,0.22299 0.499999,0.49999 v 3.83804 c 0,0.277 -0.223,0.5 -0.499999,0.5 H 22.394462 c -0.277,0 -0.499999,-0.223 -0.499999,-0.5 v -3.83804 c 0,-0.277 0.222999,-0.49999 0.499999,-0.49999 z"
+         sodipodi:nodetypes="sssssssss" />
+      <path
+         id="path5264"
+         style="fill:#336699;fill-opacity:1;stroke:none;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.805668"
+         d="m 19.082238,274.26975 h 21.457323 c 0.276999,0 0.499999,0.22299 0.499999,0.49999 v 3.83804 c 0,0.277 -0.223,0.5 -0.499999,0.5 H 19.082238 c -0.277,0 -0.499999,-0.223 -0.499999,-0.5 v -3.83804 c 0,-0.277 0.222999,-0.49999 0.499999,-0.49999 z"
+         sodipodi:nodetypes="sssssssss" />
+    </g>
+  </g>
+</svg>

--- a/mu/resources/images/svg/zoom-in.svg
+++ b/mu/resources/images/svg/zoom-in.svg
@@ -86,13 +86,6 @@
      inkscape:groupmode="layer"
      id="layer1"
      transform="translate(0,-237.38055)">
-    <ellipse
-       style="fill:none;stroke:#ffcc33;stroke-width:4.34999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="path871"
-       cx="29.809498"
-       cy="266.46942"
-       rx="2.4063713e-13"
-       ry="0.72084588" />
     <circle
        style="fill:none;stroke:#ffcc33;stroke-width:4.3585;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="path853"

--- a/mu/resources/images/svg/zoom-in.svg
+++ b/mu/resources/images/svg/zoom-in.svg
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="59.619438mm"
+   height="59.619438mm"
+   viewBox="0 0 59.619438 59.619438"
+   version="1.1"
+   id="svg8"
+   inkscape:version="1.0.2-2 (e86c870879, 2021-01-15)"
+   sodipodi:docname="zoom-in.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="2"
+     inkscape:cx="44.368477"
+     inkscape:cy="142.52523"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     inkscape:document-rotation="0"
+     showgrid="false"
+     inkscape:snap-page="true"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:window-width="1920"
+     inkscape:window-height="1001"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:snap-to-guides="true"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:snap-bbox-midpoints="true"
+     inkscape:snap-object-midpoints="true">
+    <sodipodi:guide
+       position="29.809499,69.619441"
+       orientation="-1,0"
+       id="guide24"
+       inkscape:label=""
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       position="-9.9999998,29.809721"
+       orientation="0,1"
+       id="guide26"
+       inkscape:label=""
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       position="-19.894461,69.619437"
+       orientation="0,1"
+       id="guide879"
+       inkscape:label=""
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-237.38055)">
+    <ellipse
+       style="fill:none;stroke:#ffcc33;stroke-width:4.34999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path871"
+       cx="29.809498"
+       cy="266.46942"
+       rx="2.4063713e-13"
+       ry="0.72084588" />
+    <circle
+       style="fill:none;stroke:#ffcc33;stroke-width:4.3585;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path853"
+       cx="29.809719"
+       cy="267.19028"
+       r="27.630468" />
+    <g
+       id="g839">
+      <path
+         id="rect5280"
+         style="fill:#336699;fill-opacity:1;stroke:none;stroke-width:11.3386;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.805668"
+         d="M 102.95312 85.097656 C 101.9062 85.097656 101.0625 85.941352 101.0625 86.988281 L 101.0625 100.71094 L 87.339844 100.71094 C 86.292915 100.71094 85.449219 101.55268 85.449219 102.59961 L 85.449219 105.99414 C 85.449219 107.04107 86.292915 107.88477 87.339844 107.88477 L 101.0625 107.88477 L 101.0625 121.60742 C 101.0625 122.65435 101.9062 123.49805 102.95312 123.49805 L 106.3457 123.49805 C 107.39263 123.49805 108.23633 122.65435 108.23633 121.60742 L 108.23633 107.88477 L 121.95898 107.88477 C 123.00591 107.88477 123.84961 107.04107 123.84961 105.99414 L 123.84961 102.59961 C 123.84961 101.55268 123.00591 100.71094 121.95898 100.71094 L 108.23633 100.71094 L 108.23633 86.988281 C 108.23633 85.941352 107.39263 85.097656 106.3457 85.097656 L 102.95312 85.097656 z "
+         transform="matrix(0.26458333,0,0,0.26458333,0,237.38055)" />
+      <path
+         id="path5286"
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#336699;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3.77953;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;stop-color:#000000;stop-opacity:1"
+         d="M 104.65234 61.210938 C 80.945798 61.210938 61.564453 80.594262 61.564453 104.30078 C 61.564453 128.00734 80.945798 147.38867 104.65234 147.38867 C 113.75361 147.38867 122.21056 144.52341 129.18359 139.66211 L 150.53125 161.00977 C 152.03108 162.38867 154.23797 163.25139 155.92773 163.27539 C 160.10212 163.27514 163.48607 159.89119 163.48633 155.7168 C 163.20571 153.52002 162.58002 151.83552 161.32422 150.42383 L 139.89453 128.99414 C 144.82363 121.98894 147.73438 113.4728 147.73438 104.30078 C 147.73438 80.594262 128.35889 61.210938 104.65234 61.210938 z M 104.65234 76.330078 C 120.18845 76.330078 132.61523 88.764693 132.61523 104.30078 C 132.61523 119.83691 120.18845 132.26953 104.65234 132.26953 C 89.116233 132.26953 76.683594 119.83691 76.683594 104.30078 C 76.683594 88.764693 89.116233 76.330078 104.65234 76.330078 z "
+         transform="matrix(0.26458333,0,0,0.26458333,0,237.38055)" />
+    </g>
+  </g>
+</svg>

--- a/mu/resources/images/svg/zoom-out.svg
+++ b/mu/resources/images/svg/zoom-out.svg
@@ -86,13 +86,6 @@
      inkscape:groupmode="layer"
      id="layer1"
      transform="translate(0,-237.38055)">
-    <ellipse
-       style="fill:none;stroke:#ffcc33;stroke-width:4.34999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="path871"
-       cx="29.809498"
-       cy="266.46942"
-       rx="2.4063713e-13"
-       ry="0.72084588" />
     <circle
        style="fill:none;stroke:#ffcc33;stroke-width:4.3585;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="path853"

--- a/mu/resources/images/svg/zoom-out.svg
+++ b/mu/resources/images/svg/zoom-out.svg
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="59.619438mm"
+   height="59.619438mm"
+   viewBox="0 0 59.619438 59.619438"
+   version="1.1"
+   id="svg8"
+   inkscape:version="1.0.2-2 (e86c870879, 2021-01-15)"
+   sodipodi:docname="zoom-out.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="2.8284271"
+     inkscape:cx="160.66905"
+     inkscape:cy="115.65654"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     inkscape:document-rotation="0"
+     showgrid="false"
+     inkscape:snap-page="true"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:window-width="1920"
+     inkscape:window-height="1001"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:snap-to-guides="true"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:snap-bbox-midpoints="true"
+     inkscape:snap-object-midpoints="true">
+    <sodipodi:guide
+       position="29.809499,69.619441"
+       orientation="-1,0"
+       id="guide24"
+       inkscape:label=""
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       position="-9.9999998,29.809721"
+       orientation="0,1"
+       id="guide26"
+       inkscape:label=""
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       position="-19.894461,69.619437"
+       orientation="0,1"
+       id="guide879"
+       inkscape:label=""
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-237.38055)">
+    <ellipse
+       style="fill:none;stroke:#ffcc33;stroke-width:4.34999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path871"
+       cx="29.809498"
+       cy="266.46942"
+       rx="2.4063713e-13"
+       ry="0.72084588" />
+    <circle
+       style="fill:none;stroke:#ffcc33;stroke-width:4.3585;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path853"
+       cx="29.809719"
+       cy="267.19028"
+       r="27.630468" />
+    <g
+       id="g839">
+      <path
+         id="rect5280"
+         style="fill:#336699;fill-opacity:1;stroke:none;stroke-width:11.3386;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.805668"
+         d="m 87.339844,100.71094 c -1.046929,0 -1.890625,0.84174 -1.890625,1.88867 v 3.39453 c 0,1.04693 0.843696,1.89063 1.890625,1.89063 h 34.619136 c 1.04693,0 1.89063,-0.8437 1.89063,-1.89063 v -3.39453 c 0,-1.04693 -0.8437,-1.88867 -1.89063,-1.88867 z"
+         transform="matrix(0.26458333,0,0,0.26458333,0,237.38055)"
+         sodipodi:nodetypes="cssccsscc" />
+      <path
+         id="path5286"
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#336699;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3.77953;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;stop-color:#000000;stop-opacity:1"
+         d="M 104.65234 61.210938 C 80.945798 61.210938 61.564453 80.594262 61.564453 104.30078 C 61.564453 128.00734 80.945798 147.38867 104.65234 147.38867 C 113.75361 147.38867 122.21056 144.52341 129.18359 139.66211 L 150.53125 161.00977 C 152.03108 162.38867 154.23797 163.25139 155.92773 163.27539 C 160.10212 163.27514 163.48607 159.89119 163.48633 155.7168 C 163.20571 153.52002 162.58002 151.83552 161.32422 150.42383 L 139.89453 128.99414 C 144.82363 121.98894 147.73438 113.4728 147.73438 104.30078 C 147.73438 80.594262 128.35889 61.210938 104.65234 61.210938 z M 104.65234 76.330078 C 120.18845 76.330078 132.61523 88.764693 132.61523 104.30078 C 132.61523 119.83691 120.18845 132.26953 104.65234 132.26953 C 89.116233 132.26953 76.683594 119.83691 76.683594 104.30078 C 76.683594 88.764693 89.116233 76.330078 104.65234 76.330078 z "
+         transform="matrix(0.26458333,0,0,0.26458333,0,237.38055)" />
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
These are the SVG icons requested in issue #1312.

First note that I am not a graphic designer.  I merely have significant experience with Inkscape, and this seemed like something fairly easy to do.  (I mention this, because I don't have the time, motivation, or skill to work on complex graphics.)

Second, there are some potential stylistic issues with these.  Specifically, on some of the icons, I have left parts transparent that others might prefer to be white.  Things that should obviously not be transparent, like cuff buttons on the check buttons, are white, but places like the center holes in the gears of the snippets button and the middle of the sun on the theme_day button I've left transparent.  If there are places where the transparency is a problem, please let me know, and I can add background when I have time.  Beyond this, I did my best to remain faithful to the original images.  If minor adjustments are needed, like adding background to transparent parts, let me know, and I will work on it as I have time.  Changing colors on existing elements should be trivial for anyone to do.  If the SVGs need to be rendered to PNGs, also let know.  It has been a while, but I've done batch rendering with Inkscape before, and it's way faster than trying to render 37 images manually, one-by-one.  I can also make new SVG buttons, given the png files for them to use as a template.


I don't know if this counts as a contribution big enough to add to the AUTHORS file, but if it is, I can be included as "Ben Williams" or "Rybec Arethdar".