### PR TITLE
venv: Install in user venv the same version of ipykernel that Mu is running

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,10 +34,10 @@ install_requires = [
     "PyQtChart==5.15.6"
     + '; sys_platform != "linux" '
     + 'or ("arm" not in platform_machine and "aarch" not in platform_machine)',
-    # FIXME: Needed for qtconsole, this is the latest wheel in armv7l for
+    # Needed for qtconsole, this is the latest wheel in armv7l for
     # Python 3.7 (Buster), otherwise it tries to build from source and fails.
     "pyzmq<=26.0.3",
-    # We are using an internal method of jupyter_client, that changed in v7
+    # We are using an internal method of jupyter_client that changed in v7
     # QtKernelManager._launch_kernel() returning a KernelProvisionerBase
     # https://github.com/jupyter/jupyter_client/commit/516d9df270b2e4603ee0ecd986554cb5fe1c2940
     "jupyter-client<7",


### PR DESCRIPTION
This is not an issue for the packaged Mu installers, as they will have downloaded the ipykernel wheel for Mu and the user venv at the same time and should match.
But this could be an issue for users installing Mu in the future via pip and having version mistmaches there.