### PR TITLE
Added support for CH9102 in ESP mode

### DIFF
--- a/mu/modes/esp.py
+++ b/mu/modes/esp.py
@@ -52,6 +52,7 @@ class ESPMode(MicroPythonMode):
         (0x1A86, 0x7523, None, "HL-340"),
         (0x10C4, 0xEA60, None, "CP210x"),
         (0x0403, 0x6001, "M5STACK Inc.", "M5Stack ESP32 device"),
+        (0x1A86, 0x55D4, None, None),  # CH9102
         (0x0403, 0x6001, None, None),  # FT232/FT245 (XinaBox CW01, CW02)
         (0x0403, 0x6010, None, None),  # FT2232C/D/L/HL/Q (ESP-WROVER-KIT)
         (0x0403, 0x6011, None, None),  # FT4232


### PR DESCRIPTION
Added support for CH9102 USB-Serial chip

https://cdn-learn.adafruit.com/assets/assets/000/111/949/original/CH9102DS1.PDF?1653415979