### PR TITLE
Improve logging & test coverage for virtual_environment

### DIFF
--- a/mu/app.py
+++ b/mu/app.py
@@ -175,7 +175,7 @@ def excepthook(*exc_args):
         log_file = base64.standard_b64encode(LOG_FILE.encode("utf-8"))
         error = base64.standard_b64encode(
             "".join(traceback.format_exception(*exc_args)).encode("utf-8")
-        )[:1800]
+        )[-1800:]
         p = platform.uname()
         params = {
             "v": __version__,  # version

--- a/mu/app.py
+++ b/mu/app.py
@@ -175,7 +175,7 @@ def excepthook(*exc_args):
         log_file = base64.standard_b64encode(LOG_FILE.encode("utf-8"))
         error = base64.standard_b64encode(
             "".join(traceback.format_exception(*exc_args)).encode("utf-8")
-        )
+        )[:1800]
         p = platform.uname()
         params = {
             "v": __version__,  # version

--- a/mu/virtual_environment.py
+++ b/mu/virtual_environment.py
@@ -157,7 +157,7 @@ class Process(QObject):
         if not finished:
             logger.error(compact(output))
             raise VirtualEnvironmentError(
-                "Process did not terminate normally:\n" + output
+                "Process did not terminate normally:\n" + compact(output)
             )
 
         if exit_code != 0:
@@ -166,8 +166,8 @@ class Process(QObject):
             #
             logger.error(compact(output))
             raise VirtualEnvironmentError(
-                ("Process finished but with error code %d:\n" % exit_code)
-                + output
+                "Process finished but with error code %d:\n%s"
+                % (exit_code, compact(output))
             )
 
         return output
@@ -626,7 +626,8 @@ class VirtualEnvironment(object):
         )
         if not ok:
             raise VirtualEnvironmentEnsureError(
-                "Failed to run venv interpreter %s\n%s" % (self.interpreter, output)
+                "Failed to run venv interpreter %s\n%s"
+                % (self.interpreter, compact(output))
             )
 
         venv_version = output.strip()
@@ -649,7 +650,7 @@ class VirtualEnvironment(object):
             )
             if not ok:
                 raise VirtualEnvironmentEnsureError(
-                    "Failed to import: %s\n%s" % (module, output)
+                    "Failed to import: %s\n%s" % (module, compact(output))
                 )
 
     def ensure_pip(self):
@@ -702,7 +703,7 @@ class VirtualEnvironment(object):
         else:
             raise VirtualEnvironmentCreateError(
                 "Unable to create a virtual environment using %s at %s\n%s"
-                % (sys.executable, self.path, output)
+                % (sys.executable, self.path, compact(output))
             )
 
     def upgrade_pip(self):
@@ -717,7 +718,9 @@ class VirtualEnvironment(object):
         if ok:
             logger.info("Upgraded pip")
         else:
-            raise VirtualEnvironmentCreateError("Unable to upgrade pip\n%s" % output)
+            raise VirtualEnvironmentCreateError(
+                "Unable to upgrade pip\n%s" % compact(output)
+            )
 
     def install_jupyter_kernel(self):
         """
@@ -742,7 +745,9 @@ class VirtualEnvironment(object):
         if ok:
             logger.info("Installed Jupyter Kernel: %s", kernel_name)
         else:
-            raise VirtualEnvironmentCreateError("Unable to install kernel\n%s" % output)
+            raise VirtualEnvironmentCreateError(
+                "Unable to install kernel\n%s" % compact(output)
+            )
 
     def install_baseline_packages(self):
         """

--- a/mu/virtual_environment.py
+++ b/mu/virtual_environment.py
@@ -157,7 +157,7 @@ class Process(QObject):
         if not finished:
             logger.error(compact(output))
             raise VirtualEnvironmentError(
-                "Process did not terminate normally:\n" + output[-1800:]
+                "Process did not terminate normally:\n" + output
             )
 
         if exit_code != 0:
@@ -167,7 +167,7 @@ class Process(QObject):
             logger.error(compact(output))
             raise VirtualEnvironmentError(
                 ("Process finished but with error code %d:\n" % exit_code)
-                + output[-1800:]
+                + output
             )
 
         return output
@@ -626,7 +626,7 @@ class VirtualEnvironment(object):
         )
         if not ok:
             raise VirtualEnvironmentEnsureError(
-                "Failed to run venv interpreter %s" % self.interpreter
+                "Failed to run venv interpreter %s\n%s" % (self.interpreter, output)
             )
 
         venv_version = output.strip()
@@ -649,7 +649,7 @@ class VirtualEnvironment(object):
             )
             if not ok:
                 raise VirtualEnvironmentEnsureError(
-                    "Failed to import: %s" % module
+                    "Failed to import: %s\n%s" % (module, output)
                 )
 
     def ensure_pip(self):
@@ -701,8 +701,8 @@ class VirtualEnvironment(object):
             )
         else:
             raise VirtualEnvironmentCreateError(
-                "Unable to create a virtual environment using %s at %s"
-                % (sys.executable, self.path)
+                "Unable to create a virtual environment using %s at %s\n%s"
+                % (sys.executable, self.path, output)
             )
 
     def upgrade_pip(self):
@@ -717,7 +717,7 @@ class VirtualEnvironment(object):
         if ok:
             logger.info("Upgraded pip")
         else:
-            raise VirtualEnvironmentCreateError("Unable to upgrade pip")
+            raise VirtualEnvironmentCreateError("Unable to upgrade pip\n%s" % output)
 
     def install_jupyter_kernel(self):
         """
@@ -727,7 +727,7 @@ class VirtualEnvironment(object):
         kernel_name = self.name.replace(" ", "-")
         display_name = '"Python/Mu ({})"'.format(kernel_name)
         logger.info("Installing Jupyter Kernel: %s", kernel_name)
-        ok, output = self.run_subprocess(self.interpreter, "-m", "pip", "list")
+        ## ?? ok, output = self.run_subprocess(self.interpreter, "-m", "pip", "list")
         ok, output = self.run_subprocess(
             sys.executable,
             "-m",
@@ -742,7 +742,7 @@ class VirtualEnvironment(object):
         if ok:
             logger.info("Installed Jupyter Kernel: %s", kernel_name)
         else:
-            raise VirtualEnvironmentCreateError("Unable to install kernel")
+            raise VirtualEnvironmentCreateError("Unable to install kernel\n%s" % output)
 
     def install_baseline_packages(self):
         """

--- a/mu/virtual_environment.py
+++ b/mu/virtual_environment.py
@@ -730,7 +730,6 @@ class VirtualEnvironment(object):
         kernel_name = self.name.replace(" ", "-")
         display_name = '"Python/Mu ({})"'.format(kernel_name)
         logger.info("Installing Jupyter Kernel: %s", kernel_name)
-        ## ?? ok, output = self.run_subprocess(self.interpreter, "-m", "pip", "list")
         ok, output = self.run_subprocess(
             sys.executable,
             "-m",

--- a/mu/virtual_environment.py
+++ b/mu/virtual_environment.py
@@ -143,7 +143,12 @@ class Process(QObject):
         # exitStatus (normal (0) / crashed (1)) -- we don't currently distinguish
         # exitCode (whatever the program returns; conventionally 0 => ok)
         #
-        logger.debug("Finished: %s; exitStatus %s; exitCode %s", finished, exit_status, exit_code)
+        logger.debug(
+            "Finished: %s; exitStatus %s; exitCode %s",
+            finished,
+            exit_status,
+            exit_code,
+        )
 
         #
         # Exceptions raised here will be caught by the crash-handler which will try to
@@ -161,7 +166,7 @@ class Process(QObject):
             #
             logger.error(compact(output))
             raise VirtualEnvironmentError(
-                ("Process finished but with error code %f:\n" % exit_code)
+                ("Process finished but with error code %d:\n" % exit_code)
                 + output[-1800:]
             )
 

--- a/tests/virtual_environment/test_process.py
+++ b/tests/virtual_environment/test_process.py
@@ -47,16 +47,39 @@ def test_run_blocking_timeout():
     """Ensure that a process is run synchronously and times out"""
     p = virtual_environment.Process()
     #
-    # If the process times out, it will return an empty string instead
-    # of "None" which would be actual output from print(time.sleep(...))
+    # If the process times out, it will raise a VirtualEnvironmentError
+    # whose message arg will contain any stdout
     #
-    expected_output = ""
-    output = p.run_blocking(
-        sys.executable,
-        ["-c", "import time; print(time.sleep(0.2))"],
-        wait_for_s=0.1,
-    ).strip()
-    assert output == expected_output
+    expected_stdout = uuid.uuid1().hex
+    expected_stderr = uuid.uuid1().hex
+    try:
+        p.run_blocking(
+            sys.executable,
+            ["-c", "import sys; sys.stdout.write('" + expected_stdout + "'); sys.stderr.write('" + expected_stderr + "'); time.sleep(0.2)"],
+            wait_for_s=0.1,
+        ).strip()
+    except virtual_environment.VirtualEnvironmentError as exc:
+        assert expected_stdout in exc.message
+        assert expected_stderr in exc.message
+
+def test_run_blocking_error():
+    """Ensure that a process raises a known exception on error"""
+    p = virtual_environment.Process()
+    #
+    # If the process errors out, it will raise a VirtualEnvironmentError
+    # whose message arg will contain any stdout and stderr
+    #
+    expected_stdout = uuid.uuid1().hex
+    expected_stderr = uuid.uuid1().hex
+    try:
+        p.run_blocking(
+            sys.executable,
+            ["-c", "import sys; sys.stdout.write('" + expected_stdout + "'); sys.stderr.write('" + expected_stderr + "'); 1/0"]
+        ).strip()
+    except virtual_environment.VirtualEnvironmentError as exc:
+        assert expected_stdout in exc.message
+        assert expected_stderr in exc.message
+
 
 
 def _QTimer_singleshot(delay, partial):

--- a/tests/virtual_environment/test_process.py
+++ b/tests/virtual_environment/test_process.py
@@ -61,9 +61,9 @@ def test_run_blocking_timeout():
                 + expected_stdout
                 + "'); sys.stderr.write('"
                 + expected_stderr
-                + "'); time.sleep(1.0)",
+                + "'); time.sleep(2.0)",
             ],
-            wait_for_s=0.5,
+            wait_for_s=1.0s,
         ).strip()
     except virtual_environment.VirtualEnvironmentError as exc:
         assert expected_stdout in exc.message

--- a/tests/virtual_environment/test_process.py
+++ b/tests/virtual_environment/test_process.py
@@ -63,7 +63,7 @@ def test_run_blocking_timeout():
                 + expected_stderr
                 + "'); time.sleep(2.0)",
             ],
-            wait_for_s=1.0s,
+            wait_for_s=1.0,
         ).strip()
     except virtual_environment.VirtualEnvironmentError as exc:
         assert expected_stdout in exc.message

--- a/tests/virtual_environment/test_process.py
+++ b/tests/virtual_environment/test_process.py
@@ -55,12 +55,20 @@ def test_run_blocking_timeout():
     try:
         p.run_blocking(
             sys.executable,
-            ["-c", "import sys; sys.stdout.write('" + expected_stdout + "'); sys.stderr.write('" + expected_stderr + "'); time.sleep(0.2)"],
-            wait_for_s=0.1,
+            [
+                "-c",
+                "import sys; sys.stdout.write('"
+                + expected_stdout
+                + "'); sys.stderr.write('"
+                + expected_stderr
+                + "'); time.sleep(1.0)",
+            ],
+            wait_for_s=0.5,
         ).strip()
     except virtual_environment.VirtualEnvironmentError as exc:
         assert expected_stdout in exc.message
         assert expected_stderr in exc.message
+
 
 def test_run_blocking_error():
     """Ensure that a process raises a known exception on error"""
@@ -74,12 +82,18 @@ def test_run_blocking_error():
     try:
         p.run_blocking(
             sys.executable,
-            ["-c", "import sys; sys.stdout.write('" + expected_stdout + "'); sys.stderr.write('" + expected_stderr + "'); 1/0"]
+            [
+                "-c",
+                "import sys; sys.stdout.write('"
+                + expected_stdout
+                + "'); sys.stderr.write('"
+                + expected_stderr
+                + "'); 1/0",
+            ],
         ).strip()
     except virtual_environment.VirtualEnvironmentError as exc:
         assert expected_stdout in exc.message
         assert expected_stderr in exc.message
-
 
 
 def _QTimer_singleshot(delay, partial):

--- a/tests/virtual_environment/test_virtual_environment.py
+++ b/tests/virtual_environment/test_virtual_environment.py
@@ -25,7 +25,7 @@ import uuid
 import logging
 from unittest import mock
 
-from PyQt5.QtCore import QTimer, QProcess
+# ~ from PyQt5.QtCore import QTimer, QProcess
 import pytest
 
 import mu.virtual_environment
@@ -494,27 +494,33 @@ def _QTimer_singleshot(delay, partial):
 
 
 def test_run_python_blocking(venv):
-    """Ensure that Python is run synchronously with the args passed"""
-    command = venv.interpreter
-    args = ("-c", "import sys; print(sys.executable)")
-    with mock.patch.object(
-        QTimer, "singleShot", _QTimer_singleshot
-    ), mock.patch.object(QProcess, "start") as mocked_start:
-        venv.run_python(*args)
+    """Ensure that Python is run synchronously with the args passed
 
-    mocked_start.assert_called_with(command, args)
+    NB all we're doing here is checking that run_python hands off to
+    Process.run with the correct parameters
+    """
+    command = venv.interpreter
+    args = (uuid.uuid1().hex, uuid.uuid1().hex)
+    with mock.patch.object(
+        mu.virtual_environment.Process, "run_blocking"
+    ) as mocked_run:
+        venv.run_python(*args)
+    mocked_run.assert_called_with(command, args)
 
 
 def test_run_python_nonblocking(venv):
-    """Ensure that a QProcess is started with the relevant params"""
-    command = venv.interpreter
-    args = ("-c", "import sys; print(sys.executable)")
-    with mock.patch.object(
-        QTimer, "singleShot", _QTimer_singleshot
-    ), mock.patch.object(QProcess, "start") as mocked_start:
-        venv.run_python(*args, slots=venv.Slots(output=lambda x: x))
+    """Ensure that Python is started asynchronously with the relevant params
 
-    mocked_start.assert_called_with(command, args)
+    NB all we're doing here is checking that run_python hands off to
+    Process.run with the correct parameters
+    """
+    command = venv.interpreter
+    args = (uuid.uuid1().hex, uuid.uuid1().hex)
+    with mock.patch.object(
+        mu.virtual_environment.Process, "run"
+    ) as mocked_run:
+        venv.run_python(*args, slots=venv.Slots(output=lambda x: x))
+    mocked_run.assert_called_with(command, args)
 
 
 def test_reset_pip(venv, pipped):

--- a/tests/virtual_environment/test_virtual_environment.py
+++ b/tests/virtual_environment/test_virtual_environment.py
@@ -269,6 +269,25 @@ def test_download_wheels_if_not_present(venv, test_wheels):
     assert mock_download.called
 
 
+def test_download_wheels_failure(venv, test_wheels):
+    """If the wheels download fails, ensure that we raise a VirtualEnvironmentError
+    with the same message"""
+    message = uuid.uuid1().hex
+    wheels_dirpath = test_wheels
+    for filepath in glob.glob(os.path.join(wheels_dirpath, "*.whl")):
+        os.unlink(filepath)
+    assert not glob.glob(os.path.join(wheels_dirpath, "*.whl"))
+    with mock.patch.object(
+        mu.wheels,
+        "download",
+        side_effect=mu.wheels.WheelsDownloadError(message),
+    ):
+        try:
+            venv.install_baseline_packages()
+        except VEError as exc:
+            assert message in exc.message
+
+
 def test_base_packages_installed(patched, venv, test_wheels):
     """Ensure that, when the venv is installed, the base packages are installed
     from wheels

--- a/tests/virtual_environment/test_virtual_environment.py
+++ b/tests/virtual_environment/test_virtual_environment.py
@@ -138,6 +138,9 @@ def test_splash_log_handler():
     assert signal.emit.call_count == 2
 
 
+def test_virtual_environment_str_contains_path(venv):
+    assert venv.path in str(venv)
+
 def test_create_virtual_environment_on_disk(venv_dirpath, test_wheels):
     """Ensure that we're actually creating a working virtual environment
     on the disk with wheels installed

--- a/tests/virtual_environment/test_virtual_environment.py
+++ b/tests/virtual_environment/test_virtual_environment.py
@@ -492,19 +492,21 @@ def test_venv_folder_already_exists_not_directory(venv_dirpath):
 def test_ensure_interpreter(venv):
     """When venv exists but has no interpreter ensure we raise an exception"""
     assert not os.path.isfile(venv.interpreter)
-
     with pytest.raises(VEError, match="[Ii]nterpreter"):
         venv.ensure_interpreter()
 
 
-def test_ensure_interpreter_version(venv):
-    """When venv interpreter exists but for a different Py version raise an exception"""
-    mocked_process = mock.MagicMock()
-    mocked_process.stdout = b"x.y"
-    with mock.patch.object(subprocess, "run", return_value=mocked_process):
-        with pytest.raises(VEError, match="[Ii]nterpreter"):
+def test_ensure_interpreter_failed_to_run(venv):
+    """When venv interpreter can't be run raise an exception"""
+    with mock.patch.object(VE, "run_subprocess", return_value=(False, "x.y")):
+        with pytest.raises(VEError, match="Failed to run"):
             venv.ensure_interpreter_version()
 
+def test_ensure_interpreter_version(venv):
+    """When venv interpreter exists but for a different Py version raise an exception"""
+    with mock.patch.object(VE, "run_subprocess", return_value=(True, "x.y")):
+        with pytest.raises(VEError, match="[Ii]nterpreter at version"):
+            venv.ensure_interpreter_version()
 
 #
 # Ensure Key Modules

--- a/tests/virtual_environment/test_virtual_environment.py
+++ b/tests/virtual_environment/test_virtual_environment.py
@@ -320,6 +320,22 @@ def test_jupyter_kernel_installed(patched, venv):
             assert expected_jupyter_args == args[: len(expected_jupyter_args)]
 
 
+def test_upgrade_pip_failure(venv):
+    """Ensure that we raise an error with output when pip can't be upgraded"""
+    output = uuid.uuid1().hex
+    with mock.patch.object(venv, "run_subprocess", return_value=(True, output)):
+        venv.upgrade_pip()
+
+def test_upgrade_pip_success(venv):
+    """Ensure that we raise an error with output when pip can't be upgraded"""
+    output = uuid.uuid1().hex
+    with mock.patch.object(venv, "run_subprocess", return_value=(False, output)):
+        try:
+            venv.upgrade_pip()
+        except VEError as exc:
+            assert "nable to upgrade pip" in exc.message
+            assert output in exc.message
+
 def test_install_user_packages(patched, venv):
     """Ensure that, given a list of packages, we pip install them
 

--- a/tests/virtual_environment/test_virtual_environment.py
+++ b/tests/virtual_environment/test_virtual_environment.py
@@ -445,6 +445,33 @@ def test_venv_ensure_and_create_splash_handler(venv):
 
 
 #
+# Overall Ensure
+#
+def test_ensure(venv):
+    """Check that the ensure method calls all the necessary ensure components
+
+    This is necessarily a bit of an artificial test, but does at least give us
+    test coverage
+    """
+    with mock.patch.object(VE, "ensure_path") as m1, mock.patch.object(
+        VE, "ensure_interpreter"
+    ) as m2, mock.patch.object(
+        VE, "ensure_interpreter_version"
+    ) as m3, mock.patch.object(
+        VE, "ensure_pip"
+    ) as m4, mock.patch.object(
+        VE, "ensure_key_modules"
+    ) as m5:
+        venv.ensure()
+
+    m1.assert_called_with()
+    m2.assert_called_with()
+    m3.assert_called_with()
+    m4.assert_called_with()
+    m5.assert_called_with()
+
+
+#
 # Ensure Path
 #
 def test_venv_folder_already_exists(venv):

--- a/tests/virtual_environment/test_virtual_environment.py
+++ b/tests/virtual_environment/test_virtual_environment.py
@@ -502,18 +502,37 @@ def test_ensure_interpreter_failed_to_run(venv):
         with pytest.raises(VEError, match="Failed to run"):
             venv.ensure_interpreter_version()
 
+
 def test_ensure_interpreter_version(venv):
     """When venv interpreter exists but for a different Py version raise an exception"""
     with mock.patch.object(VE, "run_subprocess", return_value=(True, "x.y")):
         with pytest.raises(VEError, match="[Ii]nterpreter at version"):
             venv.ensure_interpreter_version()
 
+
 #
 # Ensure Key Modules
 #
-@pytest.mark.skip("Not sure how to test this one yet")
-def test_ensure_key_modules(venv):
-    assert False
+def test_ensure_key_modules_failure(venv):
+    modules = [uuid.uuid1().hex, uuid.uuid1().hex, uuid.uuid1().hex]
+    output = uuid.uuid1().hex
+    with mock.patch.object(
+        mu.wheels, "mode_packages", modules
+    ), mock.patch.object(VE, "run_subprocess", return_value=(False, output)):
+        try:
+            venv.ensure_key_modules()
+        except VEError as exc:
+            assert "Failed to import" in exc.message
+            assert output in exc.message
+
+
+def test_ensure_key_modules_success(venv):
+    modules = [uuid.uuid1().hex, uuid.uuid1().hex, uuid.uuid1().hex]
+    output = uuid.uuid1().hex
+    with mock.patch.object(
+        mu.wheels, "mode_packages", modules
+    ), mock.patch.object(VE, "run_subprocess", return_value=(True, output)):
+        venv.ensure_key_modules()
 
 
 #

--- a/tests/virtual_environment/test_virtual_environment.py
+++ b/tests/virtual_environment/test_virtual_environment.py
@@ -167,6 +167,18 @@ def test_create_virtual_environment_on_disk(venv_dirpath, test_wheels):
     assert venv._directory_is_venv()
 
     #
+    # Check that we can still detect a venv when there's no .cfg file
+    # (Then replace the .cfg for later use by the venv!)
+    #
+    cfg_filepath = os.path.join(venv.path, "pyvenv.cfg")
+    if os.path.isfile(cfg_filepath):
+        renamed_filepath = cfg_filepath + ".xyz"
+        os.rename(cfg_filepath, renamed_filepath)
+        assert venv._directory_is_venv()
+        os.rename(renamed_filepath, cfg_filepath)
+
+
+    #
     # Check that we have an installed version of pip
     #
     expected_pip_filepath = os.path.join(venv_site_packages, "pip")

--- a/tests/virtual_environment/test_virtual_environment.py
+++ b/tests/virtual_environment/test_virtual_environment.py
@@ -211,7 +211,8 @@ def test_create_virtual_environment_on_disk(venv_dirpath, test_wheels):
     #
     # Issue #1372 -- venv creation fails for paths with a space
     #
-    venv.ensure_interpreter_version()
+    with mock.patch.object(VE, "ensure_key_modules"):
+        venv.ensure()
 
 
 def test_create_virtual_environment_path(patched, venv_dirpath):
@@ -442,33 +443,6 @@ def test_venv_ensure_and_create_splash_handler(venv):
     args, _ = all_args
     (handler,) = args
     assert isinstance(handler, mu.virtual_environment.SplashLogHandler)
-
-
-#
-# Overall Ensure
-#
-def test_ensure(venv):
-    """Check that the ensure method calls all the necessary ensure components
-
-    This is necessarily a bit of an artificial test, but does at least give us
-    test coverage
-    """
-    with mock.patch.object(VE, "ensure_path") as m1, mock.patch.object(
-        VE, "ensure_interpreter"
-    ) as m2, mock.patch.object(
-        VE, "ensure_interpreter_version"
-    ) as m3, mock.patch.object(
-        VE, "ensure_pip"
-    ) as m4, mock.patch.object(
-        VE, "ensure_key_modules"
-    ) as m5:
-        venv.ensure()
-
-    m1.assert_called_with()
-    m2.assert_called_with()
-    m3.assert_called_with()
-    m4.assert_called_with()
-    m5.assert_called_with()
 
 
 #

--- a/tests/virtual_environment/test_virtual_environment.py
+++ b/tests/virtual_environment/test_virtual_environment.py
@@ -320,21 +320,41 @@ def test_jupyter_kernel_installed(patched, venv):
             assert expected_jupyter_args == args[: len(expected_jupyter_args)]
 
 
+def test_jupyter_kernel_failure(patched, venv):
+    """Ensure when the Jupyter kernel fails to install we raise an exception and
+    include the output"""
+    output = uuid.uuid1().hex
+    with mock.patch.object(
+        venv, "run_subprocess", return_value=(False, output)
+    ):
+        try:
+            venv.install_jupyter_kernel()
+        except VEError as exc:
+            assert "nable to install kernel" in exc.message
+            assert output in exc.message
+
+
 def test_upgrade_pip_failure(venv):
     """Ensure that we raise an error with output when pip can't be upgraded"""
     output = uuid.uuid1().hex
-    with mock.patch.object(venv, "run_subprocess", return_value=(True, output)):
+    with mock.patch.object(
+        venv, "run_subprocess", return_value=(True, output)
+    ):
         venv.upgrade_pip()
+
 
 def test_upgrade_pip_success(venv):
     """Ensure that we raise an error with output when pip can't be upgraded"""
     output = uuid.uuid1().hex
-    with mock.patch.object(venv, "run_subprocess", return_value=(False, output)):
+    with mock.patch.object(
+        venv, "run_subprocess", return_value=(False, output)
+    ):
         try:
             venv.upgrade_pip()
         except VEError as exc:
             assert "nable to upgrade pip" in exc.message
             assert output in exc.message
+
 
 def test_install_user_packages(patched, venv):
     """Ensure that, given a list of packages, we pip install them

--- a/tests/virtual_environment/test_virtual_environment.py
+++ b/tests/virtual_environment/test_virtual_environment.py
@@ -230,6 +230,21 @@ def test_create_virtual_environment_name_obj(patched, venv_dirpath):
     assert venv.name == os.path.basename(venv_dirpath)
 
 
+def test_create_virtual_environment_failure(venv):
+    output = uuid.uuid1().hex
+    with mock.patch.object(
+        venv, "run_subprocess", return_value=(False, output)
+    ):
+        try:
+            venv.create()
+        except Exception as exc:
+            assert isinstance(
+                exc, mu.virtual_environment.VirtualEnvironmentCreateError
+            )
+            assert "nable to create" in exc.message
+            assert output in exc.message
+
+
 def test_download_wheels_if_not_present(venv, test_wheels):
     """If we try to install baseline package without any wheels
     ensure we try to download them

--- a/tests/virtual_environment/test_virtual_environment.py
+++ b/tests/virtual_environment/test_virtual_environment.py
@@ -141,6 +141,7 @@ def test_splash_log_handler():
 def test_virtual_environment_str_contains_path(venv):
     assert venv.path in str(venv)
 
+
 def test_create_virtual_environment_on_disk(venv_dirpath, test_wheels):
     """Ensure that we're actually creating a working virtual environment
     on the disk with wheels installed
@@ -176,7 +177,6 @@ def test_create_virtual_environment_on_disk(venv_dirpath, test_wheels):
         os.rename(cfg_filepath, renamed_filepath)
         assert venv._directory_is_venv()
         os.rename(renamed_filepath, cfg_filepath)
-
 
     #
     # Check that we have an installed version of pip
@@ -422,6 +422,26 @@ def test_venv_fails_after_three_tries(venv):
     ):
         with pytest.raises(VEError):
             venv.ensure_and_create()
+
+
+def test_venv_ensure_and_create_splash_handler(venv):
+    """Ensure the splash handler is set up when calling ensure_and_create"""
+    with mock.patch.object(VE, "create"), mock.patch.object(
+        VE, "ensure"
+    ), mock.patch.object(mu.virtual_environment, "logger") as mock_logger:
+        venv.ensure_and_create(object)
+
+    all_args = mock_logger.addHandler.call_args
+    assert all_args is not None, "logger.addHandler not called at all"
+    args, _ = all_args
+    (handler,) = args
+    assert isinstance(handler, mu.virtual_environment.SplashLogHandler)
+
+    all_args = mock_logger.removeHandler.call_args
+    assert all_args is not None, "logger.removeHandler not called at all"
+    args, _ = all_args
+    (handler,) = args
+    assert isinstance(handler, mu.virtual_environment.SplashLogHandler)
 
 
 #


### PR DESCRIPTION
I realised that #1530 was sprawling somewhat so I've started to pull it apart to a series of more focused PRs. This is the first, which attempts to improve the logging from subprocesses created by the `virtual_environment` module and its objects.

I've also filled many of the gaps in the test coverage for this module -- the ones which remain are all to do with Qt slots, and I haven't yet decided on the best way to approach those.

The only change I've made outside the virtual_environment module and its tests, is to centrally limit the output to 1800 chars which will form part of the crash handler URL. I was having to do that anyway in several places and it made sense to put it at the final point where it's needed.

Although we usually debug-log the full output from subprocesses, I've added the slightly compact version into a number of exception messages so we should see it much sooner via a crash report than having to wait until logs arrive. (Or guess, when they don't).