### PR TITLE
Add utility script to fetch the GitHub releases download count

### DIFF
--- a/utils/gh_downloads.py
+++ b/utils/gh_downloads.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+"""
+Retrieves the GH releases stats from their open API and counts the total number
+of asset downloads, which so far are all Mu installers.
+"""
+import requests
+
+
+releases = requests.get(
+    "https://api.github.com/repos/mu-editor/mu/releases"
+).json()
+
+total_downloads = 0
+for release in releases:
+    date = release["published_at"].split("T")[0]
+    print("\nRelease {} ({}):".format(release["tag_name"], date))
+
+    if "assets" in release and len(release["assets"]):
+        for asset in release["assets"]:
+            total_downloads += asset["download_count"]
+            print(
+                "\tDownloads: {:6}".format(asset["download_count"]), end="\t"
+            )
+            print("Asset: {}".format(asset["name"]))
+    else:
+        print("\tNo assets on this release")
+
+print("\nTotal Mu Editor asset downloads: {}  🎉".format(total_downloads))


### PR DESCRIPTION
Feel free to reject the PR, it's just something I put together quickly that might be useful to other people.

It's basically a small vanity script to fetch the number of installer downloads from the GitHub API (no need to auth):

```
$ python utils/gh_downloads.py

Release 1.1.0-beta.5 (2021-07-05):
	Downloads:  14554	Asset: Mu-Editor-Win64-1.1.0b5.msi
	Downloads:   3317	Asset: MuEditor-1.1.0b5.dmg

Release 1.1.0-beta.4 (2021-04-18):
	Downloads:  42932	Asset: Mu-Editor-Win64-1.1.0b4.msi
	Downloads:   9030	Asset: Mu.Editor.1.1.0b4.dmg

Release 1.1.0-beta.3 (2021-03-29):
	Downloads:  12934	Asset: Mu-Editor-Win64-1.1.0b3.msi
	Downloads:   2736	Asset: Mu.Editor.1.1.0b3.dmg

Release 1.1.0-beta.2 (2021-03-15):
	Downloads:  10584	Asset: Mu-Editor-Win64-1.1.0b2.msi
	Downloads:   2313	Asset: Mu.Editor.1.1.0b2.dmg

Release 1.1.0-beta.1 (2021-01-31):
	No assets on this release

Release 1.0.3 (2020-01-26):
	Downloads:  52250	Asset: mu-editor.dmg
	Downloads:  41526	Asset: mu-editor_1.0.3_win32.exe
	Downloads: 167680	Asset: mu-editor_1.0.3_win64.exe

Release 1.1.0-alpha.2 (2019-07-05):
	Downloads:  28429	Asset: mu-editor_1.1.0-alpha.2_osx.dmg
	Downloads:  28290	Asset: mu-editor_1.1.0-alpha.2_win32.exe
	Downloads: 123862	Asset: mu-editor_1.1.0-alpha.2_win64.exe

Release 1.1.0-alpha.1 (2019-03-25):
	Downloads:   2289	Asset: mu-editor_1.1.0-alpha.1_osx.dmg
	Downloads:   3287	Asset: mu-editor_1.1.0-alpha.1_win32.exe
	Downloads:  14930	Asset: mu-editor_1.1.0-alpha.1_win64.exe

Release 1.0.2 (2019-01-15):
	Downloads:  33487	Asset: mu-editor_1.0.2_osx.dmg
	Downloads:  37583	Asset: mu-editor_1.0.2_win32.exe
	Downloads: 126263	Asset: mu-editor_1.0.2_win64.exe
	Downloads:   3456	Asset: portamu_1.0.2_osx.zip

Release 1.0.1 (2018-10-01):
	Downloads:   8480	Asset: mu-editor_1.0.1_osx.dmg
	Downloads:  10094	Asset: mu-editor_1.0.1_win32.exe
	Downloads:  28017	Asset: mu-editor_1.0.1_win64.exe
	Downloads:   1037	Asset: portamu_1.0.1_win32.zip
	Downloads:   2295	Asset: portamu_1.0.1_win64.zip

Release v1.0.0 (2018-07-20):
	Downloads:   6355	Asset: mu-editor_1.0_osx.dmg
	Downloads:   3643	Asset: mu-editor_1.0_win32.exe
	Downloads:  18180	Asset: mu-editor_1.0_win64.exe

Release v1.0.0.rc.1 (2018-07-16):
	Downloads:    233	Asset: mu-editor_rc1_osx.dmg
	Downloads:    106	Asset: mu-editor_rc1_win32.exe
	Downloads:    635	Asset: mu-editor_rc1_win64.exe

Release v1.0.0.beta.17 (2018-07-09):
	Downloads:    307	Asset: mu-editor_beta17_osx.dmg
	Downloads:    213	Asset: mu-editor_beta17_win32.exe
	Downloads:    916	Asset: mu-editor_beta17_win64.exe

Release v1.0.0.beta.16 (2018-06-20):
	Downloads:    761	Asset: mu-editor_beta16_osx.dmg
	Downloads:    425	Asset: mu-editor_beta16_win32.exe
	Downloads:   1928	Asset: mu-editor_beta16_win64.exe

Release v0.9.13 (2016-11-06):
	Downloads:   8500	Asset: mu-0.9.13.linux.bin
	Downloads:  14754	Asset: mu-0.9.13.osx.zip
	Downloads:  46242	Asset: mu-0.9.13.win.exe

Release v0.9.12 (2016-10-23):
	Downloads:    183	Asset: mu-0.9.12.linux.bin
	Downloads:    307	Asset: mu-0.9.12.osx.zip
	Downloads:    625	Asset: mu-0.9.12.win.exe

Total Mu Editor asset downloads: 915968  🎉
```