### PR TITLE
Testing: Upgrade GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -100,7 +100,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        docker-tag: ['stretch-2018-03-13', 'buster-2021-05-28', 'buster-legacy-2022-04-07']
+        docker-tag: ['buster-2021-05-28', 'buster-legacy-2022-04-07', 'bullseye-2022-01-28']
       fail-fast: false
     services:
       rpios:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     name: Test Py ${{ matrix.python-version }} - ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
@@ -60,10 +60,10 @@ jobs:
     runs-on: ubuntu-latest
     name: Test Py 3.7 - arm-debian-buster
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up QEMU
         id: qemu
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
         with:
           image: tonistiigi/binfmt:latest
           platforms: 'linux/arm64,linux/arm/v7,linux/arm/v6'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -100,7 +100,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        docker-tag: ['stretch-2018-03-13', 'buster-2021-05-28', 'buster-legacy-2022-04-07']
+        docker-tag: ['buster-2021-05-28', 'buster-legacy-2022-04-07']
       fail-fast: false
     services:
       rpios:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -99,8 +99,8 @@ jobs:
     name: Test PiOS ${{ matrix.docker-tag }}
     runs-on: ubuntu-latest
     strategy:
-      matrix:
-        docker-tag: ['buster-2021-05-28', 'buster-legacy-2022-04-07', 'bullseye-2022-01-28']
+      matrix:  # bullseye uses Python 3.9 which is not yet supported.
+        docker-tag: ['buster-2021-05-28', 'buster-legacy-2022-04-07']  # , 'bullseye-2022-01-28']
       fail-fast: false
     services:
       rpios:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -99,8 +99,8 @@ jobs:
     name: Test PiOS ${{ matrix.docker-tag }}
     runs-on: ubuntu-latest
     strategy:
-      matrix:  # bullseye uses Python 3.9 which is not yet supported.
-        docker-tag: ['buster-2021-05-28', 'buster-legacy-2022-04-07']  # , 'bullseye-2022-01-28']
+      matrix:
+        docker-tag: ['stretch-2018-03-13', 'buster-2021-05-28', 'buster-legacy-2022-04-07']
       fail-fast: false
     services:
       rpios:


### PR DESCRIPTION
* https://github.com/actions/checkout/releases
* https://github.com/docker/setup-qemu-action/releases

Drop `stretch` because http://mirrordirector.raspbian.org/raspbian/dists/stretch/ is now empty.