### PR TITLE
Add support for upcoming Pololu 3pi+ 2040 Robot

### DIFF
--- a/mu/modes/pico.py
+++ b/mu/modes/pico.py
@@ -32,14 +32,15 @@ class PicoMode(ESPMode):
 
     name = _("RP2040")
     short_name = "pico"
-    board_name = "Raspberry Pi Pico"
-    description = _("Write MicroPython directly on a Raspberry Pi Pico.")
+    board_name = "Raspberry Pi RP2040"
+    description = _("Write MicroPython directly on a Raspberry Pi Pico or other RP2040 board.")
     icon = "pico"
     fs = None
 
     valid_boards = [
         # VID  , PID,    Manufacturer string, Device name
         (0x2E8A, 0x0005, None, "Raspberry Pi Pico"),
+        (0x1FFB, 0x2043, None, "Pololu 3pi+ 2040 Robot"),
     ]
 
     def api(self):


### PR DESCRIPTION
This is to support a new Pololu robot that will be released soon. I added our VID/PID to pico.py and slightly renamed things to make it clear that PicoMode can work with many different RP2040 boards.  We have a PR pending to add the VID/PID combination to MicroPython here:

* https://github.com/micropython/micropython/pull/10909

It would be nice to get this into Mu now, so our customers could start using it immediately.

Also, if this seems okay, there are a number of other VID/PID combinations we could also add to `pico.py`, which you can find in the micropython repository [here](https://github.com/micropython/micropython/tree/master/ports/rp2/boards).