### PR TITLE
venv: Hide startup pop-up command prompts on Windows.

### DIFF
--- a/mu/virtual_environment.py
+++ b/mu/virtual_environment.py
@@ -717,6 +717,7 @@ class VirtualEnvironment(object):
             self.interpreter,
             "-c",
             'import sys; print("%s%s" % sys.version_info[:2])',
+            shell=True if self._is_windows else False,
         )
         if not ok:
             raise VirtualEnvironmentEnsureError(
@@ -740,7 +741,10 @@ class VirtualEnvironment(object):
         for module, *_ in wheels.mode_packages:
             logger.debug("Verifying import of: %s", module)
             ok, output = self.run_subprocess(
-                self.interpreter, "-c", "import %s" % module
+                self.interpreter,
+                "-c",
+                "import %s" % module,
+                shell=True if self._is_windows else False,
             )
             if not ok:
                 raise VirtualEnvironmentEnsureError(


### PR DESCRIPTION
On Windows, when Popen is configured with `shell=True` it uses the wShowWindow parameter, which by default is set to SW_HIDE: https://docs.python.org/3/library/subprocess.html#subprocess.STARTUPINFO.wShowWindow

This hides the command prompt windows that appear when an installable Mu start ups: https://github.com/mu-editor/mu/issues/1457

This setting can have some unintended side effects, so sharing for feedback first as a draft PR.