### PR TITLE
Minor change in formatting to work with all versions of Black.

### DIFF
--- a/tests/interface/test_main.py
+++ b/tests/interface/test_main.py
@@ -855,11 +855,7 @@ def test_Window_on_context_menu_with_repl():
     menu.insertAction = mock.MagicMock()
     menu.insertSeparator = mock.MagicMock()
     menu.exec_ = mock.MagicMock()
-    menu.actions = mock.MagicMock(
-        return_value=[
-            "foo",
-        ]
-    )
+    menu.actions = mock.MagicMock(return_value=["foo"])
     mock_tab.createStandardContextMenu = mock.MagicMock(return_value=menu)
     w.on_context_menu()
     assert mock_tab.createStandardContextMenu.call_count == 1
@@ -885,11 +881,7 @@ def test_Window_on_context_menu_with_process_runner():
     menu.insertAction = mock.MagicMock()
     menu.insertSeparator = mock.MagicMock()
     menu.exec_ = mock.MagicMock()
-    menu.actions = mock.MagicMock(
-        return_value=[
-            "foo",
-        ]
-    )
+    menu.actions = mock.MagicMock(return_value=["foo"])
     mock_tab.createStandardContextMenu = mock.MagicMock(return_value=menu)
     w.on_context_menu()
     assert mock_tab.createStandardContextMenu.call_count == 1


### PR DESCRIPTION
Black v19.10b0, the minimum supported by Mu, wants to reformat these lines.
Newer versions of black don't seem to care and leave these as they were.

It's not great to have tiny commits just to massage the formatter, but otherwise this fails the checks with Black v19.10b0.