### PR TITLE
CI: Update the RaspPi Buster image to latest & add legacy release.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -94,7 +94,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        docker-tag: ['stretch-2018-03-13', 'buster-2021-03-25']
+        docker-tag: ['stretch-2018-03-13', 'buster-2021-05-28', 'buster-legacy-2021-12-02']
       fail-fast: false
     services:
       rpios:


### PR DESCRIPTION
The Buster "legacy" version (a maintenance-only version released after the Bullseye release) has several changes to the "standard" Raspberry Pi OS Buster, so in case that could affect Mu I've added the "legacy" version as a separate test run.

This PR also updates the "normal" Buster release image.

So "2021-05-28" becomes the last Buster release, and "2021-12-02" the latest buster legacy release.