### PR TITLE
Set ipykernel version to be < 6.0 for macOS 10.13 compatibility

### DIFF
--- a/mu/wheels/__init__.py
+++ b/mu/wheels/__init__.py
@@ -40,6 +40,10 @@ ZIP_FILEPATH = os.path.join(WHEELS_DIRPATH, mu_version + ".zip")
 mode_packages = [
     ("pgzero", "pgzero>=1.2.1"),
     ("flask", "flask==1.1.2"),
+    # FIXME: ipykernel max ver added for macOS 10.13 compatibility, min taken
+    # from qtconsole 4.7.7. Full line can be removed after Mu v1.1 release.
+    # Dependency mirrored in setup.py install_requires.
+    ("ipykernel", "ipykernel>=4.1,<6"),
     ("qtconsole", "qtconsole==4.7.4"),
     ("esptool", "esptool==3.*"),
 ]

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,10 @@ install_requires = [
     # FIXME: jupyter-client added for Py3.5 compatibility, to be dropped after
     # Mu v1.1 release. So, qtconsole < 5 and jupyter-client < 6.2 (issue #1444)
     "jupyter-client>=4.1,<6.2",
+    # FIXME: ipykernel max added for macOS 10.13 compatibility, min taken from
+    # qtconsole 4.7.7. Full line can be removed after Mu v1.1 release.
+    # Dependency mirrored for user venv in mu/wheels/__init__.py
+    "ipykernel>=4.1,<6",
     "qtconsole==4.7.7",
     #
     # adafruit-board-toolkit is used to find serial ports and help identify


### PR DESCRIPTION
This is a `qtconsole` dependency, as `qtconsole` only declares the min version, Mu gets the latest available during packaging, downloading v6 released less than a week ago.
`ipykernel` v6 adds `debugpy` as a dependency, which is not compatible with macOS 10.13 High Sierra.
This dependency is only needed for the debugging feature added to iPython in v6, so it's fine go back and use an older version.

As the iPython dependencies are also installed in the user venv  we have to add the same to `mu/wheels/__init__.py`.

After the Mu v1.1 release we'll have to update PyQt5 to a newer version that will drop support for macOS 10.13, so at that point we can unpin `ipykernel`.

Fixes https://github.com/mu-editor/mu/issues/1683.