### PR TITLE
fix 2375 - this seems to fix the issue I ran into

### DIFF
--- a/mu/app.py
+++ b/mu/app.py
@@ -284,6 +284,7 @@ class SharedMemoryMutex(object):
 
     def __exit__(self, *args, **kwargs):
         self._shared_memory.unlock()
+        self._shared_memory.detach()
 
     def acquire(self):
         if self._shared_memory.attach():


### PR DESCRIPTION
Reading the documentation, it appears that `unlock()'ing the shared memory is not sufficient and that one should `detach()` it also.  Adding that seems to have resolved this issue #2375 on macOS 10.13.6 with python 3.8.16.