### PR TITLE
Use the usb description for CP board name

### DIFF
--- a/mu/modes/circuitpython.py
+++ b/mu/modes/circuitpython.py
@@ -302,7 +302,7 @@ class CircuitPythonMode(MicroPythonMode):
                     manufacturer,
                     self.name,
                     self.short_name,
-                    "CircuitPython board",
+                    port.description(),
                 )
         # No match.
         return None


### PR DESCRIPTION
It appears this is the product name on Linux at least.