### PR TITLE
Close Files panel on Micropython error before showing error message.

### DIFF
--- a/mu/interface/panes.py
+++ b/mu/interface/panes.py
@@ -910,6 +910,7 @@ class FileSystemPane(QFrame):
         """
         Fired when listing files fails.
         """
+        self.disable()
         self.show_warning(
             _(
                 "There was a problem getting the list of files on "
@@ -919,7 +920,6 @@ class FileSystemPane(QFrame):
                 "restarting Mu."
             )
         )
-        self.disable()
 
     def on_put_fail(self, filename):
         """


### PR DESCRIPTION
Fixes https://github.com/mu-editor/mu/issues/2262.

This issue happens because multiple errors while connecting with a MicroPython device can try to close/destroy the files panel.
So there is a bit of a race condition and the second error might try to close an already destroyed files panel:

```
Traceback (most recent call last):
  File "C:\Users\xxxx\AppData\Local\Programs\Mu Editor\Python\lib\site-packages\mu\interface\panes.py", line 760, in on_ls_fail
    self.disable()
  File "C:\Users\xxxx\AppData\Local\Programs\Mu Editor\Python\lib\site-packages\mu\interface\panes.py", line 699, in disable
    self.microbit_fs.setDisabled(True)
RuntimeError: wrapped C/C++ object of type MicroPythonDeviceFileList has been deleted
```

The way to replicate this issue is to find a way to get an error while reading the files from a MicroPython device, and then to cause another connection error by, for example, unplugging the device.
The simplest way to trigger the first MicroPython files error might be to temporarily edit the microfs.py module to manually throw an `Exception` in the `microfs.ls()` operation. This opens an error pop up, and while that error window is shown, we can disconnect the USB cable.

What happens here is that the first error shows a message to the user, and only after the error window is closed it tries to close the panel, giving plenty of time for a different error to happen and close/destroy the panel.
In normal circumstances these two errors can happen, for example, if the device itself is busy reboting when the file panel is opened (so the panel is opened at a point where the serial port is still active, the device doesn't respond to the REPL, and as it reboots it closes the serial port).

Technically this doesn't really fix the race condition, but it significantly reduces the chances of it triggering this error (I coudn't trigger it anymore), as it takes a bit of time for the panel to be destroyed by the garbage collector, and this issue normally only occurs when these errors happen in a very short window of time.

The alternative would be to significantly refactor the MicroPython mode classes, how errors are bubbled up, and the lifecycle of the widget, as info about the error goes up and down the chain a couple of times.
For now I think this is a good enough solution.