### PR TITLE
Update deprecated `logging.warn()` to `warning()`.

### DIFF
--- a/mu/modes/base.py
+++ b/mu/modes/base.py
@@ -65,7 +65,7 @@ def get_default_workspace():
             )
             workspace_dir = settings_workspace
         else:
-            logger.warn(
+            logger.warning(
                 "Workspace {} in the settings file is not a valid "
                 "directory; using default {}".format(
                     settings_workspace, workspace_dir

--- a/mu/settings.py
+++ b/mu/settings.py
@@ -155,7 +155,7 @@ class SettingsBase(object):
         # If this settings file is tagged readonly don't try to save it
         #
         if self.readonly:
-            logger.warn("Settings is readonly; won't save")
+            logger.warning("Settings is readonly; won't save")
             return
 
         #
@@ -163,7 +163,7 @@ class SettingsBase(object):
         #
         saving_to_filepath = getattr(self, "filepath", None)
         if not saving_to_filepath:
-            logger.warn("No filepath set; won't save")
+            logger.warning("No filepath set; won't save")
             return
 
         logger.debug("Saving to %s", saving_to_filepath)
@@ -217,7 +217,7 @@ class SettingsBase(object):
                     serialised_settings = {}
                 self.update(serialised_settings)
         except FileNotFoundError:
-            logger.warn("No settings file found at %s; skipping", filepath)
+            logger.warning("No settings file found at %s; skipping", filepath)
         except OSError:
             logger.exception("Unable to read file at %s; skipping", filepath)
 

--- a/mu/virtual_environment.py
+++ b/mu/virtual_environment.py
@@ -850,7 +850,7 @@ class VirtualEnvironment(object):
         #
         wheel_filepaths = glob.glob(os.path.join(wheels_dirpath, "*.whl"))
         if not wheel_filepaths:
-            logger.warn(
+            logger.warning(
                 "No wheels found in %s; downloading...", wheels_dirpath
             )
             try:

--- a/tests/modes/test_base.py
+++ b/tests/modes/test_base.py
@@ -96,7 +96,7 @@ def test_base_mode_workspace_invalid_value():
         view = mock.MagicMock()
         bm = BaseMode(editor, view)
         assert bm.workspace_dir() == default_workspace
-        assert logger.warn.call_count == 1
+        assert logger.warning.call_count == 1
 
 
 def test_base_mode_workspace_invalid_json(tmp_path):

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -222,7 +222,7 @@ def test_save_readonly(mocked_logger):
     settings.readonly = True
 
     settings.save()
-    assert mocked_logger.warn.called
+    assert mocked_logger.warning.called
     assert not settings.as_string.called
 
 
@@ -234,7 +234,7 @@ def test_save_no_filepath(mocked_logger):
     settings.filepath = None  # (just in case)
 
     settings.save()
-    assert mocked_logger.warn.called
+    assert mocked_logger.warning.called
     assert not settings.as_string.called
 
 
@@ -285,7 +285,7 @@ def test_load_file_not_found(mocked_logger):
     settings = mu.settings.SettingsBase()
     settings.load(filepath)
 
-    assert mocked_logger.warn.called
+    assert mocked_logger.warning.called
     assert settings.filepath == filepath
 
 


### PR DESCRIPTION
`logging.warn()` is deprecated, so this is just a simple PR to update all instances to the equivalent `warning()`  version: https://docs.python.org/3.9/library/logging.html#logging.warning