### PR TITLE
Fix web asset dirs

### DIFF
--- a/mu/modes/web.py
+++ b/mu/modes/web.py
@@ -135,6 +135,18 @@ class WebMode(BaseMode):
         """
         return SHARED_APIS + PYTHON3_APIS + FLASK_APIS
 
+    def assets_dir(self, asset_type):
+        """
+        Determine (and create) the directory for a set of assets.
+
+        In web-mode such asset directories exist in the user's workspace
+        directory, rather than relative to the currently open Python file.
+        """
+        base_dir = self.workspace_dir()
+        assets_dir = os.path.join(base_dir, asset_type)
+        os.makedirs(assets_dir, exist_ok=True)
+        return assets_dir
+
     def run_toggle(self, event):
         """
         Handles the toggling of the run button to start/stop the server.

--- a/mu/modes/web.py
+++ b/mu/modes/web.py
@@ -37,17 +37,24 @@ app.run()
 """
 
 
-CODE_TEMPLATE = """# A simple web application.
+FLASK_APP = "app = Flask(__name__)"
+
+
+CODE_TEMPLATE = """\"\"\"
+A simple web application.
+\"\"\"
+# WARNING START: do not change the following two lines of code.
 from flask import Flask, render_template
 
-
-app = Flask(__name__)
+{}
+# WARNING END: do not change the previous two lines of code.
 
 
 @app.route("/")
 def index():
-    return render_template('index.html')
-"""
+    return render_template("index.html")""".format(
+    FLASK_APP
+)
 
 
 class WebMode(BaseMode):
@@ -142,10 +149,26 @@ class WebMode(BaseMode):
         In web-mode such asset directories exist in the user's workspace
         directory, rather than relative to the currently open Python file.
         """
-        base_dir = self.workspace_dir()
-        assets_dir = os.path.join(base_dir, asset_type)
-        os.makedirs(assets_dir, exist_ok=True)
-        return assets_dir
+        flask_apps = set()
+        for i in range(self.view.tabs.count()):
+            source_file = self.view.tabs.widget(i)
+            if FLASK_APP in source_file.text() and source_file.path:
+                flask_apps.add(source_file.path)
+        flask_file = None
+        if flask_apps:
+            if len(flask_apps) == 1:
+                flask_file = flask_apps.pop()
+            else:
+                raise ValueError(
+                    "Multiple Flask apps. Cannot resolve unique app location."
+                )
+        if flask_file:
+            base_dir = os.path.dirname(flask_file)
+        else:
+            base_dir = self.workspace_dir()
+        dir_name = os.path.join(base_dir, asset_type)
+        os.makedirs(dir_name, exist_ok=True)
+        return dir_name
 
     def run_toggle(self, event):
         """
@@ -254,6 +277,18 @@ class WebMode(BaseMode):
         """
         return read_and_decode(path)
 
+    def cannot_resolve_flask_app(self):
+        """
+        Display a helpful message when Mu cannot resolve which web application
+        to use as the basis for assets (templates, CSS, images etc...).
+        """
+        msg = _("Too many web apps.")
+        info = _(
+            "Please ensure you only have one open Python file for a web "
+            "application."
+        )
+        self.view.show_message(msg, info)
+
     def load_templates(self, event):
         """
         Open the directory containing the HTML template views used by Flask.
@@ -261,9 +296,12 @@ class WebMode(BaseMode):
         This should open the host OS's file system explorer so users can drag
         new files into the opened folder.
         """
-        templates_dir = self.assets_dir("templates")
-        logger.info(templates_dir)
-        self.editor.load(default_path=templates_dir)
+        try:
+            templates_dir = self.assets_dir("templates")
+            logger.info(templates_dir)
+            self.editor.load(default_path=templates_dir)
+        except ValueError:
+            self.cannot_resolve_flask_app()
 
     def load_css(self, event):
         """
@@ -273,9 +311,12 @@ class WebMode(BaseMode):
         new files into the opened folder.
         """
         css_path = os.path.join("static", "css")
-        css_dir = self.assets_dir(css_path)
-        logger.info(css_dir)
-        self.editor.load(default_path=css_dir)
+        try:
+            css_dir = self.assets_dir(css_path)
+            logger.info(css_dir)
+            self.editor.load(default_path=css_dir)
+        except ValueError:
+            self.cannot_resolve_flask_app()
 
     def show_images(self, event):
         """
@@ -285,9 +326,12 @@ class WebMode(BaseMode):
         new files into the opened folder.
         """
         img_path = os.path.join("static", "img")
-        img_dir = self.assets_dir(img_path)
-        logger.info(img_dir)
-        self.view.open_directory_from_os(img_dir)
+        try:
+            img_dir = self.assets_dir(img_path)
+            logger.info(img_dir)
+            self.view.open_directory_from_os(img_dir)
+        except ValueError:
+            self.cannot_resolve_flask_app()
 
     def browse(self, event):
         """


### PR DESCRIPTION
This PR is adjacent to #923.

Sometimes the default `templates`, `css` and `images` directories were erroneously created in the wrong place (they were created relative to the file in the currently active tab). This was problematic since the currently active file might have been a CSS or template file and so new directories would be created.

This PR ensures that:

* If there's too many different Flask app files in open tabs, report that Mu can't resolve the directory the user needs, and suggest the user have only a single Flask app Python source file open.
* If there is only one tab containing a Python file that is a Flask app, then look up (and if required, create) the directory relative to the Flask app's Python file.
* If there is no tab containing a Flask app, open the default directories in the mu_code directory.

**If the templates/css/images directories are created relative to the Flask app's source file (and it's not in `mu_code`), then only an empty directory is created. The assumption being that the user doing this is advanced enough to copy files around the filesystem.** :slightly_smiling_face: 

The following GIF-y shows this feature in action:

![asset_dirs](https://user-images.githubusercontent.com/37602/179396456-587a5f13-9db8-4638-8a9d-6d0540ccdde4.gif)

