### PR TITLE
Fix broken link to Adafruit in Packaging Processes section

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -139,7 +139,7 @@ they should be checked so no warning messages appear about untrusted sources
 during the installation process.
 
 The instructions for signing the Windows installers are explain in
-`this wonderful article on Adafruit's website <https://learn.adafruit.com/how-to-sign-windows-drivers-installer/making-an-installer>_`.
+`this wonderful article on Adafruit's website <https://learn.adafruit.com/how-to-sign-windows-drivers-installer/making-an-installer>`_.
 But the essence is that the command issued should look something like::
 
     "C:\Program Files (x86)\Windows Kits\10\bin\10.0.17134.0\x86\signtool" sign /v /n "Nicholas H.Tollervey" /tr http://timestamp.globalsign.com/?signature=sha2 /td sha256 mu-editor_1.0.1_win32.exe


### PR DESCRIPTION
This fixes a broken link in Packaging Processes in the second paragraph on the release page: https://mu.readthedocs.io/en/latest/release.html

Thanks!