### PR TITLE
Continuously scale button bar based on window width

### DIFF
--- a/mu/interface/main.py
+++ b/mu/interface/main.py
@@ -168,14 +168,9 @@ class ButtonBar(QToolBar):
         """
         Compact button bar for when window is very small.
         """
-        font_size = DEFAULT_FONT_SIZE
-        if width < 1124 and height > 600:
-            self.setIconSize(QSize(48, 48))
-        elif height < 600 and width < 940:
-            font_size = 10
-            self.setIconSize(QSize(32, 32))
-        else:
-            self.setIconSize(QSize(64, 64))
+        font_size = min(DEFAULT_FONT_SIZE, width // 80)
+        icon_size = min(64, width // 24)
+        self.setIconSize(QSize(icon_size, icon_size))
         stylesheet = "QWidget{font-size: " + str(font_size) + "px;}"
         self.setStyleSheet(stylesheet)
 

--- a/tests/interface/test_main.py
+++ b/tests/interface/test_main.py
@@ -102,16 +102,20 @@ def test_ButtonBar_set_responsive_mode():
         bb = mu.interface.main.ButtonBar(None)
         bb.setStyleSheet = mock.MagicMock()
         bb.set_responsive_mode(1124, 800)
-        mock_icon_size.assert_called_with(QSize(64, 64))
-        default_font = str(mu.interface.themes.DEFAULT_FONT_SIZE)
-        style = "QWidget{font-size: " + default_font + "px;}"
+        mock_icon_size.assert_called_with(QSize(46, 46))
+        style = (
+            "QWidget{font-size: "
+            + str(mu.interface.themes.DEFAULT_FONT_SIZE)
+            + "px;}"
+        )
         bb.setStyleSheet.assert_called_with(style)
         bb.set_responsive_mode(939, 800)
-        mock_icon_size.assert_called_with(QSize(48, 48))
+        mock_icon_size.assert_called_with(QSize(39, 39))
+        style = "QWidget{font-size: " + str(11) + "px;}"
         bb.setStyleSheet.assert_called_with(style)
         bb.set_responsive_mode(939, 599)
-        mock_icon_size.assert_called_with(QSize(32, 32))
-        style = "QWidget{font-size: " + str(10) + "px;}"
+        mock_icon_size.assert_called_with(QSize(39, 39))
+        style = "QWidget{font-size: " + str(11) + "px;}"
         bb.setStyleSheet.assert_called_with(style)
 
 


### PR DESCRIPTION
Now that all of the icons are SVG based, make the icon and font sizes
a fraction of the window width so that the button bar always fits
nicely.

Signed-off-by: Keith Packard <keithp@keithp.com>