### PR TITLE
Make Editor.envars a dict, so we avoid duplicated entries. Fixes #1736.

### DIFF
--- a/mu/interface/panes.py
+++ b/mu/interface/panes.py
@@ -876,9 +876,11 @@ class PythonProcessPane(QTextEdit):
         interpreter used to launch the child process.
         """
         self.is_interactive = interactive
-        if not envars:  # Envars must be a list if not passed a value.
-            envars = []
-        envars = [(name, v) for (name, v) in envars if name != "PYTHONPATH"]
+        if not envars:  # Envars must be a dict if not passed a value.
+            envars = {}
+        envars = {
+            name: v for (name, v) in envars.items() if name != "PYTHONPATH"
+        }
         self.script = ""
         if script_name:
             self.script = os.path.abspath(os.path.normcase(script_name))
@@ -908,7 +910,7 @@ class PythonProcessPane(QTextEdit):
             logger.info(
                 "Running with environment variables: " "{}".format(envars)
             )
-            for name, value in envars:
+            for name, value in envars.items():
                 env.insert(name, value)
         logger.info("Working directory: {}".format(working_directory))
         self.process.setWorkingDirectory(working_directory)

--- a/mu/logic.py
+++ b/mu/logic.py
@@ -349,11 +349,11 @@ def extract_envars(raw):
     Returns a list of environment variables given a string containing
     NAME=VALUE definitions on separate lines.
     """
-    result = []
+    result = {}
     for line in raw.split("\n"):
         definition = line.split("=", 1)
         if len(definition) == 2:
-            result.append([definition[0].strip(), definition[1].strip()])
+            result[definition[0].strip()] = definition[1].strip()
     return result
 
 
@@ -772,7 +772,7 @@ class Editor(QObject):
         self.mode = "python"
         self.python_extensions = [".py", ".pyw"]
         self.modes = {}
-        self.envars = []  # See restore session and show_admin
+        self.envars = {}  # See restore session and show_admin
         self.minify = False
         self.microbit_runtime = ""
         self.user_locale = ""  # user defined language locale
@@ -899,7 +899,10 @@ class Editor(QObject):
                 self.direct_load(old_path)
             logger.info("Loaded files.")
         if "envars" in old_session:
-            self.envars = old_session["envars"]
+            old_envars = old_session["envars"]
+            if isinstance(old_envars, list):
+                old_envars = dict(old_envars)
+            self.envars = old_envars
             logger.info(
                 "User defined environment variables: " "{}".format(self.envars)
             )
@@ -1412,7 +1415,10 @@ class Editor(QObject):
         """
         logger.info("Showing admin with logs from {}".format(LOG_FILE))
         envars = "\n".join(
-            ["{}={}".format(name, value) for name, value in self.envars]
+            [
+                "{}={}".format(name, value)
+                for name, value in self.envars.items()
+            ]
         )
         settings = {
             "envars": envars,

--- a/mu/modes/web.py
+++ b/mu/modes/web.py
@@ -185,10 +185,10 @@ class WebMode(BaseMode):
                 return
             logger.debug(tab.text())
             envars = self.editor.envars
-            envars.append(("FLASK_APP", os.path.basename(tab.path)))
-            envars.append(("FLASK_ENV", "development"))
-            envars.append(("LC_ALL", "en_GB.UTF8"))
-            envars.append(("LANG", "en_GB.UTF8"))
+            envars["FLASK_APP"] = os.path.basename(tab.path)
+            envars["FLASK_ENV"] = "development"
+            envars["LC_ALL"] = "en_GB.UTF8"
+            envars["LANG"] = "en_GB.UTF8"
             args = ["-m", "flask", "run"]
             cwd = os.path.dirname(tab.path)
             self.runner = self.view.add_python3_runner(

--- a/tests/interface/test_panes.py
+++ b/tests/interface/test_panes.py
@@ -1707,7 +1707,7 @@ def test_PythonProcessPane_start_process_user_environment_variables():
     ):
         mock_sys.platform = "darwin"
         ppp = mu.interface.panes.PythonProcessPane()
-        envars = [["name", "value"]]
+        envars = {"name": "value"}
         ppp.start_process(
             interpreter,
             script_filename,

--- a/tests/modes/test_web.py
+++ b/tests/modes/test_web.py
@@ -185,6 +185,25 @@ def test_stop_server():
     view.remove_python_runner.assert_called_once_with()
 
 
+def test_start_server_no_duplicate_envars():
+    """
+    Check that we don't add repeated envars to the Python3 Environment.
+    """
+    editor = mock.MagicMock()
+    editor.envars = {}
+    view = mock.MagicMock()
+    view.current_tab.path = "foo.py"
+    view.current_tab.isModified.return_value = True
+    wm = WebMode(editor, view)
+    wm.stop_server = mock.MagicMock()
+    with mock.patch("os.path.isdir", return_value=True):
+        wm.start_server()
+    assert len(editor.envars) == 4
+    with mock.patch("os.path.isdir", return_value=True):
+        wm.start_server()
+    assert len(editor.envars) == 4
+
+
 def test_stop():
     """
     Ensure that this method, called when Mu is quitting, stops the local

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -1006,6 +1006,17 @@ def test_restore_session_open_tabs_in_the_same_order():
     assert direct_load_calls_args == settings_paths
 
 
+def test_editor_restore_session_list_envars():
+    """
+    If envars is a list in the old session, convert it to a dict.
+    """
+    ed = mocked_editor()
+    with generate_session(envars=[["name", "value"]]):
+        ed.restore_session()
+
+    assert ed.envars == {"name": "value"}
+
+
 def test_editor_restore_saved_window_geometry():
     """
     Window geometry specified in the session file is restored properly.

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -1017,6 +1017,25 @@ def test_editor_restore_session_list_envars():
     assert ed.envars == {"name": "value"}
 
 
+def test_editor_restore_session_duplicated_list_envars():
+    """
+    If envars is a list with duplicates in the old session, convert it to a
+    dict of unique entries.
+    """
+    ed = mocked_editor()
+    with generate_session(
+        envars=[
+            ["name", "value"],
+            ["name", "value"],
+            ["name2", "value2"],
+            ["name2", "value2"],
+        ]
+    ):
+        ed.restore_session()
+
+    assert ed.envars == {"name": "value", "name2": "value2"}
+
+
 def test_editor_restore_saved_window_geometry():
     """
     Window geometry specified in the session file is restored properly.

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -456,7 +456,7 @@ def test_extract_envars():
     """
     raw = "FOO=BAR\n BAZ = Q=X    \n\n\n"
     expected = mu.logic.extract_envars(raw)
-    assert expected == [["FOO", "BAR"], ["BAZ", "Q=X"]]
+    assert expected == {"FOO": "BAR", "BAZ": "Q=X"}
 
 
 def test_check_flake():
@@ -803,7 +803,7 @@ def test_editor_init():
         assert e.theme == "day"
         assert e.mode == "python"
         assert e.modes == {}
-        assert e.envars == []
+        assert e.envars == {}
         assert e.minify is False
         assert e.microbit_runtime == ""
         # assert e.connected_devices == set()
@@ -889,7 +889,7 @@ def test_editor_restore_session_existing_runtime():
     assert ed.theme == theme
     assert ed._view.add_tab.call_count == len(file_contents)
     ed._view.set_theme.assert_called_once_with(theme)
-    assert ed.envars == [["name", "value"]]
+    assert ed.envars == {"name": "value"}
     assert ed.minify is False
     assert ed.microbit_runtime == "/foo"
     assert ed._view.zoom_position == 5
@@ -911,7 +911,7 @@ def test_editor_restore_session_missing_runtime():
     assert ed.theme == theme
     assert ed._view.add_tab.call_count == len(file_contents)
     ed._view.set_theme.assert_called_once_with(theme)
-    assert ed.envars == [["name", "value"]]
+    assert ed.envars == {"name": "value"}
     assert ed.minify is False
     assert ed.microbit_runtime == ""  # File does not exist so set to ''
 
@@ -2212,7 +2212,7 @@ def test_show_admin():
     ed = mu.logic.Editor(view)
     ed.modes = {"python": mock.MagicMock()}
     ed.sync_package_state = mock.MagicMock()
-    ed.envars = [["name", "value"]]
+    ed.envars = {"name": "value"}
     ed.minify = True
     ed.microbit_runtime = "/foo/bar"
     settings = {
@@ -2242,7 +2242,7 @@ def test_show_admin():
             )
             assert view.show_admin.call_count == 1
             assert view.show_admin.call_args[0][1] == settings
-            assert ed.envars == [["name", "value"]]
+            assert ed.envars == {"name": "value"}
             assert ed.minify is True
             assert ed.microbit_runtime == "/foo/bar"
             # Expect package names to be normalised to lowercase.
@@ -2259,7 +2259,7 @@ def test_show_admin_no_change():
     ed = mu.logic.Editor(view)
     ed.modes = {"python": mock.MagicMock()}
     ed.sync_package_state = mock.MagicMock()
-    ed.envars = [["name", "value"]]
+    ed.envars = {"name": "value"}
     ed.minify = True
     ed.microbit_runtime = "/foo/bar"
     new_settings = {}
@@ -2284,7 +2284,7 @@ def test_show_admin_missing_microbit_runtime():
     ed = mu.logic.Editor(view)
     ed.modes = {"python": mock.MagicMock()}
     ed.sync_package_state = mock.MagicMock()
-    ed.envars = [["name", "value"]]
+    ed.envars = {"name": "value"}
     ed.minify = True
     ed.microbit_runtime = "/foo/bar"
     settings = {
@@ -2314,7 +2314,7 @@ def test_show_admin_missing_microbit_runtime():
             )
             assert view.show_admin.call_count == 1
             assert view.show_admin.call_args[0][1] == settings
-            assert ed.envars == [["name", "value"]]
+            assert ed.envars == {"name": "value"}
             assert ed.minify is True
             assert ed.microbit_runtime == ""
             assert view.show_message.call_count == 1


### PR DESCRIPTION
This solves the issue of duplicated entries on the "Python3 Environment" tab, like those that get added when running Web mode server (#1736).

To avoid errors from old session files, `Editor.restore_session` still accepts envars as list, but converts them to dict.