### PR TITLE
CI: Move AppImage runner to a docker container.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,38 +54,20 @@ jobs:
   build-linux:
     runs-on: ubuntu-latest
     container:
-      image: ubuntu:16.04
+      image: ghcr.io/mu-editor/mu-appimage:2022.05.01
     name: Build AppImage
     steps:
       - uses: actions/checkout@v2
-      - name: Install Python 3.8
-        run: |
-          apt-get update
-          apt-get install -y wget make
-          wget https://github.com/indygreg/python-build-standalone/releases/download/20220502/cpython-3.8.13+20220502-x86_64-unknown-linux-gnu-install_only.tar.gz
-          tar -xf cpython-3.8.13+20220502-x86_64-unknown-linux-gnu-install_only.tar.gz -C /
-          ln -s /python/bin/python3.8 /bin/python
-          ln -s /python/bin/python3.8 /bin/python3
-          ln -s /python/bin/python3.8 /bin/python3.8
-          ln -s /python/bin/pip /bin/pip
-      - name: Display Python info
+      - name: Display system info
         run: |
           uname -a
+          cat /etc/lsb-release
           python -c "import sys; print(sys.version)"
           python -c "import platform, struct; print(platform.machine(), struct.calcsize('P') * 8)"
           python -c "import sys; print(sys.executable)"
           python -m pip --version
           pip --version
-          pip config list
           pip list --verbose
-      - name: Install xvfb
-        run: apt-get install -y libxkbcommon-x11-0 xvfb
-      # Install this dependency as a workaround to PyQt5 issue
-      # qt.qpa.plugin: Could not load the Qt platform plugin "xcb" in "" even though it was found.
-      - name: Install PyQt5 issue workaround
-        run: apt install -y libqt5gui5
-      - name: Install AppImage dependencies
-        run: apt-get -y install file appstream
       - name: Install Mu test dependencies
         run: |
           pip install .[tests]
@@ -93,7 +75,7 @@ jobs:
       - run: mkdir upload
       - name: Build Linux AppImage
         run: xvfb-run make linux
-      # GitHub actions upload artifact breaks permissions, so tar workaround
+      # GitHub actions upload artifact breaks permissions, workaround using tar
       # https://github.com/actions/upload-artifact/issues/38
       - name: Tar AppImage to maintain permissions
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [macos-10.15, windows-2019, ubuntu-18.04]
+        os: [macos-10.15, windows-2019]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     name: Build ${{ matrix.os }}
@@ -45,14 +45,49 @@ jobs:
         run: |
           make macos
           mv dist/*.dmg upload/
-      - name: Build Linux AppImage
-        if: runner.os == 'Linux'
+      - name: Upload Mu installer
+        uses: actions/upload-artifact@v1
+        with:
+          name: mu-editor-${{ runner.os }}-${{ github.sha }}
+          path: upload
+
+  build-linux:
+    runs-on: ubuntu-latest
+    container:
+      image: python:3.8-buster
+    name: Build AppImage
+    steps:
+      - uses: actions/checkout@v2
+      - name: Display Python info
         run: |
-          sudo apt-get update
-          sudo apt-get install -y libxkbcommon-x11-0 xvfb
+          uname -a
+          python -c "import sys; print(sys.version)"
+          python -c "import platform, struct; print(platform.machine(), struct.calcsize('P') * 8)"
+          python -c "import sys; print(sys.executable)"
+          python -m pip --version
+          pip --version
+          pip config list
+          pip list --verbose
+      - name: Install xvfb
+        run: |
+          apt-get update
+          apt-get install -y libxkbcommon-x11-0 xvfb
+      # Install this dependency as a workaround to PyQt5 issue
+      # qt.qpa.plugin: Could not load the Qt platform plugin "xcb" in "" even though it was found.
+      - name: Install PyQt5 issue workaround
+        run: apt install -y libqt5gui5
+      - name: Install AppImage dependencies
+        run: apt-get install -y fuse libfuse2
+      - name: Install Mu test dependencies
+        run: |
+          pip install .[tests]
+          pip list
+      - run: mkdir upload
+      - name: Build Linux AppImage
+        run: |
           xvfb-run make linux
           mv dist/*.AppImage upload/
-      - name: Upload Mu installer
+      - name: Upload Mu AppImage
         uses: actions/upload-artifact@v1
         with:
           name: mu-editor-${{ runner.os }}-${{ github.sha }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,10 +54,20 @@ jobs:
   build-linux:
     runs-on: ubuntu-latest
     container:
-      image: python:3.8-buster
+      image: ubuntu:16.04
     name: Build AppImage
     steps:
       - uses: actions/checkout@v2
+      - name: Install Python 3.8
+        run: |
+          apt-get update
+          apt-get install -y wget make
+          wget https://github.com/indygreg/python-build-standalone/releases/download/20220502/cpython-3.8.13+20220502-x86_64-unknown-linux-gnu-install_only.tar.gz
+          tar -xf cpython-3.8.13+20220502-x86_64-unknown-linux-gnu-install_only.tar.gz -C /
+          ln -s /python/bin/python3.8 /bin/python
+          ln -s /python/bin/python3.8 /bin/python3
+          ln -s /python/bin/python3.8 /bin/python3.8
+          ln -s /python/bin/pip /bin/pip
       - name: Display Python info
         run: |
           uname -a
@@ -69,26 +79,29 @@ jobs:
           pip config list
           pip list --verbose
       - name: Install xvfb
-        run: |
-          apt-get update
-          apt-get install -y libxkbcommon-x11-0 xvfb
+        run: apt-get install -y libxkbcommon-x11-0 xvfb
       # Install this dependency as a workaround to PyQt5 issue
       # qt.qpa.plugin: Could not load the Qt platform plugin "xcb" in "" even though it was found.
       - name: Install PyQt5 issue workaround
         run: apt install -y libqt5gui5
       - name: Install AppImage dependencies
-        run: apt-get install -y fuse libfuse2
+        run: apt-get -y install file appstream
       - name: Install Mu test dependencies
         run: |
           pip install .[tests]
           pip list
       - run: mkdir upload
       - name: Build Linux AppImage
+        run: xvfb-run make linux
+      # GitHub actions upload artifact breaks permissions, so tar workaround
+      # https://github.com/actions/upload-artifact/issues/38
+      - name: Tar AppImage to maintain permissions
         run: |
-          xvfb-run make linux
-          mv dist/*.AppImage upload/
+          cd dist/
+          tar -cvf Mu_Editor-AppImage-x86_64-${{ github.sha }}.tar *.AppImage
+          ls -la .
       - name: Upload Mu AppImage
         uses: actions/upload-artifact@v1
         with:
           name: mu-editor-${{ runner.os }}-${{ github.sha }}
-          path: upload
+          path: dist/Mu_Editor-AppImage-x86_64-${{ github.sha }}.tar


### PR DESCRIPTION
Let's start with an "easy" container that has already Python 3.8 set up, and when this is working we can move to an older Ubuntu container.

