### PR TITLE
Preliminary Linux AppImage packaging.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,6 +120,20 @@ macos: check
 	ls -la ./build/pup/
 	ls -la ./dist/
 
+linux: check
+	@echo "\nFetching wheels."
+	python -m mu.wheels
+	@echo "\nPackaging Mu into a Linux AppImage."
+	python -m virtualenv venv-pup
+	# Don't activate venv-pup because:
+	# 1. Not really needed.
+	# 2. Previously active venv would be "gone" on venv-pup deactivation.
+	./venv-pup/bin/pip install pup
+	./venv-pup/bin/pup package --launch-module=mu --nice-name="Mu Editor" --icon-path=./mu/resources/images/icon.png --license-path=./LICENSE .
+	rm -r venv-pup
+	ls -la ./build/pup/
+	ls -la ./dist/
+
 video: clean
 	@echo "\nFetching contributor avatars."
 	python utils/avatar.py


### PR DESCRIPTION
As discussed:

* This updates the `Makefile` with a new `linux` target: brings in the latest `pup` and packages Mu as a Linux AppImage thing -- currently 3.8 x86_64 only!

Goes along with:

* PR #1863 that makes running Mu as an AppImage usable.
* The latest `pup` release 1.0.0a14.

Outstanding:

* Updating GitHub Actions to automate this somehow -- @carlosperate, can you assist, please?
