### PR TITLE
Fix CI due to new versions of black and pytest.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ install_requires = [
     # though. Regarding these packages' versions, please refer to:
     # http://flake8.pycqa.org/en/latest/faq.html#why-does-flake8-use-ranges-for-its-dependencies
     "flake8 >= 3.8.3",
-    "black>=19.10b0;python_version>'3.5'",
+    "black>=19.10b0,<22.1.0;python_version>'3.5'",
     "appdirs>=1.4.3",
     "semver>=2.8.0",
     #

--- a/tests/interface/test_panes.py
+++ b/tests/interface/test_panes.py
@@ -1736,7 +1736,7 @@ def test_PythonProcessPane_start_process_user_environment_variables():
     assert mock_environment.insert.call_args_list[4][0] == ("name", "value")
 
 
-@pytest.mark.skip(True, reason="Only used by debugger; now refactored")
+@pytest.mark.skip(reason="Only used by debugger; now refactored")
 def test_PythonProcessPane_start_process_custom_runner():
     """
     Ensure that if the runner is set, it is used as the command to start the


### PR DESCRIPTION
This PR does two things:
- Set black version upper bound to <22.1.0.
    - Something with the default settings has changed and v22.1.0 makes some code changes that are not compatible with the same default settings from v19.10b0, which we still want to maintain compatibility.
- Fixes a pytest fixture
    - The first argument to skip was incorrectly set, this didn't seem to be a problem before, but pytest v7.0.0 marks the test as a failure. 