### PR TITLE
micro:bit: Update board IDs to support V2.2

### DIFF
--- a/mu/modes/microbit.py
+++ b/mu/modes/microbit.py
@@ -123,7 +123,7 @@ class MicrobitMode(MicroPythonMode):
     valid_boards = [(0x0D28, 0x0204, None, "BBC micro:bit")]
 
     # Board IDs of supported boards.
-    valid_board_ids = [0x9900, 0x9901, 0x9904]
+    valid_board_ids = [0x9900, 0x9901, 0x9904, 0x9905, 0x9906]
 
     python_script = ""
 


### PR DESCRIPTION
Add board IDs (9905, 9906) to support [micro:bit interface processor revision V2.2](https://support.microbit.org/support/solutions/articles/19000132336-bbc-micro-bit-v2-interface-processor-change-v2-2-)