### PR TITLE
Only enable on-screen logging if the MU_LOG_TO_STDOUT env variable is set

### DIFF
--- a/mu/app.py
+++ b/mu/app.py
@@ -220,16 +220,18 @@ def setup_logging():
     handler.setFormatter(formatter)
     handler.setLevel(logging.DEBUG)
 
-    stdout_handler = logging.StreamHandler()
-    stdout_handler.setFormatter(formatter)
-    stdout_handler.setLevel(logging.DEBUG)
-
     # set up primary log
     log = logging.getLogger()
     log.setLevel(logging.DEBUG)
     log.addHandler(handler)
-    log.addHandler(stdout_handler)
     sys.excepthook = excepthook
+
+    # Only enable on-screen logging if the MU_LOG_TO_STDOUT env variable is set
+    if "MU_LOG_TO_STDOUT" in os.environ:
+        stdout_handler = logging.StreamHandler()
+        stdout_handler.setFormatter(formatter)
+        stdout_handler.setLevel(logging.DEBUG)
+        log.addHandler(stdout_handler)
 
 
 def setup_modes(editor, view):


### PR DESCRIPTION
@tjguk this was originally added to https://github.com/mu-editor/mu/pull/1530/, but was not present in https://github.com/mu-editor/mu/pull/1622 or https://github.com/mu-editor/mu/pull/1624. I assume it was accidentally left out?

Feel free to close, reimplement, or add a comments if this needed a different implementation, thanks!

Fixes https://github.com/mu-editor/mu/issues/1508.