### PR TITLE
Allow a user to change manually change their locale via a new tab in the admin dialog.

### DIFF
--- a/mu/i18n.py
+++ b/mu/i18n.py
@@ -13,3 +13,12 @@ localedir = os.path.abspath(os.path.join(os.path.dirname(__file__), "locale"))
 gettext.translation(
     "mu", localedir=localedir, languages=[language_code], fallback=True
 ).install()
+
+
+def set_language(language_code, localedir=localedir):
+    """
+    Utility function to allow admin pane updates to change the locale.
+    """
+    gettext.translation(
+        "mu", localedir=localedir, languages=[language_code], fallback=True
+    ).install()

--- a/mu/interface/dialogs.py
+++ b/mu/interface/dialogs.py
@@ -263,7 +263,7 @@ class LocaleWidget(QWidget):
         label = QLabel(
             _(
                 "Please select the language for Mu's user interface from the "
-                "choices listed below. <strong>Restart MU for these changes "
+                "choices listed below. <strong>Restart Mu for these changes "
                 "to take effect.</strong>"
             )
         )

--- a/mu/interface/dialogs.py
+++ b/mu/interface/dialogs.py
@@ -230,6 +230,55 @@ class PackagesWidget(QWidget):
         widget_layout.addWidget(self.text_area)
 
 
+class LocaleWidget(QWidget):
+    """
+    Used for manually setting the locale (and thus the language) used by Mu.
+    """
+
+    LANGUAGES = {
+        _("Automatically detect"): "",
+        "English": "en",
+        "Deutsch": "de_DE",
+        "Español": "es",
+        "Français": "fr",
+        "日本語": "ja",
+        "Polskie": "pl",
+        "Português (Br)": "pt_BR",
+        "Português (Pt)": "pt_PT",
+        "Slovenský": "sk_SK",
+        "Svenska": "sv",
+        "tiếng Việt": "vi",
+        "中文": "zh_CN",
+    }
+
+    def setup(self, locale):
+        widget_layout = QVBoxLayout()
+        self.setLayout(widget_layout)
+        self.drop_down = QComboBox()
+        for k, v in self.LANGUAGES.items():
+            self.drop_down.addItem(k, v)
+        index = self.drop_down.findData(locale)
+        if index > -1:
+            self.drop_down.setCurrentIndex(index)
+        label = QLabel(
+            _(
+                "Please select the language for Mu's user interface from the "
+                "choices listed below. <strong>Restart MU for these changes "
+                "to take effect.</strong>"
+            )
+        )
+        label.setWordWrap(True)
+        widget_layout.addWidget(label)
+        widget_layout.addWidget(self.drop_down)
+        widget_layout.addStretch()
+
+    def get_locale(self):
+        """
+        Return the user-selected language code.
+        """
+        return self.LANGUAGES.get(self.drop_down.currentText(), "")
+
+
 class ESPFirmwareFlasherWidget(QWidget):
     """
     Used for configuring how to interact with the ESP:
@@ -491,6 +540,10 @@ class AdminDialog(QDialog):
             self.esp_widget = ESPFirmwareFlasherWidget(self)
             self.esp_widget.setup(mode, device_list)
             self.tabs.addTab(self.esp_widget, _("ESP Firmware flasher"))
+        # Configure local.
+        self.locale_widget = LocaleWidget(self)
+        self.locale_widget.setup(settings.get("locale"))
+        self.tabs.addTab(self.locale_widget, _("Select Language"))
         self.log_widget.log_text_area.setFocus()
 
     def settings(self):
@@ -509,6 +562,7 @@ class AdminDialog(QDialog):
             ] = self.microbit_widget.runtime_path.text()
         if self.package_widget:
             settings["packages"] = self.package_widget.text_area.toPlainText()
+        settings["locale"] = self.locale_widget.get_locale()
         return settings
 
 

--- a/mu/logic.py
+++ b/mu/logic.py
@@ -765,6 +765,7 @@ class Editor(QObject):
         self.envars = []  # See restore session and show_admin
         self.minify = False
         self.microbit_runtime = ""
+        self.user_locale = ""  # user defined language locale
         self.connected_devices = DeviceList(self.modes, parent=self)
         self.current_device = None
         self.find = ""
@@ -918,6 +919,11 @@ class Editor(QObject):
         if "venv_path" in old_session:
             venv.relocate(old_session["venv_path"])
             venv.ensure()
+
+        if "locale" in old_session:
+            self.user_locale = old_session["locale"].strip()
+            if self.user_locale:
+                i18n.set_language(self.user_locale)
 
         old_window = old_session.get("window", {})
         self._view.size_window(**old_window)
@@ -1382,6 +1388,7 @@ class Editor(QObject):
                 "w": self._view.width(),
                 "h": self._view.height(),
             },
+            "locale": self.user_locale,
         }
         save_session(session)
         logger.info("Quitting.\n\n")
@@ -1401,6 +1408,7 @@ class Editor(QObject):
             "envars": envars,
             "minify": self.minify,
             "microbit_runtime": self.microbit_runtime,
+            "locale": self.user_locale,
         }
         baseline_packages, user_packages = venv.installed_packages()
         packages = user_packages
@@ -1438,6 +1446,8 @@ class Editor(QObject):
                 ]
                 old_packages = [p.lower() for p in user_packages]
                 self.sync_package_state(old_packages, new_packages)
+            if "locale" in new_settings:
+                self.user_locale = new_settings["locale"]
         else:
             logger.info("No admin settings changed.")
 

--- a/tests/interface/test_dialogs.py
+++ b/tests/interface/test_dialogs.py
@@ -373,6 +373,7 @@ def test_AdminDialog_setup_python_mode():
     log = "this is the contents of a log file"
     settings = {
         "envars": "name=value",
+        "locale": "",
     }
     packages = "foo\nbar\nbaz\n"
     mock_window = QWidget()
@@ -399,6 +400,7 @@ def test_AdminDialog_setup_microbit_mode():
     settings = {
         "minify": True,
         "microbit_runtime": "/foo/bar",
+        "locale": "",
     }
     packages = "foo\nbar\nbaz\n"
     mock_window = QWidget()
@@ -420,7 +422,9 @@ def test_AdminDialog_setup():
     file and envars.
     """
     log = "this is the contents of a log file"
-    settings = {}
+    settings = {
+        "locale": "",
+    }
     packages = "foo\nbar\nbaz\n"
     mock_window = QWidget()
     mode = mock.MagicMock()

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -2206,12 +2206,14 @@ def test_show_admin():
         "envars": "name=value",
         "minify": True,
         "microbit_runtime": "/foo/bar",
+        "locale": "",
     }
     new_settings = {
         "envars": "name=value",
         "minify": True,
         "microbit_runtime": "/foo/bar",
         "packages": "baz\n",
+        "locale": "",
     }
     view.show_admin.return_value = new_settings
     with mock.patch.object(
@@ -2276,12 +2278,14 @@ def test_show_admin_missing_microbit_runtime():
         "envars": "name=value",
         "minify": True,
         "microbit_runtime": "/foo/bar",
+        "locale": "",
     }
     new_settings = {
         "envars": "name=value",
         "minify": True,
         "microbit_runtime": "/foo/bar",
         "packages": "baz\n",
+        "locale": "",
     }
     view.show_admin.return_value = new_settings
     mock_open = mock.mock_open()


### PR DESCRIPTION
This "spike" does exactly what it says on the tin. Once folks are happy with the approach I'll "solidify" the code with better and more specific test coverage.

It looks like this:

![mu_select_translate](https://user-images.githubusercontent.com/37602/132242813-0e3244cd-0520-4782-bf60-17a811bc254c.gif)

Feedback welcome.