### PR TITLE
CI: Update version of used Actions to remove warnings.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,9 +15,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     name: Build ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: '3.8'
       - name: Display Python info
@@ -46,7 +46,7 @@ jobs:
           make macos
           mv dist/*.dmg upload/
       - name: Upload Mu installer
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v3
         with:
           name: mu-editor-${{ runner.os }}-${{ github.sha }}
           path: upload
@@ -57,7 +57,7 @@ jobs:
       image: ghcr.io/mu-editor/mu-appimage:2022.05.01
     name: Build AppImage
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Display system info
         run: |
           uname -a
@@ -83,7 +83,7 @@ jobs:
           tar -cvf Mu_Editor-AppImage-x86_64-${{ github.sha }}.tar *.AppImage
           ls -la .
       - name: Upload Mu AppImage
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v3
         with:
           name: mu-editor-${{ runner.os }}-${{ github.sha }}
           path: dist/Mu_Editor-AppImage-x86_64-${{ github.sha }}.tar

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,9 +17,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     name: Test Py ${{ matrix.python-version }} - ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Display Python info
@@ -54,10 +54,10 @@ jobs:
     runs-on: ubuntu-latest
     name: Test Py 3.7 - arm-debian-buster
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up QEMU
         id: qemu
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
         with:
           image: tonistiigi/binfmt:latest
           platforms: 'linux/arm64,linux/arm/v7,linux/arm/v6'


### PR DESCRIPTION
The majority of the 50 warnings we currently get are:
- Node.js 12 actions are deprecated
- The `set-output` command is deprecated and will be disabled soon