### PR TITLE
CI: Add macos-latest again to the tests workflow.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        os: [ubuntu-18.04, ubuntu-latest, macos-10.15, windows-2016, windows-latest]
+        os: [ubuntu-18.04, ubuntu-latest, macos-10.15, macos-latest, windows-2016, windows-latest]
         python-version: ['3.5', '3.6', '3.7', '3.8']
       fail-fast: false
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
It was removed as part of https://github.com/mu-editor/mu/pull/1273 since the macOS 11 runner was quite unstable at the time.