### PR TITLE
Update pyflakes regex to match pre and post v2.5.0 release.

### DIFF
--- a/mu/logic.py
+++ b/mu/logic.py
@@ -51,7 +51,7 @@ LOG_FILE = os.path.join(LOG_DIR, "mu.log")
 # Regex to match pycodestyle (PEP8) output.
 STYLE_REGEX = re.compile(r".*:(\d+):(\d+):\s+(.*)")
 # Regex to match flake8 output.
-FLAKE_REGEX = re.compile(r".*:(\d+):(\d+)\s+(.*)")
+FLAKE_REGEX = re.compile(r".*:(\d+):(\d+):?\s+(.*)")
 # Regex to match undefined name errors for given builtins
 BUILTINS_REGEX = r"^undefined name '({})'"
 # Regex to match false positive flake errors if microbit.* is expanded.


### PR DESCRIPTION
pyflakes 2.5.0 has unified their output fomatting:
- https://github.com/PyCQA/pyflakes/blob/master/NEWS.rst
- https://github.com/PyCQA/pyflakes/pull/693

So, Mu's regex has to match pyflakes messages like this:
- pre-2.5.0  -> `filename:line:char message`
- post-2.5.0 -> `filename:line:char: message`

And so `:?` has been added to the regex for an optional `:` after the `char` value.

Fixes https://github.com/mu-editor/mu/issues/2322.