### PR TITLE
Fix typo in the Russian locale

### DIFF
--- a/mu/locale/ru_RU/LC_MESSAGES/mu.po
+++ b/mu/locale/ru_RU/LC_MESSAGES/mu.po
@@ -259,7 +259,7 @@ msgstr "Отформатировать код"
 
 #: mu/interface/main.py:155
 msgid "Tidy up the layout of your code."
-msgstr "Отформатировать код скрипта утилитой \"Black"\."
+msgstr "Отформатировать код скрипта утилитой \"Black\"."
 
 #: mu/interface/main.py:159
 msgid "Help"


### PR DESCRIPTION
On my linux system, trying to rebuild the locales results in a fatal error for the Russian one due to unescaped quote. More specifically:

msgfmt mu.po -o mu.mo
mu.po:262:55: syntax error
mu.po:263: end-of-line within string
msgfmt: found 2 fatal errors

The PR fixes the typo and allows the locale to be built.