### PR TITLE
Don't show crash reporter for KeyboardInterrupts

### DIFF
--- a/mu/app.py
+++ b/mu/app.py
@@ -77,9 +77,7 @@ class AnimatedSplash(QSplashScreen):
         self.animation = animation
         self.animation.frameChanged.connect(self.set_frame)
         # Always on top.
-        super().__init__(
-            self.animation.currentPixmap(), Qt.WindowStaysOnTopHint
-        )
+        super().__init__(self.animation.currentPixmap(), Qt.WindowStaysOnTopHint)
         # Disable clicks.
         self.setEnabled(False)
         self.animation.start()
@@ -208,8 +206,7 @@ def setup_logging():
 
     # set logging format
     log_fmt = (
-        "%(asctime)s - %(name)s:%(lineno)d(%(funcName)s) "
-        "%(levelname)s: %(message)s"
+        "%(asctime)s - %(name)s:%(lineno)d(%(funcName)s) " "%(levelname)s: %(message)s"
     )
     formatter = logging.Formatter(log_fmt)
 

--- a/mu/app.py
+++ b/mu/app.py
@@ -170,30 +170,33 @@ def excepthook(*exc_args):
     """
     Log exception and exit cleanly.
     """
-    logging.error("Unrecoverable error", exc_info=(exc_args))
-    try:
-        log_file = base64.standard_b64encode(LOG_FILE.encode("utf-8"))
-        error = base64.standard_b64encode(
-            "".join(traceback.format_exception(*exc_args)).encode("utf-8")
-        )[-1800:]
-        p = platform.uname()
-        params = {
-            "v": __version__,  # version
-            "l": str(i18n.language_code),  # locale
-            "p": base64.standard_b64encode(
-                " ".join([p.system, p.release, p.version, p.machine]).encode(
-                    "utf-8"
-                )
-            ),  # platform
-            "f": log_file,  # location of log file
-            "e": error,  # error message
-        }
-        args = urllib.parse.urlencode(params)
-        webbrowser.open("https://codewith.mu/crash/?" + args)
-    except Exception as e:  # The Alamo of crash handling.
-        logging.error("Failed to report crash", exc_info=e)
-    sys.__excepthook__(*exc_args)
-    sys.exit(1)
+    if exc_args[0] != KeyboardInterrupt:
+        logging.error("Unrecoverable error", exc_info=(exc_args))
+        try:
+            log_file = base64.standard_b64encode(LOG_FILE.encode("utf-8"))
+            error = base64.standard_b64encode(
+                "".join(traceback.format_exception(*exc_args)).encode("utf-8")
+            )[-1800:]
+            p = platform.uname()
+            params = {
+                "v": __version__,  # version
+                "l": str(i18n.language_code),  # locale
+                "p": base64.standard_b64encode(
+                    " ".join([p.system, p.release, p.version, p.machine]).encode(
+                        "utf-8"
+                    )
+                ),  # platform
+                "f": log_file,  # location of log file
+                "e": error,  # error message
+            }
+            args = urllib.parse.urlencode(params)
+            webbrowser.open("https://codewith.mu/crash/?" + args)
+        except Exception as e:  # The Alamo of crash handling.
+            logging.error("Failed to report crash", exc_info=e)
+        sys.__excepthook__(*exc_args)
+        sys.exit(1)
+    else:  # It's harmless, don't sound the alarm.
+        sys.exit(0)
 
 
 def setup_logging():

--- a/mu/app.py
+++ b/mu/app.py
@@ -77,7 +77,9 @@ class AnimatedSplash(QSplashScreen):
         self.animation = animation
         self.animation.frameChanged.connect(self.set_frame)
         # Always on top.
-        super().__init__(self.animation.currentPixmap(), Qt.WindowStaysOnTopHint)
+        super().__init__(
+            self.animation.currentPixmap(), Qt.WindowStaysOnTopHint
+        )
         # Disable clicks.
         self.setEnabled(False)
         self.animation.start()
@@ -168,8 +170,8 @@ def excepthook(*exc_args):
     """
     Log exception and exit cleanly.
     """
+    logging.error("Unrecoverable error", exc_info=(exc_args))
     if exc_args[0] != KeyboardInterrupt:
-        logging.error("Unrecoverable error", exc_info=(exc_args))
         try:
             log_file = base64.standard_b64encode(LOG_FILE.encode("utf-8"))
             error = base64.standard_b64encode(
@@ -180,9 +182,9 @@ def excepthook(*exc_args):
                 "v": __version__,  # version
                 "l": str(i18n.language_code),  # locale
                 "p": base64.standard_b64encode(
-                    " ".join([p.system, p.release, p.version, p.machine]).encode(
-                        "utf-8"
-                    )
+                    " ".join(
+                        [p.system, p.release, p.version, p.machine]
+                    ).encode("utf-8")
                 ),  # platform
                 "f": log_file,  # location of log file
                 "e": error,  # error message
@@ -206,7 +208,8 @@ def setup_logging():
 
     # set logging format
     log_fmt = (
-        "%(asctime)s - %(name)s:%(lineno)d(%(funcName)s) " "%(levelname)s: %(message)s"
+        "%(asctime)s - %(name)s:%(lineno)d(%(funcName)s) "
+        "%(levelname)s: %(message)s"
     )
     formatter = logging.Formatter(log_fmt)
 

--- a/mu/virtual_environment.py
+++ b/mu/virtual_environment.py
@@ -18,6 +18,7 @@ from PyQt5.QtCore import (
 from . import wheels
 from . import settings
 from . import config
+from . import __version__ as mu_version
 
 wheels_dirpath = os.path.dirname(wheels.__file__)
 
@@ -173,11 +174,8 @@ class Process(QObject):
         return output
 
     def data(self):
-        return (
-            self.process.readAll()
-            .data()
-            .decode(sys.stdout.encoding, errors="replace")
-        )
+        output = self.process.readAll().data()
+        return output.decode(sys.stdout.encoding, errors="replace")
 
     def _started(self):
         self.started.emit()
@@ -203,7 +201,7 @@ class Pip(object):
         self.process = Process()
 
     def run(
-        self, command, *args, wait_for_s=30.0, slots=Process.Slots(), **kwargs
+        self, command, *args, wait_for_s=120.0, slots=Process.Slots(), **kwargs
     ):
         """
         Run a command with args, treating kwargs as Posix switches.
@@ -410,6 +408,7 @@ class VirtualEnvironment(object):
 
         Return True if the process succeeded, False otherwise
         """
+        logger.info("Running %s with kwargs %s", args, kwargs)
         process = subprocess.run(
             list(args),
             stdout=subprocess.PIPE,
@@ -441,6 +440,7 @@ class VirtualEnvironment(object):
         the Python and Pip binaries, but doesn't access the file system. That's
         done by code in or called from `create`
         """
+        logger.debug("Relocating to %s", dirpath)
         self.path = str(dirpath)
         self.name = os.path.basename(self.path)
         self._bin_directory = os.path.join(
@@ -505,8 +505,8 @@ class VirtualEnvironment(object):
 
         return False
 
-    def quarantine_failed_venv(self):
-        error_dirpath = self.path + ".FAILED"
+    def quarantine_venv(self, reason="FAILED"):
+        error_dirpath = self.path + "." + reason
         try:
             os.rename(self.path, error_dirpath)
         except OSError:
@@ -515,6 +515,38 @@ class VirtualEnvironment(object):
             )
         else:
             logger.info("Quarantined %s as %s", self.path, error_dirpath)
+
+    def recreate(self):
+        """Recreate this virtual environment with updated baseline packages and the
+        same user packages
+
+        The intended use is when the Mu version changes as this can bring with it
+        additional and/or updated packages. The simplest thing to do is to switch
+        to a new venv and then pull in the packages the user had additionally installed
+        """
+        #
+        # Keep track of the user packages installed into the current venv
+        #
+        _, user_packages = self.installed_packages()
+
+        #
+        # Now, quarantine the current venv with
+        # a marker to say it's been superseded
+        #
+        self.quarantine_venv(reason="SUPERSEDED")
+
+        #
+        # Create a new venv which will then become the current one.
+        # Install the (possibly updated) baseline packages
+        #
+        self.relocate(self._generate_dirpath())
+        self.create()
+
+        #
+        # Now reinstall the original user packages
+        #
+        logger.debug("About to reinstall user packages: %s", user_packages)
+        self.install_user_packages(user_packages)
 
     def ensure_and_create(self, emitter=None):
         """Check whether we have a valid virtual environment in place and, if not,
@@ -539,15 +571,53 @@ class VirtualEnvironment(object):
         while True:
             logger.debug("Checking virtual environment; attempt #%d.", n)
             try:
+                #
+                # try_to_create will be True if this is a brand new install
+                # or if we've failed to ensure at least once
+                #
                 if try_to_create:
                     self.create()
+                    try_to_create = False
+
+                #
+                # Otherwise check whether the venv settings match the version of Mu
+                # If not, recreate the venv with updated baseline packages and
+                # the existing user packages
+                #
+                else:
+                    venv_mu_version = self.settings.get(
+                        "mu_version", "-no-version-"
+                    )
+                    if venv_mu_version != mu_version:
+                        logger.warning(
+                            "Venv created by Mu version %s; Current Mu is version %s",
+                            venv_mu_version,
+                            mu_version,
+                        )
+                        self.recreate()
+
+                #
+                # In any situation (initial creation, recreation after Mu update,
+                # regular run) ensure that the venv is still valid
+                #
                 self.ensure()
                 logger.info("Valid virtual environment found at %s", self.path)
+
+                #
+                # If we reach this point, ensure hasn't raised an exception and
+                # we're good to save settings and move on
+                #
                 self.settings.save()
                 break
 
-            except VirtualEnvironmentError:
-                self.quarantine_failed_venv()
+            except VirtualEnvironmentError as exc:
+                #
+                # If any of the ensure/create steps cause a VirtualEnvironmentError
+                # retry up to a maximum number in case we've just been unlucky
+                # with network, file contention etc.
+                #
+                logger.error(exc.message)
+                self.quarantine_venv()
                 if n < n_tries:
                     self.relocate(self._generate_dirpath())
                     try_to_create = True
@@ -565,6 +635,10 @@ class VirtualEnvironment(object):
     def ensure(self):
         """
         Ensure that virtual environment exists and is in a good state.
+
+        If any of these fails, they should raise a (subclass of)
+        VirtualEnvironmentError which will bubble up to `ensure_and_create` and be
+        caught and acted on appropriately
         """
         self.ensure_path()
         self.ensure_interpreter()
@@ -671,10 +745,10 @@ class VirtualEnvironment(object):
         before re-raising the error.
         """
         self.create_venv()
-        self.upgrade_pip()
         self.install_baseline_packages()
         self.register_baseline_packages()
         self.install_jupyter_kernel()
+        self.settings["mu_version"] = mu_version
 
     def create_venv(self):
         """

--- a/tests/virtual_environment/test_process.py
+++ b/tests/virtual_environment/test_process.py
@@ -3,6 +3,7 @@
 Tests for the QProcess-based Process class
 """
 import sys
+import platform
 from unittest import mock
 import uuid
 
@@ -11,6 +12,10 @@ import pytest
 from PyQt5.QtCore import QTimer, QProcess
 
 from mu import virtual_environment
+
+is_arm = platform.machine().startswith("arm") or platform.machine().startswith(
+    "aarch"
+)
 
 
 def test_creation_environment():
@@ -43,6 +48,10 @@ def test_run_blocking():
     assert output == expected_output
 
 
+@pytest.mark.skipif(
+    is_arm,
+    reason="Unreliable on ARM probably because of slowness of test container",
+)
 def test_run_blocking_timeout():
     """Ensure that a process is run synchronously and times out"""
     p = virtual_environment.Process()
@@ -61,9 +70,9 @@ def test_run_blocking_timeout():
                 + expected_stdout
                 + "'); sys.stderr.write('"
                 + expected_stderr
-                + "'); time.sleep(2.0)",
+                + "'); time.sleep(1.0)",
             ],
-            wait_for_s=1.0,
+            wait_for_s=0.5,
         ).strip()
     except virtual_environment.VirtualEnvironmentError as exc:
         assert expected_stdout in exc.message
@@ -132,3 +141,21 @@ def test_wait_shows_failure():
         p.run(None, None)
         with pytest.raises(virtual_environment.VirtualEnvironmentError):
             p.wait()
+
+
+#
+# There are two places we return the outputs from subprocesses
+# decoded to utf-8 with errors replaced by the unicode "unknown" character:
+# The result of Process.wait (which can be invoked via .run_blocking); and
+# the result of VirtualEnvironment.run_subprocess
+#
+def test_run_blocking_invalid_utf8():
+    """Ensure that if the output of a QProcess run is not valid UTF-8 we
+    carry on as best we can"""
+    corrupted_utf8 = b"\xc2\x00\xa3"
+    expected_output = "\ufffd\x00\ufffd"
+    with mock.patch.object(QProcess, "readAll") as mocked_readAll:
+        mocked_readAll.return_value.data.return_value = corrupted_utf8
+        p = virtual_environment.Process()
+        output = p.run_blocking(sys.executable, ["-c", "print()"])
+    assert output == expected_output


### PR DESCRIPTION
Close #1547 by not showing the crash reporter on a KeyboardInterrupt (`^C`) and exiting 0.