### PR TITLE
Tests: Avoid calling reset_mock() on a mock of super() to avoid RecursionError

### DIFF
--- a/tests/modes/test_python3.py
+++ b/tests/modes/test_python3.py
@@ -483,10 +483,9 @@ def test_python_remove_plotter():
     """
     editor = mock.MagicMock()
     view = mock.MagicMock()
+    pm = PythonMode(editor, view)
+    pm.set_buttons = mock.MagicMock()
     with mock.patch("builtins.super") as mock_super:
-        pm = PythonMode(editor, view)
-        pm.set_buttons = mock.MagicMock()
-        mock_super.reset_mock()
         pm.remove_plotter()
         pm.set_buttons.assert_called_once_with(run=True, repl=True, debug=True)
         mock_super().remove_plotter.assert_called_once_with()


### PR DESCRIPTION
Starting with Python 3.12.7 or 3.13.0rc3, the reset_mock() method calls super().

https://github.com/python/cpython/issues/123934

This lead to:

    __________________________ test_python_remove_plotter __________________________
        def test_python_remove_plotter():
            """
            Ensure the button states are returned to normal before calling super
            method.
            """
            editor = mock.MagicMock()
            view = mock.MagicMock()
            with mock.patch("builtins.super") as mock_super:
                pm = PythonMode(editor, view)
                pm.set_buttons = mock.MagicMock()
    >           mock_super.reset_mock()
    tests/modes/test_python3.py:489:
    _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
    /usr/lib64/python3.13/unittest/mock.py:2232: in reset_mock
        super().reset_mock(*args, return_value=return_value, **kwargs)
    /usr/lib64/python3.13/unittest/mock.py:2232: in reset_mock
        super().reset_mock(*args, return_value=return_value, **kwargs)
    /usr/lib64/python3.13/unittest/mock.py:2232: in reset_mock
        super().reset_mock(*args, return_value=return_value, **kwargs)
    E   RecursionError: maximum recursion depth exceeded
    !!! Recursion detected (same locals & position)

We avoid the problem by not needlessly calling reset_mock() in this test at all.