### PR TITLE
Ensure Mu always appears on the screen when calculating the window size and position.

### DIFF
--- a/mu/interface/main.py
+++ b/mu/interface/main.py
@@ -1083,12 +1083,21 @@ class Window(QMainWindow):
         Makes the editor 80% of the width*height of the screen and centres it
         when none of x, y, w and h is passed in; otherwise uses the passed in
         values to position and size the editor window.
+
+        If the X or Y value will be off the screen, these are reset to None
+        (thus stopping the window being drawn in a hard-to-reach place). See
+        issue #1613 for context.
         """
         screen_width, screen_height = self.screen_size()
         w = int(screen_width * 0.8) if w is None else w
         h = int(screen_height * 0.8) if h is None else h
         self.resize(w, h)
         size = self.geometry()
+        # Ensure the window isn't added off the screen.
+        if x and (x <= 0 or x > screen_width):
+            x = None
+        if y and (y <= 0 or y > screen_height):
+            y = None
         x = (screen_width - size.width()) / 2 if x is None else x
         y = (screen_height - size.height()) / 2 if y is None else y
         self.move(x, y)

--- a/tests/interface/test_main.py
+++ b/tests/interface/test_main.py
@@ -1716,6 +1716,31 @@ def test_Window_autosize_window():
     w.move.assert_called_once_with(x, y)
 
 
+def test_Window_autosize_window_off_screen():
+    """
+    Check the correct calculations take place and methods are called so the
+    window is resized and positioned correctly even if the passed in X/Y
+    coordinates would put the window OFF the screen. See issue #1613 for
+    context.
+    """
+    mock_qdw = _qdesktopwidget_mock(1024, 768)
+    w = mu.interface.main.Window()
+    w.resize = mock.MagicMock(return_value=None)
+    mock_size = mock.MagicMock()
+    mock_size.width = mock.MagicMock(return_value=819)
+    mock_size.height = mock.MagicMock(return_value=614)
+    w.geometry = mock.MagicMock(return_value=mock_size)
+    w.move = mock.MagicMock(return_value=None)
+    with mock.patch("mu.interface.main.QDesktopWidget", mock_qdw):
+        w.size_window(x=-20, y=9999)
+    mock_qdw.assert_called_once_with()
+    w.resize.assert_called_once_with(int(1024 * 0.8), int(768 * 0.8))
+    w.geometry.assert_called_once_with()
+    x = (1024 - 819) / 2
+    y = (768 - 614) / 2
+    w.move.assert_called_once_with(x, y)
+
+
 def test_Window_reset_annotations():
     """
     Ensure the current tab has its annotations reset.


### PR DESCRIPTION
Fixes #1613.

I have not been able to test this on PiOS (I don't have a Pi to hand). Can someone (@carlosperate?) who does, please check this works as I think it will. Thank you.