### PR TITLE
Remove the splash screen stay-on-top flag.

### DIFF
--- a/mu/app.py
+++ b/mu/app.py
@@ -77,9 +77,7 @@ class AnimatedSplash(QSplashScreen):
         self.animation = animation
         self.animation.frameChanged.connect(self.set_frame)
         # Always on top.
-        super().__init__(
-            self.animation.currentPixmap(), Qt.WindowStaysOnTopHint
-        )
+        super().__init__(self.animation.currentPixmap())
         # Disable clicks.
         self.setEnabled(False)
         self.animation.start()


### PR DESCRIPTION
On Windows and Linux the splash screen is centre and stays on top of every window no matter what.

This stops the users from essentially using their computer, and on long startups, like the first run where installs the venv, this can be really annoying.

Fixes https://github.com/mu-editor/mu/issues/1363