### PR TITLE
Clamp click version to workaround issue with black & other CI fixes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [macos-10.15, windows-2016, ubuntu-18.04]
+        os: [macos-10.15, windows-2019, ubuntu-18.04]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     name: Build ${{ matrix.os }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -127,8 +127,9 @@ jobs:
           username: pi
           password: raspberry
           port:  ${{ job.services.rpios.ports[5022] }}
-          # Purposely skip apt update, install version from image stale index
-          script: sudo apt-get install -y python3-virtualenv
+          script: |
+            sudo apt-get update
+            sudo apt-get install -y python3-virtualenv
       - name: Create venv and install Python dependencies
         uses: appleboy/ssh-action@master
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        os: [ubuntu-18.04, ubuntu-latest, macos-10.15, macos-latest, windows-2016, windows-latest]
+        os: [ubuntu-18.04, ubuntu-latest, macos-10.15, macos-latest, windows-2019, windows-latest]
         python-version: ['3.5', '3.6', '3.7', '3.8']
       fail-fast: false
     runs-on: ${{ matrix.os }}

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,8 @@ install_requires = [
     # though. Regarding these packages' versions, please refer to:
     # http://flake8.pycqa.org/en/latest/faq.html#why-does-flake8-use-ranges-for-its-dependencies
     "flake8 >= 3.8.3",
+    # Clamp click max version to workaround incompatibility with black<22.1.0
+    "click<=8.0.4",
     "black>=19.10b0,<22.1.0;python_version>'3.5'",
     "appdirs>=1.4.3",
     "semver>=2.8.0",


### PR DESCRIPTION
Click is a black dependency and the latest releases (>8.0.4) have broken older black releases (<22.3.0).
https://github.com/psf/black/issues/2964

Ideally we should update black to the latest version, but right now we might  want to keep compatibility with older black releases.
Once we update all dependencies, including black, we can remove click.