### PR TITLE
CI: Exclude Python 3.5 and 3.6 from running in Ubuntu-latest runner.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,12 @@ jobs:
       matrix:
         os: [ubuntu-18.04, ubuntu-latest, macos-10.15, macos-latest, windows-2019, windows-latest]
         python-version: ['3.5', '3.6', '3.7', '3.8']
+        exclude:
+          # Python 3.5 and 3.6 not available in the latest Ubuntu runners
+          - os: ubuntu-latest
+            python-version: '3.5'
+          - os: ubuntu-latest
+            python-version: '3.6'
       fail-fast: false
     runs-on: ${{ matrix.os }}
     name: Test Py ${{ matrix.python-version }} - ${{ matrix.os }}


### PR DESCRIPTION
As these Python versions are not supported in 22.04 and the Action step fails to install them.
This PR only skips them for `ubuntu-latest`, the Ubuntu 18.04 runner is still running the tests with 3.5 & 3.6