### PR TITLE
Fix issue 1328 - link to virtual env guide at Real Python

### DIFF
--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -61,6 +61,10 @@ into your virtualenv with::
 
         py -3 -mvenv .venv
 
+    Virtual environment setup can vary depending on your operating system.
+    To learn more about virtual environments, see this `in-depth guide from Real Python <https://realpython.com/python-virtual-environments-a-primer/>`_.
+
+
 Running Development Mu
 ++++++++++++++++++++++
 


### PR DESCRIPTION
I added a paragraph that reads:

> Virtual environment setup can vary depending on your operating system. To learn more about virtual environments, see this [in-depth guide from Real Python](https://realpython.com/python-virtual-environments-a-primer/).

The guide at Real Python has tabs that cover all 3 OSes, which is why I recommend it. 