### PR TITLE
venv: Log pip version on venv creation, clarify empty output logging

### DIFF
--- a/mu/virtual_environment.py
+++ b/mu/virtual_environment.py
@@ -44,7 +44,8 @@ class VirtualEnvironmentCreateError(VirtualEnvironmentError):
 
 def compact(text):
     """Remove double line spaces and anything else which might help"""
-    return "\n".join(line for line in text.splitlines() if line.strip())
+    compacted = "\n".join(line for line in text.splitlines() if line.strip())
+    return compacted or "No output received."
 
 
 class Process(QObject):
@@ -303,6 +304,15 @@ class Pip(object):
                 yes=True,
                 **kwargs
             )
+
+    def version(self):
+        """
+        Get the pip version
+
+        NB this is fairly trivial but is pulled out principally for
+        testing purposes
+        """
+        return self.run("--version")
 
     def freeze(self):
         """
@@ -898,6 +908,7 @@ class VirtualEnvironment(object):
         usual way.
         """
         logger.info("Installing baseline packages.")
+        logger.info("pip version: %s", compact(self.pip.version()))
         #
         # TODO: Add semver check to ensure filepath is safe
         #

--- a/tests/virtual_environment/test_pip.py
+++ b/tests/virtual_environment/test_pip.py
@@ -274,8 +274,22 @@ def test_pip_uninstall_single_package_with_flag_value():
 
 
 #
-# freeze & list
+# version, freeze & list
 #
+def test_pip_version():
+    """Ensure that pip.version calls pip --version"""
+    pip_executable = "pip-" + rstring() + ".exe"
+    pip = mu.virtual_environment.Pip(pip_executable)
+    with patch.object(pip.process, "run_blocking") as mock_run:
+        pip.version()
+        expected_args = (
+            pip_executable,
+            ["--version", "--disable-pip-version-check"],
+        )
+        args, _ = mock_run.call_args
+        assert args == expected_args
+
+
 def test_pip_freeze():
     """Ensure that pip.freeze calls pip freeze"""
     pip_executable = "pip-" + rstring() + ".exe"

--- a/tests/virtual_environment/test_virtual_environment.py
+++ b/tests/virtual_environment/test_virtual_environment.py
@@ -276,6 +276,8 @@ def test_download_wheels_if_not_present(venv, test_wheels):
         mu.wheels, "download"
     ) as mock_download, mock.patch.object(
         venv, "install_from_zipped_wheels"
+    ), mock.patch.object(
+        venv.pip, "version"
     ):
         try:
             venv.install_baseline_packages()
@@ -301,7 +303,7 @@ def test_download_wheels_failure(venv, test_wheels):
         mu.wheels,
         "download",
         side_effect=mu.wheels.WheelsDownloadError(message),
-    ):
+    ), mock.patch.object(venv.pip, "version"):
         try:
             venv.install_baseline_packages()
         except mu.wheels.WheelsDownloadError as exc:
@@ -321,6 +323,8 @@ def test_base_packages_installed(patched, venv, test_wheels):
     with mock.patch.object(venv, "create_venv"), mock.patch.object(
         venv, "register_baseline_packages"
     ), mock.patch.object(venv, "install_jupyter_kernel"), mock.patch.object(
+        venv.pip, "version"
+    ), mock.patch.object(
         PIP, "install"
     ) as mock_pip_install:
         venv.create()


### PR DESCRIPTION
I find myself asking a lot of users with Crash Reports to run commands in the terminal to determine the pip version running inside the virtual environment, so this PR logs that to the venv creation process.

It also logs "No output received." whenever there is an empty output from venv creation/verification commands, as otherwise we end up with empty entries in the log, which are a bit hard to follow.