### PR TITLE
Avoid saving a file called ".py" when user cancels Save As. Fixes #1880

### DIFF
--- a/mu/interface/main.py
+++ b/mu/interface/main.py
@@ -435,7 +435,7 @@ class Window(QMainWindow):
         # Ensure there's a .py extension if none is provided by the user.
         # See issue #1571.
         name, ext = os.path.splitext(os.path.basename(path))
-        if (not name.startswith(".")) and (not ext):
+        if name and (not name.startswith(".")) and (not ext):
             # The file is not a . (dot) file and there's no extension, so add
             # .py as default.
             path += ".py"

--- a/tests/interface/test_main.py
+++ b/tests/interface/test_main.py
@@ -624,6 +624,20 @@ def test_Window_get_save_path_missing_extension():
     assert returned_path == path + ".py"  # Note addition of ".py" extension.
 
 
+def test_Window_get_save_path_empty_path():
+    """
+    Avoid appending a ".py" extension if the path is empty. See #1880.
+    """
+    mock_fd = mock.MagicMock()
+    path = ""  # Empty, as when user cancels Save As / Rename Tab.
+    mock_fd.getSaveFileName = mock.MagicMock(return_value=(path, True))
+    w = mu.interface.main.Window()
+    w.widget = mock.MagicMock()
+    with mock.patch("mu.interface.main.QFileDialog", mock_fd):
+        returned_path = w.get_save_path("micropython")
+    assert returned_path == ""  # Note lack of addition of ".py" extension.
+
+
 def test_Window_get_save_path_for_dot_file():
     """
     Ensure that if the user enters a dot file without an extension, then


### PR DESCRIPTION
`Editor.rename_tab` is called when users double-click on tabs. If it receives an empty path back from `Window.get_save_path` saving is cancelled. However, `Window.get_save_path` is unconditionally adding a `.py` extension to path, so we get a file called ".py" saved when user cancels the "Save file" dialog, as reported in #1880.

Fixed by avoiding appending ".py" to an empty path in `get_save_path`, so `rename_tab` does the right thing.