### PR TITLE
wheel: Add --package flag to mu.wheels to include extra pip flags.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ win64: check
 
 macos: check
 	@echo "\nFetching wheels."
-	python -m mu.wheels
+	python -m mu.wheels --package
 	@echo "\nPackaging Mu into a macOS native application."
 	python -m virtualenv venv-pup
 	# Don't activate venv-pup because:
@@ -119,7 +119,7 @@ macos: check
 
 linux: check
 	@echo "\nFetching wheels."
-	python -m mu.wheels
+	python -m mu.wheels --package
 	@echo "\nPackaging Mu into a Linux AppImage."
 	python -m virtualenv venv-pup
 	# Don't activate venv-pup because:

--- a/make.py
+++ b/make.py
@@ -415,7 +415,7 @@ def _build_windows_msi(bitness=64):
     if check() != 0:
         raise RuntimeError("Check failed")
     print("Fetching wheels")
-    subprocess.check_call([sys.executable, "-m", "mu.wheels"])
+    subprocess.check_call([sys.executable, "-m", "mu.wheels", "--package"])
     print("Building {}-bit Windows installer".format(bitness))
     if pup_pbs_url:
         os.environ["PUP_PBS_URL"] = pup_pbs_url

--- a/mu/wheels/__init__.py
+++ b/mu/wheels/__init__.py
@@ -54,6 +54,28 @@ mode_packages = [
 ]
 
 
+def os_compatibility_flags():
+    """
+    Determine additional `pip download` flags required to maximise
+    compatibility with older versions of the current operating system.
+
+    If downloading wheels with these flags fails, then we should consider it
+    an issue to be resolved before doing a Mu release.
+    """
+    extra_flags = []
+    # For macOS the oldest supported version is 10.12 Sierra, as that's the
+    # oldest version supported by PyQt5 v5.13
+    if sys.platform == "darwin":
+        extra_flags.extend(
+            [
+                "--platform=macosx_10_12_x86_64",
+                "--only-binary=:all:",
+            ]
+        )
+    # At the moment there aren't any additional flags for Windows or Linux
+    return extra_flags
+
+
 def compact(text):
     """Remove double line spaces and anything else which might help"""
     return "\n".join(line for line in text.splitlines() if line.strip())
@@ -76,13 +98,14 @@ def remove_dist_files(dirpath, logger):
         os.remove(rm_filepath)
 
 
-def pip_download(dirpath, logger):
+def pip_download(dirpath, logger, additional_flags=[]):
     for name, pip_identifier, *extra_flags in mode_packages:
         logger.info(
-            "Running pip download for %s / %s / %s",
+            "Running pip download for %s / %s / %s / %s",
             name,
             pip_identifier,
             extra_flags,
+            additional_flags,
         )
         process = subprocess.run(
             [
@@ -97,7 +120,8 @@ def pip_download(dirpath, logger):
                 dirpath,
                 pip_identifier,
             ]
-            + extra_flags,
+            + extra_flags
+            + additional_flags,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
         )
@@ -152,7 +176,7 @@ def zip_wheels(zip_filepath, dirpath, logger=logger):
             z.write(filepath, filename)
 
 
-def download(zip_filepath=ZIP_FILEPATH, logger=logger):
+def download(zip_filepath=ZIP_FILEPATH, logger=logger, os_old_compat=False):
     """Download from PyPI, convert to wheels, and zip up
 
     To make all the libraries available for Mu modes (eg pygame zero, Flask etc.)
@@ -162,8 +186,12 @@ def download(zip_filepath=ZIP_FILEPATH, logger=logger):
     We allow `logger` to be overridden because output from the
     virtual_environment module logger goes to the splash screen, while
     output from this module's logger doesn't
+
+    Additional pip download flags to maximise wheel compatibility with old
+    operating systems can be included using the `os_old_compat` parameter.
     """
     logger.info("Downloading wheels to %s", zip_filepath)
+    extra_pip_flags = os_compatibility_flags() if os_old_compat else []
 
     #
     # Remove any leftover files from the place where the zip file
@@ -172,6 +200,6 @@ def download(zip_filepath=ZIP_FILEPATH, logger=logger):
     remove_dist_files(os.path.dirname(zip_filepath), logger)
 
     with tempfile.TemporaryDirectory() as temp_dirpath:
-        pip_download(temp_dirpath, logger)
+        pip_download(temp_dirpath, logger, extra_pip_flags)
         convert_sdists_to_wheels(temp_dirpath, logger)
         zip_wheels(zip_filepath, temp_dirpath, logger)

--- a/mu/wheels/__main__.py
+++ b/mu/wheels/__main__.py
@@ -1,4 +1,6 @@
 import logging
+import sys
+
 from . import logger, download
 
 #
@@ -8,4 +10,10 @@ from . import logger, download
 logger.setLevel(logging.DEBUG)
 logger.addHandler(logging.StreamHandler())
 
-download()
+# A single flag is accepted to trigger a `pip download` using flag to increase
+# compatibility with older operating system versions.
+# As there is a single option available sys.argv is used for simplicity,
+# if more options are added in the future we should start using argparse
+os_old_compat = sys.argv[1] == "--package"
+
+download(os_old_compat=os_old_compat)


### PR DESCRIPTION
Using the `--package` flag (e.g. `python -m mu.wheels --package`) adds extra flags to `pip download` to maximise compatibility of downloaded wheels with older operating systems.

By default users downloading wheels from a mu-editor pip/pipx install are not affected, this is only when running the `mu.wheels` module with the `--package` flag.

For the CI to pass this will need this PR to be merged first:
- https://github.com/mu-editor/mu/pull/2352

These PRs has been discussed in:
- https://github.com/mu-editor/mu/issues/2120#issuecomment-1309468274