### PR TITLE
retry to enter raw repl when listing fs

### DIFF
--- a/mu/contrib/microfs.py
+++ b/mu/contrib/microfs.py
@@ -85,10 +85,15 @@ def raw_on(serial):
     for i in range(3):
         serial.write(b"\r\x03")
         time.sleep(0.01)
-    flush(serial)
-    # Go into raw mode with CTRL-A.
-    serial.write(b"\r\x01")
-    flush_to_msg(serial, raw_repl_msg)
+    flush(serial)    
+    # Go into raw mode with CTRL-A. (retry 3 times)
+    for i in range(3):
+        try:
+            serial.write(b"\r\x01")
+            flush_to_msg(serial, raw_repl_msg)
+            break
+        except:
+            pass
     # Soft Reset with CTRL-D
     serial.write(b"\x04")
     flush_to_msg(serial, b"soft reboot\r\n")


### PR DESCRIPTION
Sometimes the repl response is not detected on my esp32.
Might also solve https://github.com/mu-editor/mu/issues/2360