### PR TITLE
Fix Mu version format to match PEP 440.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -58,7 +58,7 @@ author = "Nicholas H.Tollervey"
 from mu import __version__ as full_version
 
 # The short X.Y version.
-version = ".".join(full_version.split(".")[:3])
+version = ".".join(full_version.split(".")[:2])
 # The full version, including alpha/beta/rc tags.
 release = full_version
 

--- a/mu/__init__.py
+++ b/mu/__init__.py
@@ -6,7 +6,7 @@
 __title__ = "mu-editor"
 __description__ = "A simple Python editor for beginner programmers."
 
-__version__ = "1.1.0.beta.6"
+__version__ = "1.1.0b6"
 
 __license__ = "GPL3"
 __url__ = "https://github.com/mu-editor/mu"


### PR DESCRIPTION
To fix https://github.com/mu-editor/mu/issues/1292.

Basically the current version string is neither [semver](https://semver.org/) nor [PEP 440](https://www.python.org/dev/peps/pep-0440/):
https://github.com/mu-editor/mu/blob/ee049b7941f2606b2dfe4c9bfac328995039ebc4/mu/__init__.py#L9

Semver has been used for the GitHub release tags, and PEP440 for the PyPI releases.

For this PR I've picked PEP440 simply because from my perspective is probably better to continue using the same PyPI version format and change the format used in any future git tags, than the other way around. Since PEP440 is the version users have to type when pip installing, it's probably more "user facing": https://pypi.org/project/mu-editor/1.1.0b6/#history

As @tmontes mentions in https://github.com/mu-editor/mu/issues/1292#issuecomment-778513976 neither version format will work on the Windows installer, so doesn't matter too much which one to pick.

Happy to change it to semver if anybody has got any strong opinion about it.