### PR TITLE
.github: Switch test matrix from Ubuntu 16.04 to Ubuntu 18.04

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        os: [ubuntu-16.04, ubuntu-latest, macos-10.15, windows-2016, windows-latest]
+        os: [ubuntu-18.04, ubuntu-latest, macos-10.15, windows-2016, windows-latest]
         python-version: ['3.5', '3.6', '3.7', '3.8']
       fail-fast: false
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Github is deprecating Ubuntu 16.04 runners, which makes tests using
them fail. Switch to a later version.

Signed-off-by: Keith Packard <keithp@keithp.com>