### PR TITLE
Resolve the actual data path for windows distrubutions

### DIFF
--- a/mu/config.py
+++ b/mu/config.py
@@ -1,9 +1,26 @@
 import os
+import sys
+import tempfile
 
-import appdirs
+import platformdirs
+
+
+def _resolve_data_dir():
+    path = platformdirs.user_data_dir(appname="mu", appauthor="python")
+    if sys.platform == "win32":
+        # Locate the actual path for Windows by making a temporary file
+        # then resolving the real path. Solves a bug in the Windows store
+        # distribution of Python 3.8+
+        fd, tmp = tempfile.mkstemp(dir=path)
+        realpath = os.path.dirname(os.path.realpath(tmp))
+        os.close(fd)
+        os.remove(tmp)
+        return realpath
+    else:
+        return path
 
 # The default directory for application data (i.e., configuration).
-DATA_DIR = appdirs.user_data_dir(appname="mu", appauthor="python")
+DATA_DIR = _resolve_data_dir()
 
 # The name of the default virtual environment used by Mu.
 VENV_NAME = "mu_venv"


### PR DESCRIPTION
Fixes a bug where if the host Python is from the Windows store then DATA_DIR will be different with subproceses. This causes a crash creating virtual environments.

See https://github.com/mu-editor/crash-reports/issues/228