### PR TITLE
Enable f-strings in dark modes. Fixes #1707.

### DIFF
--- a/mu/interface/themes.py
+++ b/mu/interface/themes.py
@@ -129,6 +129,7 @@ class DayTheme(Theme):
     SingleQuotedString = DoubleQuotedString = Font(color="#800000")
     SingleQuotedFString = DoubleQuotedFString = Font(color="#800000")
     TripleSingleQuotedString = TripleDoubleQuotedString = Font(color="#060")
+    TripleSingleQuotedFString = TripleDoubleQuotedFString = Font(color="#060")
     Number = Font(color="#00008B")
     Decorator = Font(color="#cc6600")
     Default = Identifier = Font()
@@ -198,6 +199,9 @@ class NightTheme(Theme):
     TripleSingleQuotedString = TripleDoubleQuotedString = Font(
         color="#f0c674", paper="#222"
     )
+    TripleSingleQuotedFString = TripleDoubleQuotedFString = Font(
+        color="#f0c674", paper="#222"
+    )
     Number = Font(color="#b5bd68", paper="#222")
     Decorator = Font(color="#cc6666", paper="#222")
     Default = Identifier = Font(color="#DDD", paper="#222")
@@ -262,6 +266,9 @@ class ContrastTheme(Theme):
         color="#AAA", paper="black"
     )
     TripleSingleQuotedString = TripleDoubleQuotedString = Font(
+        color="#AAA", paper="black"
+    )
+    TripleSingleQuotedFString = TripleDoubleQuotedFString = Font(
         color="#AAA", paper="black"
     )
     Number = Font(color="#AAA", paper="black")

--- a/mu/interface/themes.py
+++ b/mu/interface/themes.py
@@ -127,6 +127,7 @@ class DayTheme(Theme):
     Comment = CommentBlock = Font(color="gray")
     Keyword = Font(color="#005050", bold=True)
     SingleQuotedString = DoubleQuotedString = Font(color="#800000")
+    SingleQuotedFString = DoubleQuotedFString = Font(color="#800000")
     TripleSingleQuotedString = TripleDoubleQuotedString = Font(color="#060")
     Number = Font(color="#00008B")
     Decorator = Font(color="#cc6600")
@@ -189,6 +190,9 @@ class NightTheme(Theme):
     Comment = CommentBlock = CommentLine = Font(color="#969896", paper="#222")
     Keyword = Font(color="#73a46a", bold=True, paper="#222")
     SingleQuotedString = DoubleQuotedString = Font(
+        color="#f0c674", paper="#222"
+    )
+    SingleQuotedFString = DoubleQuotedFString = Font(
         color="#f0c674", paper="#222"
     )
     TripleSingleQuotedString = TripleDoubleQuotedString = Font(
@@ -254,6 +258,9 @@ class ContrastTheme(Theme):
     Comment = CommentBlock = Font(color="#AAA", paper="black")
     Keyword = Font(color="#EEE", bold=True, paper="black")
     SingleQuotedString = DoubleQuotedString = Font(color="#AAA", paper="black")
+    SingleQuotedFString = DoubleQuotedFString = Font(
+        color="#AAA", paper="black"
+    )
     TripleSingleQuotedString = TripleDoubleQuotedString = Font(
         color="#AAA", paper="black"
     )

--- a/tests/interface/test_themes.py
+++ b/tests/interface/test_themes.py
@@ -47,10 +47,11 @@ def test_theme_apply_to():
     lexer.setEolFill = mock.MagicMock(return_value=None)
     lexer.setPaper = mock.MagicMock(return_value=None)
     theme.apply_to(lexer)
-    assert lexer.setFont.call_count == 21
-    assert lexer.setColor.call_count == 20
-    assert lexer.setEolFill.call_count == 20
-    assert lexer.setPaper.call_count == 20
+    fstrings = 4 if hasattr(lexer, "DoubleQuotedFString") else 0
+    assert lexer.setFont.call_count == 17 + fstrings
+    assert lexer.setColor.call_count == 16 + fstrings
+    assert lexer.setEolFill.call_count == 16 + fstrings
+    assert lexer.setPaper.call_count == 16 + fstrings
 
 
 def test_Font_loading():

--- a/tests/interface/test_themes.py
+++ b/tests/interface/test_themes.py
@@ -47,10 +47,10 @@ def test_theme_apply_to():
     lexer.setEolFill = mock.MagicMock(return_value=None)
     lexer.setPaper = mock.MagicMock(return_value=None)
     theme.apply_to(lexer)
-    assert lexer.setFont.call_count == 17
-    assert lexer.setColor.call_count == 16
-    assert lexer.setEolFill.call_count == 16
-    assert lexer.setPaper.call_count == 16
+    assert lexer.setFont.call_count == 21
+    assert lexer.setColor.call_count == 20
+    assert lexer.setEolFill.call_count == 20
+    assert lexer.setPaper.call_count == 20
 
 
 def test_Font_loading():


### PR DESCRIPTION
Mu themes lacked styling for the following f-string variants:
- DoubleQuotedFString
- SingleQuotedFString
- TripleDoubleQuotedFString
- TripleSingleQuotedFString

This PR adds them, using the same styling as normal strings. We could bikeshed on a better style to set f-strings apart.