### PR TITLE
Don't use our own dmgbuild fork to package Mu on macOS.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,10 +112,6 @@ macos: check
 	# 1. Not really needed.
 	# 2. Previously active venv would be "gone" on venv-pup deactivation.
 	./venv-pup/bin/pip install pup
-	# HACK
-	# 1. Use a custom dmgbuild to address `hdiutil detach` timeouts.
-	./venv-pup/bin/pip uninstall -y dmgbuild
-	./venv-pup/bin/pip install git+https://github.com/tmontes/dmgbuild.git@mu-pup-ci-hack
 	./venv-pup/bin/pup package --launch-module=mu --nice-name="Mu Editor" --icon-path=./package/icons/mac_icon.icns --license-path=./LICENSE .
 	rm -r venv-pup
 	ls -la ./build/pup/


### PR DESCRIPTION
CONTEXT:

* Our first attempts at `pup`-packaging Mu for macOS on CI lead to `dmgbuild` failures with messages like `hdiutil: detach: timeout for DiskArbitration expired`.
* Because of that, I forked `dmgbuild` to work around the issue.
* See #1234.

WHAT's CHANGED:

* `dmgbuild`'s recent releases claim to have fixed the issue.
* `pup`'s just released 1.0.0a17 now brings in that.

THUS:

* This PR cleans up the forced usage of my own `dmgbuild` fork when packaging on macOS.
