### PR TITLE
venv: Use Windows short paths for venv intepreter & pip as well.

### DIFF
--- a/mu/virtual_environment.py
+++ b/mu/virtual_environment.py
@@ -531,11 +531,11 @@ class VirtualEnvironment(object):
         #
         # Pip and the interpreter will be set up when the virtualenv is created
         #
-        self.interpreter = os.path.join(
-            self._bin_directory, "python" + self._bin_extension
+        self.interpreter = safe_short_path(
+            os.path.join(self._bin_directory, "python" + self._bin_extension)
         )
-        self.pip_executable = os.path.join(
-            self._bin_directory, "pip" + self._bin_extension
+        self.pip_executable = safe_short_path(
+            os.path.join(self._bin_directory, "pip" + self._bin_extension)
         )
         self.reset_pip()
         logger.debug(


### PR DESCRIPTION
Attempt to fix:
- https://github.com/mu-editor/mu/issues/2451

I've been unable to replicate in my Windows environment, but could ask affected users to check if the installer from this PR might work for them.