### PR TITLE
Added logic to function under Crostini on ChromeOS and return correct CIRCUITPY path if it exists

### DIFF
--- a/mu/modes/circuitpython.py
+++ b/mu/modes/circuitpython.py
@@ -200,6 +200,12 @@ class CircuitPythonMode(MicroPythonMode):
                             repr(e), mount_command
                         )
                     )
+            if os.path.exists('/mnt/chromeos'):
+                # We're on ChromeOS
+                if os.path.exists('/mnt/chromeos/removable/CIRCUITPY/'):
+                    device_dir = '/mnt/chromeos/removable/CIRCUITPY/'
+                else:
+                    self.view.show_message('If your Circuit Python device is plugged in, you need to "Share with Linux" on the CIRCUITPY drive in the "Files" app then restart Mu.')
 
         elif os.name == "nt":
             # We're on Windows.

--- a/mu/modes/circuitpython.py
+++ b/mu/modes/circuitpython.py
@@ -205,9 +205,12 @@ class CircuitPythonMode(MicroPythonMode):
                 if os.path.exists("/mnt/chromeos/removable/CIRCUITPY/"):
                     device_dir = "/mnt/chromeos/removable/CIRCUITPY/"
                 else:
-                    self.view.show_message(
-                        'If your Circuit Python device is plugged in, you need to "Share with Linux" on the CIRCUITPY drive in the "Files" app then restart Mu.'
+                    m = _(
+                        "If your Circuit Python device is plugged in,"
+                        + ' you need to "Share with Linux" on the CIRCUITPY drive'
+                        + ' in the "Files" app then restart Mu.'
                     )
+                    self.view.show_message(m)
 
         elif os.name == "nt":
             # We're on Windows.

--- a/mu/modes/circuitpython.py
+++ b/mu/modes/circuitpython.py
@@ -200,12 +200,14 @@ class CircuitPythonMode(MicroPythonMode):
                             repr(e), mount_command
                         )
                     )
-            if os.path.exists('/mnt/chromeos'):
+            if os.path.exists("/mnt/chromeos"):
                 # We're on ChromeOS
-                if os.path.exists('/mnt/chromeos/removable/CIRCUITPY/'):
-                    device_dir = '/mnt/chromeos/removable/CIRCUITPY/'
+                if os.path.exists("/mnt/chromeos/removable/CIRCUITPY/"):
+                    device_dir = "/mnt/chromeos/removable/CIRCUITPY/"
                 else:
-                    self.view.show_message('If your Circuit Python device is plugged in, you need to "Share with Linux" on the CIRCUITPY drive in the "Files" app then restart Mu.')
+                    self.view.show_message(
+                        'If your Circuit Python device is plugged in, you need to "Share with Linux" on the CIRCUITPY drive in the "Files" app then restart Mu.'
+                    )
 
         elif os.name == "nt":
             # We're on Windows.

--- a/tests/modes/chromeos_devpath_exists.txt
+++ b/tests/modes/chromeos_devpath_exists.txt
@@ -1,0 +1,1 @@
+/mnt/chromeos/removable/CIRCUITPY

--- a/tests/modes/chromeos_devpath_missing.txt
+++ b/tests/modes/chromeos_devpath_missing.txt
@@ -1,0 +1,1 @@
+/mnt/chromeos/removable

--- a/tests/modes/test_circuitpython.py
+++ b/tests/modes/test_circuitpython.py
@@ -145,6 +145,7 @@ def test_workspace_dir_posix_missing():
                 mpm.return_value = "foo"
                 assert am.workspace_dir() == "foo"
 
+
 def test_workspace_dir_posix_chromeos_exists():
     """
     Simulate being on os.name == 'posix' and a check in /mnt/chromeos/removable returns
@@ -159,10 +160,12 @@ def test_workspace_dir_posix_chromeos_exists():
             with mock.patch(
                 "mu.modes.circuitpython.check_output", return_value=fixture
             ):
-                with mock.patch(
-                    "os.path.exists", return_value=True
-                ):
-                    assert am.workspace_dir() == "/mnt/chromeos/removable/CIRCUITPY/"
+                with mock.patch("os.path.exists", return_value=True):
+                    assert (
+                        am.workspace_dir()
+                        == "/mnt/chromeos/removable/CIRCUITPY/"
+                    )
+
 
 def test_workspace_dir_posix_chromeos_missing():
     """
@@ -172,16 +175,17 @@ def test_workspace_dir_posix_chromeos_missing():
     editor = mock.MagicMock()
     view = mock.MagicMock()
     am = CircuitPythonMode(editor, view)
-    with open("tests/modes/chromeos_devpath_missing.txt", "rb") as fixture_file:
+    with open(
+        "tests/modes/chromeos_devpath_missing.txt", "rb"
+    ) as fixture_file:
         fixture = fixture_file.read()
         with mock.patch("os.name", "posix"):
             with mock.patch(
                 "mu.modes.circuitpython.check_output", return_value=fixture
-            ):                 
-              with mock.patch(
-                    "os.path.exists", return_value=False
-                ):
-                    assert am.workspace_dir().endswith('mu_code')
+            ):
+                with mock.patch("os.path.exists", return_value=False):
+                    assert am.workspace_dir().endswith("mu_code")
+
 
 @pytest.fixture
 def windll():

--- a/tests/modes/test_circuitpython.py
+++ b/tests/modes/test_circuitpython.py
@@ -145,6 +145,43 @@ def test_workspace_dir_posix_missing():
                 mpm.return_value = "foo"
                 assert am.workspace_dir() == "foo"
 
+def test_workspace_dir_posix_chromeos_exists():
+    """
+    Simulate being on os.name == 'posix' and a check in /mnt/chromeos/removable returns
+    a record associated with a CIRCUITPY device.
+    """
+    editor = mock.MagicMock()
+    view = mock.MagicMock()
+    am = CircuitPythonMode(editor, view)
+    with open("tests/modes/chromeos_devpath_exists.txt", "rb") as fixture_file:
+        fixture = fixture_file.read()
+        with mock.patch("os.name", "posix"):
+            with mock.patch(
+                "mu.modes.circuitpython.check_output", return_value=fixture
+            ):
+                with mock.patch(
+                    "os.path.exists", return_value=True
+                ):
+                    assert am.workspace_dir() == "/mnt/chromeos/removable/CIRCUITPY/"
+
+def test_workspace_dir_posix_chromeos_missing():
+    """
+    Simulate being on os.name == 'posix' and a check in /mnt/chromeos/removable returns
+    no records associated with a CIRCUITPY device.
+    """
+    editor = mock.MagicMock()
+    view = mock.MagicMock()
+    am = CircuitPythonMode(editor, view)
+    with open("tests/modes/chromeos_devpath_missing.txt", "rb") as fixture_file:
+        fixture = fixture_file.read()
+        with mock.patch("os.name", "posix"):
+            with mock.patch(
+                "mu.modes.circuitpython.check_output", return_value=fixture
+            ):                 
+              with mock.patch(
+                    "os.path.exists", return_value=False
+                ):
+                    assert am.workspace_dir().endswith('mu_code')
 
 @pytest.fixture
 def windll():


### PR DESCRIPTION
Fixes #1758 

May add similar functionality for micro:bit since it uses a flash drive based deployment mechanism as well.