### PR TITLE
venv: Pass splash logger to wheels.download().

### DIFF
--- a/mu/virtual_environment.py
+++ b/mu/virtual_environment.py
@@ -875,7 +875,7 @@ class VirtualEnvironment(object):
         logger.info("Expecting zipped wheels at %s", zipped_wheels_filepath)
         if not os.path.exists(zipped_wheels_filepath):
             logger.warning("No zipped wheels found; downloading...")
-            wheels.download(zipped_wheels_filepath)
+            wheels.download(zipped_wheels_filepath, logger)
 
         self.install_from_zipped_wheels(zipped_wheels_filepath)
 


### PR DESCRIPTION
Fixes https://github.com/mu-editor/mu/issues/1687.

Before this change the "downloading wheels" step wasn't been updated in the splash screen, and because this can take a long time it looks like the splash screen is frozen:
![pre-screenshot](https://user-images.githubusercontent.com/4189262/124808296-a8605880-df56-11eb-93dd-4ec33a634522.png)

Turned out to be a simple update to pass the `virtual_environment` logger, which is registered in the splash screen, to the `wheels` function. Now each download step is displayed:
<img width="846" alt="post-screenshot" src="https://user-images.githubusercontent.com/4189262/128244455-2c21718e-5455-4713-9dd9-bc7b663c3fe3.png">
