### PR TITLE
Unset VIRTUAL_ENV env var: pgzero mode fails, otherwise.

### DIFF
--- a/mu/app.py
+++ b/mu/app.py
@@ -367,6 +367,10 @@ def run():
     setup_exception_handler()
     check_only_running_once()
 
+    # Remove the VIRTUAL_ENV env var: when set, prevents pgzero mode from working
+    # if Mu is installed from source/PyPI into a virtual environment.
+    os.environ.pop("VIRTUAL_ENV", None)
+
     #
     # Load settings from known locations and register them for
     # autosave


### PR DESCRIPTION
CONTEXT:

* Found failure after setting up dev env with:
```
$ python3.8 -m venv venv
$ ./venv/bin/activate
(venv) $ pip install -e ".[dev]"
(venv) $ mu-editor
```

* In this scenario, the `VIRTUAL_ENV` var is set, when running Mu.
* For some not-100% clear reason, this leads Mu to use the dev venv Python binary to run PGZero code, instead of it's own venv where `pgzero` is actually installed.

SELF-NOTE:

* The root cause was not found.
* This is more of a quick-fix. 🤷🏻‍♂️😅