### PR TITLE
Serial communication on ESP needs handshake

### DIFF
--- a/mu/modes/base.py
+++ b/mu/modes/base.py
@@ -81,27 +81,26 @@ class REPLConnection(QObject):
     serial = None
     data_received = pyqtSignal(bytes)
     connection_error = pyqtSignal(str)
-    
-    class SerialPortBuffer():
+
+    class SerialPortBuffer:
         def __init__(self):
             pass
-        
+
         def clear(self):
-            if hasattr(self, '_buffer'):
-                delattr(self, '_buffer')
-                
+            if hasattr(self, "_buffer"):
+                delattr(self, "_buffer")
+
         @property
         def buffer(self):
-            if hasattr(self, '_buffer'):
+            if hasattr(self, "_buffer"):
                 return self._buffer
             else:
-                return b''
-            
+                return b""
+
         @buffer.setter
         def buffer(self, x):
             self._buffer = x
 
-        
     def __init__(self, port, baudrate=115200):
         super().__init__()
         self.serial = QSerialPort()
@@ -170,7 +169,7 @@ class REPLConnection(QObject):
         self.data_received.emit(data)
         if self._serialmode == BUFFER:
             self._buffer.buffer += data
-    
+
     def write(self, data):
         self.serial.write(data)
 
@@ -214,23 +213,23 @@ class REPLConnection(QObject):
 
         raw_off = [
             SOFT_REBOOT,
-         ]
-               
-        logger.info('\n'.join(['Executing:'] + commands))
+        ]
+
+        logger.info("\n".join(["Executing:"] + commands))
         newline = [b'print("\\n");']
         commands = [c.encode("utf-8") + b"\r" for c in commands]
         commands.append(b"\r")
-        
+
         self._serialmode = BUFFER
         self.execute(raw_on)
-        self.wait_for_prompt(b'MPY sofraw REPL; CTRL-B to exit\r')             
-        logger.info('Data from serial:' + self._buffer.buffer.decode('UTF-8'))
-        self._buffer.clear()       
+        self.wait_for_prompt(b"MPY sofraw REPL; CTRL-B to exit\r")
+        logger.info("Data from serial:" + self._buffer.buffer.decode("UTF-8"))
+        self._buffer.clear()
         command_sequence = newline + commands + raw_off
         self.execute(command_sequence)
         self._serialmode = PASSTHRU
         self._buffer.clear()
-        
+
 
 class BaseMode(QObject):
     """


### PR DESCRIPTION
I ran a classroom using Mu and many ESP devices. The behavior when using the RUN button was flaky, and dependent on the precise laptop. Hitting RUN and RUN again gave different results. Through code inspection I learned that there is no handshake in the serial communication when downloading the code during the RUN command. 
Inspired by the [mpremote tool](https://github.com/micropython/micropython/blob/master/tools/mpremote/mpremote/transport_serial.py) I propose a handshake on the serial port for the RUN command. 
This works fine in my environment. Please note, the testing has been limited. Glancing through the issues mentioned here at Github, the following issues appear to be similar and may be affected (solved?): #2397, #2319, #1996 and #1433. Unfortunately, I have no means to verify the last claim.