### PR TITLE
Remove qtconsole from user venv and permanently leave ipykernel.

### DIFF
--- a/mu/wheels/__init__.py
+++ b/mu/wheels/__init__.py
@@ -40,11 +40,11 @@ ZIP_FILEPATH = os.path.join(WHEELS_DIRPATH, mu_version + ".zip")
 mode_packages = [
     ("pgzero", "pgzero>=1.2.1"),
     ("flask", "flask==1.1.2"),
+    # The version of ipykernel here should match to the version used by
+    # qtconsole at the version specified in setup.py
     # FIXME: ipykernel max ver added for macOS 10.13 compatibility, min taken
-    # from qtconsole 4.7.7. Full line can be removed after Mu v1.1 release.
-    # Dependency mirrored in setup.py install_requires.
+    # from qtconsole 4.7.7. This is mirrored in setup.py
     ("ipykernel", "ipykernel>=4.1,<6"),
-    ("qtconsole", "qtconsole==4.7.4"),
     ("esptool", "esptool==3.*"),
 ]
 


### PR DESCRIPTION
This is basically PR https://github.com/mu-editor/mu/pull/1686 take II.

The reasoning is summaried here: https://github.com/mu-editor/mu/issues/1683#issuecomment-876769555

This PR would be the option 3: 
>In mu/wheels/__init__.py we could install only ipykerner instead of qtconsole

The only reason we install `qtconsole` in the user venv is to match the version of `ipykernel` installed in Mu via `qtconsole`.

By only installing `ipykernel` we have more control about what version to use, fixing https://github.com/mu-editor/mu/issues/1683, and it al also reduces the packaging size as we remove unnecessary wheels zipped up and installed.