### PR TITLE
Fix deleting the first character of next line when toggling comment (Ctrl+K). Fixes #1511

### DIFF
--- a/mu/interface/editor.py
+++ b/mu/interface/editor.py
@@ -632,7 +632,8 @@ class EditorPane(QsciScintilla):
             # Toggle the line currently containing the cursor.
             line_number, column = self.getCursorPosition()
             logger.info("Toggling line {}".format(line_number))
-            line_content = self.text(line_number)
+            # Replace CRLF line endings that we add when run on Windows
+            line_content = self.text(line_number).replace("\r\n", "\n")
             new_line = self.toggle_line(line_content)
             self.setSelection(line_number, 0, line_number, len(line_content))
             self.replaceSelectedText(new_line)

--- a/tests/interface/test_editor.py
+++ b/tests/interface/test_editor.py
@@ -928,6 +928,18 @@ def test_EditorPane_toggle_comments_selection_follows_len_change():
     ep.setSelection.assert_called_once_with(0, 0, 2, 4)
 
 
+def test_EditorPane_toggle_comments_handle_crlf_newline():
+    """
+    Check that stray "\r\n" line endings don't lead to deleting the first
+    character of the following line.
+    """
+    ep = mu.interface.editor.EditorPane(None, "test\r\nline 2\n")
+    ep.hasSelectedText = mock.MagicMock(return_value=False)
+    ep.toggle_comments()
+    assert ep.text() == "# test\nline 2\n"
+    assert ep.selectedText() == "# test"
+
+
 def test_EditorPane_wheelEvent():
     """ """
     ep = mu.interface.editor.EditorPane(None, "baz")


### PR DESCRIPTION
The `EditorPane.toggle_comments` command deletes the first character of the next line if the toggled line ends in `CRLF`. That method expects `EditorPane.toggle_line` to remove one EOL character, but it removes two in this case. We currently add `CRLF` line endings when editing a file[0] on Windows.

This minimal fix replaces `"\r\n"` with `"\n"` to keep changes simple. Having mixed EOL styles in a file shouldn't be a big concern, because that's what already happens on Windows[1], It also doesn't affect which EOL the file will be saved with, as that is determined on load or creation.

There's another way to fix this: make Windows also generate `LF` EOL by using `EditorPane.setEolMode(QsciScintilla.EolUnix)` (I'll add an issue describing that option). I believe having both fixes is better, but am open to picking either.

 [0] which will mostly have `LF` endings if saved from new tab or load, except if loaded from `CRLF` terminated file:
Loaded with `LF` EOL:
![lf](https://user-images.githubusercontent.com/74280297/145251313-3d44a3c7-09c0-473e-9cab-ded7a22f3873.png)

Enter adds `CRLF` as EOL:
![crlf](https://user-images.githubusercontent.com/74280297/145251304-e9775181-1063-4111-9b51-22d87aae6c05.png)

[1] We can see the EOL by setting `EditorPane.setEolVisibility(True)`.