### PR TITLE
add pyproject.toml according to PEP 517

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,4 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+


### PR DESCRIPTION
According to the [tutorial](https://peps.python.org/pep-0517/#source-trees) of setuptools and [PEP 517](https://peps.python.org/pep-0517/#source-trees), We should add pyproject.toml