### PR TITLE
Avoid a race condition when creating LOG_DIR

### DIFF
--- a/mu/app.py
+++ b/mu/app.py
@@ -202,8 +202,7 @@ def setup_logging():
     """
     Configure logging.
     """
-    if not os.path.exists(LOG_DIR):
-        os.makedirs(LOG_DIR)
+    os.makedirs(LOG_DIR, exist_ok=True)
 
     # set logging format
     log_fmt = (

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -197,7 +197,7 @@ def test_setup_logging_without_envvar():
         "mu.app.os.makedirs", return_value=None
     ) as mkdir:
         setup_logging()
-        mkdir.assert_called_once_with(LOG_DIR)
+        mkdir.assert_called_once_with(LOG_DIR, exist_ok=True)
         log_conf.assert_called_once_with(
             LOG_FILE,
             when="midnight",
@@ -223,7 +223,7 @@ def test_setup_logging_with_envvar():
         "mu.app.os.makedirs", return_value=None
     ) as mkdir:
         setup_logging()
-        mkdir.assert_called_once_with(LOG_DIR)
+        mkdir.assert_called_once_with(LOG_DIR, exist_ok=True)
         log_conf.assert_called_once_with(
             LOG_FILE,
             when="midnight",


### PR DESCRIPTION
One of the Fedora Linux users had this traceback reported automatically:

    Traceback (most recent call last):
      File "/usr/bin/mu-editor", line 8, in <module>
        sys.exit(run())
      File "/usr/lib/python3.10/site-packages/mu/app.py", line 111, in run
        setup_logging()
      File "/usr/lib/python3.10/site-packages/mu/app.py", line 47, in setup_logging
        os.makedirs(LOG_DIR)
      File "/usr/lib64/python3.10/os.py", line 225, in makedirs
        mkdir(name, mode)
    FileExistsError: [Errno 17] File exists: '/home/robertfairbrother/.cache/mu/log'

Looking at the code, this can probably happen when Mu is started twice
at the same time. Instead of checking if the dir exist, just attempt to create
it and don't fail if it is already there.