### PR TITLE
Update virtualenv depedency min version to v20 for --symlinks flag.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,10 +61,10 @@ install_requires = [
     "black>=19.10b0,<22.1.0;python_version>'3.5'",
     "appdirs>=1.4.3",
     "semver>=2.8.0",
-    #
-    # Needed for creating the runtime virtual environment
-    #
-    "virtualenv>=16.7.6",
+    # virtualenv vendors pip, we need at least pip v19.3 to install some
+    # rust based dependencies. virtualenv >=v20 is required for the --symlinks
+    # flag needed by AppImage, and it packs pip v20.0.2.
+    "virtualenv>=20.0.0",
     #
     # Needed for packaging
     #


### PR DESCRIPTION
The latest AppImage updates require the user virtual env in Linux to use symlinks, so that they can be recreated when the AppImage python excutable moves to a different temp folder.

The virtualenv --symlinks flag was only added in v20.0, so that's our required new min version.

More info and fixes https://github.com/mu-editor/mu/issues/2256.