### PR TITLE
Web mode checks existence of templates directory before starting local server

### DIFF
--- a/mu/modes/web.py
+++ b/mu/modes/web.py
@@ -167,6 +167,23 @@ class WebMode(BaseMode):
             # If needed, save the script.
             if tab.isModified():
                 self.editor.save_tab_to_file(tab)
+            # Check for template files.
+            template_path = os.path.join(
+                os.path.dirname(os.path.abspath(tab.path)), "templates"
+            )
+            if not os.path.isdir(template_path):
+                # Oops... show a helpful message and stop.
+                msg = _("Cannot find template directory!")
+                info = _(
+                    "To serve your web application, there needs to be a "
+                    "'templates' directory in the same place as your web "
+                    "application's Python code. Please fix this and try "
+                    "again. (Hint: Mu was expecting the `templates` directory "
+                    "to be here: " + template_path + ")"
+                )
+                self.view.show_message(msg, info)
+                self.stop_server()
+                return
             logger.debug(tab.text())
             envars = self.editor.envars
             envars.append(("FLASK_APP", os.path.basename(tab.path)))

--- a/tests/modes/test_web.py
+++ b/tests/modes/test_web.py
@@ -137,6 +137,23 @@ def test_start_server_not_python_file():
     assert view.add_python3_runner.call_count == 0
 
 
+def test_start_server_no_templates():
+    """
+    If the user attempts to start the server from a location without a
+    templates directory, then complain and abort.
+    """
+    editor = mock.MagicMock()
+    view = mock.MagicMock()
+    view.current_tab.path = "foo.py"
+    wm = WebMode(editor, view)
+    wm.stop_server = mock.MagicMock()
+    with mock.patch("os.path.isdir", return_value=False):
+        wm.start_server()
+    assert view.show_message.call_count == 1
+    wm.stop_server.assert_called_once_with()
+    assert view.add_python3_runner.call_count == 0
+
+
 def test_start_server():
     """
     The server is started and stored as the runner associated with the mode.
@@ -147,7 +164,8 @@ def test_start_server():
     view.current_tab.isModified.return_value = True
     wm = WebMode(editor, view)
     wm.stop_server = mock.MagicMock()
-    wm.start_server()
+    with mock.patch("os.path.isdir", return_value=True):
+        wm.start_server()
     assert view.add_python3_runner.call_count == 1
     view.add_python3_runner().process.waitForStarted.assert_called_once_with()
 


### PR DESCRIPTION
Fixes #890.

If there is no `templates` directory in the same location as the Python file containing the web app, then Flask will only ever respond with a non-beginner-friendly stack trace. This change checks for the `templates` directory in the expected location and displays a warning message with details of the problem so the user can try to fix it.