### PR TITLE
venv: Install each wheel individually. 

### DIFF
--- a/mu/app.py
+++ b/mu/app.py
@@ -264,6 +264,7 @@ def run():
     setup_logging()
     logging.info("\n\n-----------------\n\nStarting Mu {}".format(__version__))
     logging.info(platform.uname())
+    logging.info("Platform: {}".format(platform.platform()))
     logging.info("Python path: {}".format(sys.path))
     logging.info("Language code: {}".format(i18n.language_code))
 

--- a/mu/virtual_environment.py
+++ b/mu/virtual_environment.py
@@ -737,8 +737,9 @@ class VirtualEnvironment(object):
                 "No wheels in %s; try `python -mmu.wheels`" % wheels_dirpath
             )
         self.reset_pip()
-        logger.info("About to install from wheels")
-        self.pip.install(wheel_filepaths)
+        for wheel in wheel_filepaths:
+            logger.info("About to install from wheels: {}".format(wheel))
+            self.pip.install(wheel, deps=False, index=False)
 
     def register_baseline_packages(self):
         """

--- a/tests/virtual_environment/test_virtual_environment.py
+++ b/tests/virtual_environment/test_virtual_environment.py
@@ -243,22 +243,23 @@ def test_base_packages_installed(patched, venv, test_wheels):
     from wheels
     """
     #
+    # Check that we're calling `pip install` with all the
+    # wheels in the wheelhouse
+    #
+    expected_args = glob.glob(
+        os.path.join(mu.virtual_environment.wheels_dirpath, "*.whl")
+    )
+    #
     # Make sure the juypter kernel install doesn't interfere
     #
     with mock.patch.object(VE, "install_jupyter_kernel"):
         with mock.patch.object(VE, "register_baseline_packages"):
             with mock.patch.object(PIP, "install") as mock_pip_install:
-                #
-                # Check that we're calling `pip install` with all the
-                # wheels in the wheelhouse
-                #
-                expected_args = glob.glob(
-                    os.path.join(
-                        mu.virtual_environment.wheels_dirpath, "*.whl"
-                    )
-                )
                 venv.create()
-                mock_pip_install.assert_called_once_with(expected_args)
+    for mock_call_args in mock_pip_install.call_args_list:
+        assert len(mock_call_args[0]) == 1
+        assert mock_call_args[0][0] in expected_args
+        assert mock_call_args[1] == {"deps": False, "index": False}
 
 
 def test_jupyter_kernel_installed(patched, venv):


### PR DESCRIPTION
This also provides more granular logs and decreases the chance of having a timeout of the pip install process. 

Before this the 3 minutes configured for the timeout might not have been long enough to install all the wheels together, so with this PR we have 3 min per wheel which should be enough for individual install.

Should hopefully fix https://github.com/mu-editor/mu/issues/1600