### PR TITLE
make: Add Makefile target to build Linux AppImage with Docker.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -131,6 +131,24 @@ linux: check
 	ls -la ./build/pup/
 	ls -la ./dist/
 
+linux-docker: clean
+	@echo "\nFetching wheels."
+	docker run -v $(CURDIR):/home --rm ghcr.io/mu-editor/mu-appimage:2022.05.01 bash -c "\
+		pip install . && \
+		python -m mu.wheels --package"
+	@echo "\nInstall pup inside the container and build the Linux AppImage."
+	# pup build directory is hardcoded to ./build, but the build fails if the build folder is inside the docker mounted volume
+	# So let's mount the Mu repo into a subdirectory and then invoke pup from the parent folder
+	# https://github.com/mu-editor/pup/issues/242
+	docker run -v $(CURDIR):/home/mu --rm ghcr.io/mu-editor/mu-appimage:2022.05.01 bash -c "\
+		pip install virtualenv && \
+		python -m virtualenv venv-pup && \
+		./venv-pup/bin/pip install pup && \
+		./venv-pup/bin/pup package --launch-module=mu --nice-name='Mu Editor' --icon-path=mu/mu/resources/images/icon.png --license-path=mu/LICENSE mu/ && \
+		ls -la ./build/pup/ && \
+		mv dist/ mu/dist"
+	ls -la ./dist/
+
 video: clean
 	@echo "\nFetching contributor avatars."
 	python utils/avatar.py


### PR DESCRIPTION
It's beneficial to create the Linux AppImages within an old version of a linux distro, mostly to make sure it has compatibility with older glibc releases.

So this PR adds a target to create an AppImage using docker and the Mu `ghcr.io/mu-editor/mu-appimage` docker image: https://github.com/mu-editor/docker-mu-appimage
```
make linux-docker
```

Theoretically it should work in all operating systems, although I have only tried it so far in macOS.

@ntoll it'd be great if you could give this a spin as well to confirm it works.