### PR TITLE
Update venv Flash version to fix issue with incompatible dependency.

### DIFF
--- a/mu/wheels/__init__.py
+++ b/mu/wheels/__init__.py
@@ -38,7 +38,7 @@ ZIP_FILEPATH = os.path.join(WHEELS_DIRPATH, mu_version + ".zip")
 #
 mode_packages = [
     ("pgzero", "pgzero>=1.2.1"),
-    ("flask", "flask==1.1.2"),
+    ("flask", "flask==1.1.4"),
     # The version of ipykernel here should match to the version used by
     # qtconsole at the version specified in setup.py
     # FIXME: ipykernel max ver added for macOS 10.13 compatibility, min taken


### PR DESCRIPTION
Flask v1.1.2 has `itsdangerous` as a dependency without a max version lock, and v2 of `itsdangerous` is not compatible with Flash v1.
`itsdangerous`  v2.1 was released 3 days ago with a breaking change if you are using Flask v2, so we need to update to Flask v1.1.4 as this version has locked `itsdangerous` to <= 2.

The Flash changes between v1.1.2 and v1.1.4 should not cause any issues to Mu or its users: https://github.com/pallets/flask/compare/1.1.2...1.1.4