### PR TITLE
Remove shebang from a non-executable script

### DIFF
--- a/mu/mu_debug.py
+++ b/mu/mu_debug.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 import os
 import sys
 from mu.debugger.config import DEBUGGER_PORT


### PR DESCRIPTION
This file is not (installed as) executable,
hence the shebang is never used and is redundant.