### PR TITLE
make: Update Linux Docker recipe to create `.tar` file from `.AppImage`.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,7 +136,7 @@ linux-docker: clean
 	docker run -v $(CURDIR):/home --rm ghcr.io/mu-editor/mu-appimage:2022.05.01 bash -c "\
 		pip install . && \
 		python -m mu.wheels --package"
-	@echo "\nInstall pup inside the container and build the Linux AppImage."
+	@echo "\nInstall pup inside the container, build the Linux AppImage, and tar it."
 	# pup build directory is hardcoded to ./build, but the build fails if the build folder is inside the docker mounted volume
 	# So let's mount the Mu repo into a subdirectory and then invoke pup from the parent folder
 	# https://github.com/mu-editor/pup/issues/242
@@ -145,8 +145,12 @@ linux-docker: clean
 		python -m virtualenv venv-pup && \
 		./venv-pup/bin/pip install pup && \
 		./venv-pup/bin/pup package --launch-module=mu --nice-name='Mu Editor' --icon-path=mu/mu/resources/images/icon.png --license-path=mu/LICENSE mu/ && \
-		ls -la ./build/pup/ && \
+		cd dist/ && \
+		find *.AppImage -type f -exec tar -cvf {}.tar {} \; && \
+		cd /home && \
+		mv build/pup mu/build/pup && \
 		mv dist/ mu/dist"
+	ls -la ./build/pup/
 	ls -la ./dist/
 
 video: clean


### PR DESCRIPTION
This way the `.AppImage` file will retain its executable rights and users will be able to double click it as soon as it's uncompressed, as it is currenty indicated in the installations instructions from the website.