### PR TITLE
Fix test calling `called_once_with()` instead of `assert_called_once_with()`.

### DIFF
--- a/tests/interface/test_main.py
+++ b/tests/interface/test_main.py
@@ -483,11 +483,10 @@ def test_Window_connect_zoom():
     w._zoom_out = mock.MagicMock()
     w._zoom_out.connect = mock.MagicMock()
     widget = mock.MagicMock()
-    widget.zoomIn = mock.MagicMock()
-    widget.zoomOut = mock.MagicMock()
+    widget.set_zoom = mock.MagicMock()
     w.connect_zoom(widget)
-    assert w._zoom_in.connect.called_once_with(widget.zoomIn)
-    assert w._zoom_out.connect.called_once_with(widget.zoomOut)
+    w._zoom_in.connect.assert_called_once_with(widget.set_zoom)
+    w._zoom_out.connect.assert_called_once_with(widget.set_zoom)
 
 
 def test_Window_current_tab():


### PR DESCRIPTION
A MagicMock object was being asserted with `called_once_with()` instead of `assert_called_once_with()`, likely an accidental mistake.

As a MagicMock always returns another instance of MagicMock on anything not previoysly set up, the `assert` was always passing, even though we updated the `Window.connect_zoom()` implementation and these asserts should be failing.

I only noticed this because in Python 3.12 this type of typo is caught and throws an exception.