### PR TITLE
Tests: Explicitly set cursor position

### DIFF
--- a/tests/interface/test_editor.py
+++ b/tests/interface/test_editor.py
@@ -936,6 +936,7 @@ def test_EditorPane_toggle_comments_handle_crlf_newline():
     """
     ep = mu.interface.editor.EditorPane(None, "test\r\nline 2\n")
     ep.hasSelectedText = mock.MagicMock(return_value=False)
+    ep.setCursorPosition(0, 0)
     ep.toggle_comments()
     assert ep.text() == "# test\nline 2\n"
     assert ep.selectedText() == "# test"


### PR DESCRIPTION
Since we updated QScintilla 2.13 -> 2.14 in Fedora 41+, we see this test failure:

    _____________ test_EditorPane_toggle_comments_handle_crlf_newline ______________
        def test_EditorPane_toggle_comments_handle_crlf_newline():
            """
            Check that stray "\r\n" line endings don't lead to deleting the first
            character of the following line.
            """
            ep = mu.interface.editor.EditorPane(None, "test\r\nline 2\n")
            ep.hasSelectedText = mock.MagicMock(return_value=False)
            ep.toggle_comments()
    >       assert ep.text() == "# test\nline 2\n"
    E       AssertionError: assert 'test\r\nline 2\n' == '# test\nline 2\n'
    E
    E         - # test
    E         ? --
    E         + test
    E         ?     +
    E           line 2
    tests/interface/test_editor.py:940: AssertionError

I've added some debugging prints and realized that getCursorPosition() returns 2, 0 in this test, while is assumes the cursor is on line 0.

By explicitly calling setCursorPosition() we fix the test and we make it more clear to the reader.