### PR TITLE
CI: Update RPi OS Buster runner to latest release (2022-04-07).

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,11 +90,11 @@ jobs:
             "
 
   test-pios:
-    name: Test Raspbian ${{ matrix.docker-tag }}
+    name: Test PiOS ${{ matrix.docker-tag }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        docker-tag: ['stretch-2018-03-13', 'buster-2021-05-28', 'buster-legacy-2021-12-02']
+        docker-tag: ['stretch-2018-03-13', 'buster-2021-05-28', 'buster-legacy-2022-04-07']
       fail-fast: false
     services:
       rpios:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -165,5 +165,5 @@ jobs:
           username: pi
           password: raspberry
           port:  ${{ job.services.rpios.ports[5022] }}
-          command_timeout: 25m
+          command_timeout: 30m
           script: xvfb-run python make.py check


### PR DESCRIPTION
A new docker image with the latest Raspberry Pi OS Buster (Legacy) is available. 