### PR TITLE
Limit clicking in the serial panel to moving back a line

### DIFF
--- a/mu/interface/panes.py
+++ b/mu/interface/panes.py
@@ -322,6 +322,19 @@ class MicroPythonREPLPane(QTextEdit):
         self.set_qtcursor_to_devicecursor()
         # Calculate number of steps
         steps = new_position - self.device_cursor_position
+
+        # Limit cursor movement to the last line
+        if steps < 0:
+            cursor = self.textCursor()
+            cursor.setPosition(self.device_cursor_position)
+            cursor.movePosition(
+                QTextCursor.StartOfLine,
+                mode=QTextCursor.KeepAnchor,
+            )
+            line_start = cursor.selectionStart()
+            if line_start > new_position:
+                return
+
         # Send the appropriate right/left moves
         if steps > 0:
             # Move cursor right if positive


### PR DESCRIPTION
This is an attempt at mitigating #1505 by implementing my 3rd suggestion: limiting the cursor movement to the last line (when moving backwards). The change is not limited to clicking, the same function is used when moving the cursor with the arrows while there's text currently selected, which should not be a big deal.
- When in the REPL the cursor movements are what you expect when clicking inside the last line.
- Clicking above the last line, even when in the REPL, does nothing, because the cursor is
- In the most common case, when the serial output is limited to normal `prints()`, the last line is empty, so that works for us.
- When not in the REPL and printing with `end=""` you can click in the last line and still send a bucket-load of characters.

I have only tested on Mac though, so if there's some platform-specific quirk, it would be nice to test that.

Are there cases (maybe outside of Circuitpython) where we would want to allow to move backwards beyond the line start ?