### PR TITLE
CI: Workaround CodeQL pip install issues by changing Ubuntu version.

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     permissions:
       actions: read
       contents: read


### PR DESCRIPTION
I'm not too sure why in the GH Actions runner  `ubuntu-latest`, which has been recently updated from 20.04 to 22.04, the pip resolver struggles to download wheels and (when given some help by manually installing some subdependencies at a version we know should work) it ends up with a large recursion of trying to find dependency versions that match all requirements.

And when `ubuntu-latest` is used with the Python Github Action it does work, not sure why the default system Python/pip fails.

So, specifying `ubuntu-20.04` as the runner resolves/worksaround the issue. Also, as we will be updating the Mu dependencies soon, there is not much point spending more time on this unless it starts affecting users pip installing Mu.