### PR TITLE
Fix crash when user script encoding cookie is invalid.

### DIFF
--- a/mu/logic.py
+++ b/mu/logic.py
@@ -260,7 +260,17 @@ def sniff_encoding(filepath):
     else:
         match = ENCODING_COOKIE_RE.match(uline)
         if match:
-            return match.group(1)
+            cookie_codec = match.group(1)
+            try:
+                codecs.lookup(cookie_codec)
+            except LookupError:
+                logger.warning(
+                    "Encoding cookie has invalid codec name: {}".format(
+                        cookie_codec
+                    )
+                )
+            else:
+                return cookie_codec
 
     #
     # Fall back to the locale default
@@ -318,7 +328,7 @@ def read_and_decode(filepath):
             text = btext.decode(encoding)
             logger.info("Decoded with %s", encoding)
             break
-        except UnicodeDecodeError:
+        except (UnicodeDecodeError, LookupError):
             continue
     else:
         raise UnicodeDecodeError(encoding, btext, 0, 0, "Unable to decode")

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -370,13 +370,26 @@ def test_sniff_encoding_from_cookie():
         assert mu.logic.sniff_encoding("foo.py") == "latin-1"
 
 
-def test_sniff_encoding_from_bad_cookie():
+def test_sniff_encoding_from_bad_cookie_encoding():
     """
     If there's a cookie present but we can't even read it, then return None.
     """
     encoding_cookie = "# -*- coding: silly-你好 -*-".encode("utf-8")
     mock_locale = mock.MagicMock()
     mock_locale.getpreferredencoding.return_value = "ascii"
+    with mock.patch(
+        "mu.logic.open", mock.mock_open(read_data=encoding_cookie)
+    ), mock.patch("mu.logic.locale", mock_locale):
+        assert mu.logic.sniff_encoding("foo.py") is None
+
+
+def test_sniff_encoding_from_bad_cookie_name():
+    """
+    If there's a cookie present but we can't even read it, then return None.
+    """
+    encoding_cookie = "# -*- coding: invalid-codec -*-".encode("utf-8")
+    mock_locale = mock.MagicMock()
+    mock_locale.getpreferredencoding.return_value = "utf-8"
     with mock.patch(
         "mu.logic.open", mock.mock_open(read_data=encoding_cookie)
     ), mock.patch("mu.logic.locale", mock_locale):


### PR DESCRIPTION
If the user script has a encoding shebang/cookie (`#-*- coding: utf-8 -*-`) it will try to use that to decode the text. If the codec name is invalid Python throws a `LookupError` exception.

Fixes https://github.com/mu-editor/mu/issues/1813.