### PR TITLE
Test: Use a pup fork to make mac installer compatible with OS X 10.12.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,8 +111,10 @@ macos: check
 	# Don't activate venv-pup because:
 	# 1. Not really needed.
 	# 2. Previously active venv would be "gone" on venv-pup deactivation.
-	./venv-pup/bin/pip install pup
-	./venv-pup/bin/pup package --launch-module=mu --nice-name="Mu Editor" --icon-path=./package/icons/mac_icon.icns --license-path=./LICENSE .
+	# Installing pup from a fork with the --pip-platform flag proof of concept
+	# and using it to install wheels for the `macosx_10_12_x86_64` platform
+	./venv-pup/bin/pip install git+https://github.com/carlosperate/pup.git@pip-platform
+	./venv-pup/bin/pup package --launch-module=mu --nice-name="Mu Editor" --icon-path=./package/icons/mac_icon.icns --license-path=./LICENSE --pip-platform=macosx_10_12_x86_64 .
 	rm -r venv-pup
 	ls -la ./build/pup/
 	ls -la ./dist/


### PR DESCRIPTION
Uses a proof of concept fork to see if it can create a macOS installer with wheels compatible with older macOS versions, 10.12+.

This is to test a possible solution to:
- https://github.com/mu-editor/mu/issues/2368

And the proof-of-concept PR in the pup repo that shows the difference between this fork and pup:
- https://github.com/mu-editor/pup/pull/246