### PR TITLE
Fix `None` being lowercase in checker messages

### DIFF
--- a/mu/logic.py
+++ b/mu/logic.py
@@ -470,11 +470,14 @@ def check_pycodestyle(code, config_file=False):
                 description += _(" above this line")
             if line_no not in style_feedback:
                 style_feedback[line_no] = []
+            # Make sure that description starts with a capital letter.
+            if description:
+                description = description[0].upper() + description[1:]
             style_feedback[line_no].append(
                 {
                     "line_no": line_no,
                     "column": int(col) - 1,
-                    "message": description.capitalize(),
+                    "message": description,
                     "code": code,
                 }
             )

--- a/mu/logic.py
+++ b/mu/logic.py
@@ -470,7 +470,7 @@ def check_pycodestyle(code, config_file=False):
                 description += _(" above this line")
             if line_no not in style_feedback:
                 style_feedback[line_no] = []
-            # Make sure that description starts with a capital letter.
+            # Capitalise the 1st letter keeping the rest of the str unmodified
             if description:
                 description = description[0].upper() + description[1:]
             style_feedback[line_no].append(


### PR DESCRIPTION
Consider the following expression:

```python
foo == None
```

Before this change, Mu’s checker would tell you “Comparison to none should be 'if cond is none:'” if it encountered that expression. The word “none” in that message should be capitalized because it refers to something that should be capitalized in Python code.

The problem was caused by an inappropriate use of `str.capitalize()`. The author probably just wanted to make the first letter of the message uppercase. [Unfortunately, `str.capitalize()` also makes every other letter in the string lowercase.][1]

[1]: <https://docs.python.org/3.8/library/stdtypes.html#str.capitalize>