### PR TITLE
replace appdirs with platformdirs

### DIFF
--- a/mu/config.py
+++ b/mu/config.py
@@ -1,9 +1,9 @@
 import os
 
-import appdirs
+import platformdirs
 
 # The default directory for application data (i.e., configuration).
-DATA_DIR = appdirs.user_data_dir(appname="mu", appauthor="python")
+DATA_DIR = platformdirs.user_data_dir(appname="mu", appauthor="python")
 
 # The name of the default virtual environment used by Mu.
 VENV_NAME = "mu_venv"

--- a/mu/logic.py
+++ b/mu/logic.py
@@ -29,7 +29,7 @@ import random
 import locale
 import shutil
 
-import appdirs
+import platformdirs
 from PyQt5.QtWidgets import QMessageBox
 from PyQt5.QtCore import QObject, pyqtSignal
 from PyQt5 import QtCore
@@ -45,7 +45,7 @@ from . import settings
 from .virtual_environment import venv
 
 # The default directory for application logs.
-LOG_DIR = appdirs.user_log_dir(appname="mu", appauthor="python")
+LOG_DIR = platformdirs.user_log_dir(appname="mu", appauthor="python")
 # The path to the log file for the application.
 LOG_FILE = os.path.join(LOG_DIR, "mu.log")
 # Regex to match pycodestyle (PEP8) output.

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ install_requires = [
     # Clamp click max version to workaround incompatibility with black<22.1.0
     "click<=8.0.4",
     "black>=19.10b0,<22.1.0;python_version>'3.5'",
-    "appdirs>=1.4.3",
+    "platformdirs>=2.0.0,<3.0.0",
     "semver>=2.8.0",
     # virtualenv vendors pip, we need at least pip v19.3 to install some
     # rust based dependencies. virtualenv >=v20 is required for the --symlinks


### PR DESCRIPTION
appdirs is no longer actively maintained, whereas platformdirs (a fork) is actively maintained and supported by tidelift