### PR TITLE
Delete zip file of wheels when make clean (avoids uploading the zip to PyPI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ clean:
 	find . \( -name '*.tgz' -o -name dropin.cache \) -delete
 	find . | grep -E "(__pycache__)" | xargs rm -rf
 	rm -f ./mu/locale/messages.pot
+	rm -f ./mu/wheels/*.zip
 
 run: clean
 ifeq ($(VIRTUAL_ENV),)

--- a/make.py
+++ b/make.py
@@ -205,6 +205,7 @@ def clean():
     _rmtree("venv-pup")
     _rmfiles(".", "*.pyc")
     _rmfiles("mu/locale", "*.pot")
+    _rmfiles("mu/wheels", "*.zip")
     return 0
 
 


### PR DESCRIPTION
What the title says. :-) Ensures the Mu installable via `pip` is **small**.