### PR TITLE
CI: Update Pi OS job to the last Buster release (35% faster).

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -100,7 +100,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        docker-tag: ['stretch-2018-03-13', 'buster-2021-05-28', 'buster-legacy-2022-04-07']
+        docker-tag: ['stretch-2018-03-13', 'buster-2021-05-28', 'buster-legacy-2023-05-03']
       fail-fast: false
     services:
       rpios:


### PR DESCRIPTION
Which uses a new Qemu emulation configuration (https://github.com/carlosperate/docker-qemu-rpi-os/commit/49c922b8b9e30984767105cd8b9be960732ae095), which is about 35% faster in the CI completion time, from around 30ish minutes to 20ish minutes.

This Buster legacy release from May 2025 is also the last Buster release by Raspberry Pi. As the next OS release in October was based on Bookworm, and so Bullseye became the new "legacy" OS version.