### PR TITLE
Avoid TypeErrors when moving windows to float positions

### DIFF
--- a/mu/interface/main.py
+++ b/mu/interface/main.py
@@ -1098,8 +1098,8 @@ class Window(QMainWindow):
             x = None
         if y and (y <= 0 or y > screen_height):
             y = None
-        x = (screen_width - size.width()) / 2 if x is None else x
-        y = (screen_height - size.height()) / 2 if y is None else y
+        x = (screen_width - size.width()) // 2 if x is None else x
+        y = (screen_height - size.height()) // 2 if y is None else y
         self.move(x, y)
 
     def reset_annotations(self):

--- a/tests/interface/test_main.py
+++ b/tests/interface/test_main.py
@@ -1711,8 +1711,8 @@ def test_Window_autosize_window():
     mock_qdw.assert_called_once_with()
     w.resize.assert_called_once_with(int(1024 * 0.8), int(768 * 0.8))
     w.geometry.assert_called_once_with()
-    x = (1024 - 819) / 2
-    y = (768 - 614) / 2
+    x = (1024 - 819) // 2
+    y = (768 - 614) // 2
     w.move.assert_called_once_with(x, y)
 
 


### PR DESCRIPTION
On Python 3.10+, we cannot use floats for int arguments:

TypeError: arguments did not match any overloaded call:
  move(self, QPoint): argument 1 has unexpected type 'float'
  move(self, int, int): argument 1 has unexpected type 'float'