### PR TITLE
CI: Add Arm Raspbian job that installs Mu in system Python.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,11 +90,12 @@ jobs:
             "
 
   test-pios:
-    name: Test Raspbian ${{ matrix.docker-tag }}
+    name: Test PiOS ${{ matrix.docker-tag }} (${{ matrix.pyenv }})
     runs-on: ubuntu-latest
     strategy:
       matrix:
         docker-tag: ['stretch-2018-03-13', 'buster-2021-03-25']
+        pyenv: ['virtualenv', 'system']
       fail-fast: false
     services:
       rpios:
@@ -129,7 +130,19 @@ jobs:
           port:  ${{ job.services.rpios.ports[5022] }}
           # Purposely skip apt update, install version from image stale index
           script: sudo apt-get install -y python3-virtualenv
-      - name: Create venv and install Python dependencies
+      - name: Create virtual environment and always activate it
+        if: matrix.pyenv == 'virtualenv'
+        uses: appleboy/ssh-action@master
+        with:
+          host: rpios
+          username: pi
+          password: raspberry
+          port:  ${{ job.services.rpios.ports[5022] }}
+          script: |
+            python3 -m virtualenv ~/mu/.venv -v --python=python3 --system-site-packages
+            echo "source ~/mu/.venv/bin/activate" > ~/.bashrc_new && cat ~/.bashrc >> ~/.bashrc_new
+            rm ~/.bashrc && mv ~/.bashrc_new ~/.bashrc
+      - name: Install Python dependencies
         uses: appleboy/ssh-action@master
         with:
           host: rpios
@@ -138,12 +151,8 @@ jobs:
           port:  ${{ job.services.rpios.ports[5022] }}
           command_timeout: 20m
           script: |
-            python3 -m virtualenv ~/mu/.venv -v --python=python3 --system-site-packages
-            echo "source ~/mu/.venv/bin/activate" > ~/.bashrc_new && cat ~/.bashrc >> ~/.bashrc_new
-            rm ~/.bashrc && mv ~/.bashrc_new ~/.bashrc
-            source .venv/bin/activate
-            python -m pip list
-            python -m pip install ."[dev]"
+            python3 -m pip list
+            python3 -m pip install ."[dev]"
       - name: Environment info
         uses: appleboy/ssh-action@master
         with:
@@ -164,5 +173,5 @@ jobs:
           username: pi
           password: raspberry
           port:  ${{ job.services.rpios.ports[5022] }}
-          command_timeout: 25m
-          script: xvfb-run python make.py check
+          command_timeout: 20m
+          script: xvfb-run python3 make.py check


### PR DESCRIPTION
In addition to the jobs installing it in a virtual environment.

This is something that a lot of users do, so we should test it as well in CI.

It is also a lot users do in "desktop" Ubuntu (and other linux distros), so having this should also help cover that.

This PR is currently targetting the `make` branch (PR https://github.com/mu-editor/mu/pull/1959) as it needs those changes merged first, but once it's merged this PR should re-target master.